### PR TITLE
Fix AltGr shortcuts closing the desktop app (#859)

### DIFF
--- a/android/src/main/kotlin/com/darkrockstudios/apps/hammer/android/ProjectRootActivity.kt
+++ b/android/src/main/kotlin/com/darkrockstudios/apps/hammer/android/ProjectRootActivity.kt
@@ -188,20 +188,20 @@ class ProjectRootActivity : AppCompatActivity() {
 
 	override fun dispatchKeyEvent(event: KeyEvent): Boolean {
 		if (event.action == KeyEvent.ACTION_DOWN) {
-			if (event.keyCode == KeyEvent.KEYCODE_F && event.isShiftPressed && event.isCtrlPressed) {
+			// hasModifiers matches exactly, so AltGr chords fall through and type their character.
+			val ctrlShift = KeyEvent.META_CTRL_ON or KeyEvent.META_SHIFT_ON
+			if (event.keyCode == KeyEvent.KEYCODE_F && event.hasModifiers(ctrlShift)) {
 				projectRoot?.let {
 					it.showGlobalSearch()
 					return true
 				}
 			}
 
-			// hasModifiers matches exactly, so Ctrl+F3 and Ctrl+Alt+Shift+S fall through.
 			if (event.keyCode == KeyEvent.KEYCODE_F3 && event.hasNoModifiers()) {
 				if (shortcutHost.startProjectSync()) return true
 			}
 
-			val ctrlAlt = KeyEvent.META_CTRL_ON or KeyEvent.META_ALT_ON
-			if (event.keyCode == KeyEvent.KEYCODE_S && event.hasModifiers(ctrlAlt)) {
+			if (event.keyCode == KeyEvent.KEYCODE_S && event.hasModifiers(ctrlShift)) {
 				if (shortcutHost.saveAllBuffers()) return true
 			}
 		}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -43,6 +43,9 @@ allprojects {
 
 	tasks.withType<Test> {
 		useJUnitPlatform()
+		// The Koin compiler plugin's compile-safety hints are not tests, and as of plugin
+		// 1.1.0 they carry duplicate method signatures that JUnit's scan chokes on.
+		exclude("org/koin/plugin/hints/**")
 	}
 
 	// Compiler flags applied globally

--- a/composeUi/src/desktopTest/kotlin/com/darkrockstudios/apps/hammer/common/compose/MatchesShortcutTest.kt
+++ b/composeUi/src/desktopTest/kotlin/com/darkrockstudios/apps/hammer/common/compose/MatchesShortcutTest.kt
@@ -66,20 +66,20 @@ class MatchesShortcutTest {
 	}
 
 	@Test
-	fun `ctrl alt S fires save all`() {
+	fun `ctrl shift S fires save all`() {
 		assertEquals(
 			1,
-			shortcutFirings({ onKeyShortcut(Key.S, ctrl = true, alt = true, action = it) }) {
-				withKeyDown(Key.CtrlLeft) { withKeyDown(Key.AltLeft) { pressKey(Key.S) } }
+			shortcutFirings({ onKeyShortcut(Key.S, ctrl = true, shift = true, action = it) }) {
+				withKeyDown(Key.CtrlLeft) { withKeyDown(Key.ShiftLeft) { pressKey(Key.S) } }
 			},
 		)
 	}
 
 	@Test
-	fun `ctrl alt shift S does not fire save all`() {
+	fun `AltGr shift S does not fire save all`() {
 		assertEquals(
 			0,
-			shortcutFirings({ onKeyShortcut(Key.S, ctrl = true, alt = true, action = it) }) {
+			shortcutFirings({ onKeyShortcut(Key.S, ctrl = true, shift = true, action = it) }) {
 				withKeyDown(Key.CtrlLeft) {
 					withKeyDown(Key.AltLeft) {
 						withKeyDown(Key.ShiftLeft) { pressKey(Key.S) }

--- a/desktop/src/jvmMain/kotlin/com/darkrockstudios/apps/hammer/desktop/ProjectEditorWindow.kt
+++ b/desktop/src/jvmMain/kotlin/com/darkrockstudios/apps/hammer/desktop/ProjectEditorWindow.kt
@@ -104,31 +104,25 @@ internal fun NucleusApplicationScope.ProjectEditorWindow(
 			}
 		},
 		onKeyEvent = { event ->
-			when {
-				event.key == Key.Escape && event.type == KeyEventType.KeyUp -> {
-					backDispatcher.back()
-				}
-				event.type == KeyEventType.KeyDown &&
-					event.key == Key.F &&
-					event.isShiftPressed &&
-					(event.isCtrlPressed || event.isMetaPressed) -> {
+			when (event.toProjectEditorShortcut()) {
+				WindowShortcut.Back -> backDispatcher.back()
+
+				WindowShortcut.GlobalSearch -> {
 					component.showGlobalSearch()
 					true
 				}
-				event.type == KeyEventType.KeyDown &&
-					event.key == Key.W &&
-					(event.isCtrlPressed || event.isMetaPressed) -> {
+
+				WindowShortcut.CloseProject -> {
 					onRequestClose(component, app, ApplicationState.CloseType.Project)
 					true
 				}
 
-				event.type == KeyEventType.KeyDown &&
-					event.key == Key.Q &&
-					(event.isCtrlPressed || event.isMetaPressed) -> {
+				WindowShortcut.Quit -> {
 					onRequestClose(component, app, ApplicationState.CloseType.Application)
 					true
 				}
-				else -> false
+
+				null -> false
 			}
 		}
 	) {

--- a/desktop/src/jvmMain/kotlin/com/darkrockstudios/apps/hammer/desktop/ProjectEditorWindow.kt
+++ b/desktop/src/jvmMain/kotlin/com/darkrockstudios/apps/hammer/desktop/ProjectEditorWindow.kt
@@ -95,12 +95,11 @@ internal fun NucleusApplicationScope.ProjectEditorWindow(
 		state = windowState,
 		icon = painterResource(Res.drawable.hammer_icon),
 		onCloseRequest = { onRequestClose(component, app, ApplicationState.CloseType.Application) },
-		// These two run pre-focus so a focused editor can't swallow them.
 		onPreviewKeyEvent = { event ->
-			when {
-				event.matchesShortcut(Key.F3) -> shortcutHost.startProjectSync()
-				event.matchesShortcut(Key.S, ctrl = true, alt = true) -> shortcutHost.saveAllBuffers()
-				else -> false
+			when (event.toProjectShortcut()) {
+				ProjectShortcut.SyncProject -> shortcutHost.startProjectSync()
+				ProjectShortcut.SaveAll -> shortcutHost.saveAllBuffers()
+				null -> false
 			}
 		},
 		onKeyEvent = { event ->

--- a/desktop/src/jvmMain/kotlin/com/darkrockstudios/apps/hammer/desktop/ProjectSelectionWindow.kt
+++ b/desktop/src/jvmMain/kotlin/com/darkrockstudios/apps/hammer/desktop/ProjectSelectionWindow.kt
@@ -82,15 +82,13 @@ internal fun NucleusApplicationScope.ProjectSelectionWindow(
 		onCloseRequest = ::exitApplication,
 		icon = painterResource(Res.drawable.hammer_icon),
 		onKeyEvent = { event ->
-			when {
-				event.key == Key.Escape && event.type == KeyEventType.KeyUp -> {
+			when (event.toProjectSelectionShortcut()) {
+				WindowShortcut.Back -> {
 					backDispatcher.back()
 					true
 				}
 
-				event.type == KeyEventType.KeyDown &&
-					event.key == Key.Q &&
-					(event.isCtrlPressed || event.isMetaPressed) -> {
+				WindowShortcut.Quit -> {
 					exitApplication()
 					true
 				}

--- a/desktop/src/jvmMain/kotlin/com/darkrockstudios/apps/hammer/desktop/WindowShortcuts.kt
+++ b/desktop/src/jvmMain/kotlin/com/darkrockstudios/apps/hammer/desktop/WindowShortcuts.kt
@@ -1,0 +1,33 @@
+package com.darkrockstudios.apps.hammer.desktop
+
+import androidx.compose.ui.input.key.*
+import com.darkrockstudios.apps.hammer.common.compose.matchesShortcut
+
+/**
+ * Window level shortcuts, matched before the focused component sees the event.
+ *
+ * Modifiers must match exactly: AltGr arrives as Ctrl+Alt, so a loose `Ctrl+Q` test would
+ * fire while the user types `@` on a Turkish or German keyboard.
+ */
+internal enum class WindowShortcut {
+	Back,
+	Quit,
+	CloseProject,
+	GlobalSearch,
+}
+
+internal fun KeyEvent.toProjectSelectionShortcut(): WindowShortcut? = when {
+	isBack() -> WindowShortcut.Back
+	matchesShortcut(Key.Q, ctrl = true) -> WindowShortcut.Quit
+	else -> null
+}
+
+internal fun KeyEvent.toProjectEditorShortcut(): WindowShortcut? = when {
+	isBack() -> WindowShortcut.Back
+	matchesShortcut(Key.F, ctrl = true, shift = true) -> WindowShortcut.GlobalSearch
+	matchesShortcut(Key.W, ctrl = true) -> WindowShortcut.CloseProject
+	matchesShortcut(Key.Q, ctrl = true) -> WindowShortcut.Quit
+	else -> null
+}
+
+private fun KeyEvent.isBack(): Boolean = key == Key.Escape && type == KeyEventType.KeyUp

--- a/desktop/src/jvmMain/kotlin/com/darkrockstudios/apps/hammer/desktop/WindowShortcuts.kt
+++ b/desktop/src/jvmMain/kotlin/com/darkrockstudios/apps/hammer/desktop/WindowShortcuts.kt
@@ -4,16 +4,27 @@ import androidx.compose.ui.input.key.*
 import com.darkrockstudios.apps.hammer.common.compose.matchesShortcut
 
 /**
- * Window level shortcuts, matched before the focused component sees the event.
- *
- * Modifiers must match exactly: AltGr arrives as Ctrl+Alt, so a loose `Ctrl+Q` test would
- * fire while the user types `@` on a Turkish or German keyboard.
+ * Modifiers must match exactly, and no chord may use Alt: AltGr arrives as Ctrl+Alt, so
+ * either would fire while a Turkish, German, or Polish layout types the character on that
+ * key.
  */
 internal enum class WindowShortcut {
 	Back,
 	Quit,
 	CloseProject,
 	GlobalSearch,
+}
+
+/** Project actions, matched pre-focus so a focused editor cannot swallow them. */
+internal enum class ProjectShortcut {
+	SyncProject,
+	SaveAll,
+}
+
+internal fun KeyEvent.toProjectShortcut(): ProjectShortcut? = when {
+	matchesShortcut(Key.F3) -> ProjectShortcut.SyncProject
+	matchesShortcut(Key.S, ctrl = true, shift = true) -> ProjectShortcut.SaveAll
+	else -> null
 }
 
 internal fun KeyEvent.toProjectSelectionShortcut(): WindowShortcut? = when {

--- a/desktop/src/jvmTest/kotlin/com/darkrockstudios/apps/hammer/desktop/WindowShortcutsTest.kt
+++ b/desktop/src/jvmTest/kotlin/com/darkrockstudios/apps/hammer/desktop/WindowShortcutsTest.kt
@@ -1,0 +1,79 @@
+package com.darkrockstudios.apps.hammer.desktop
+
+import androidx.compose.ui.InternalComposeUiApi
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.input.key.KeyEvent
+import androidx.compose.ui.input.key.KeyEventType
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+@OptIn(InternalComposeUiApi::class)
+class WindowShortcutsTest {
+
+	private fun keyDown(
+		key: Key,
+		ctrl: Boolean = false,
+		meta: Boolean = false,
+		alt: Boolean = false,
+		shift: Boolean = false,
+	) = KeyEvent(
+		key = key,
+		type = KeyEventType.KeyDown,
+		isCtrlPressed = ctrl,
+		isMetaPressed = meta,
+		isAltPressed = alt,
+		isShiftPressed = shift,
+	)
+
+	@Test
+	fun `ctrl Q quits from the project selection window`() {
+		assertEquals(WindowShortcut.Quit, keyDown(Key.Q, ctrl = true).toProjectSelectionShortcut())
+	}
+
+	@Test
+	fun `cmd Q quits from the project selection window`() {
+		assertEquals(WindowShortcut.Quit, keyDown(Key.Q, meta = true).toProjectSelectionShortcut())
+	}
+
+	@Test
+	fun `AltGr Q types an at sign instead of quitting`() {
+		val altGrQ = keyDown(Key.Q, ctrl = true, alt = true)
+
+		assertNull(altGrQ.toProjectSelectionShortcut())
+		assertNull(altGrQ.toProjectEditorShortcut())
+	}
+
+	@Test
+	fun `AltGr W does not close the project`() {
+		assertNull(keyDown(Key.W, ctrl = true, alt = true).toProjectEditorShortcut())
+	}
+
+	@Test
+	fun `ctrl W closes the project`() {
+		assertEquals(WindowShortcut.CloseProject, keyDown(Key.W, ctrl = true).toProjectEditorShortcut())
+	}
+
+	@Test
+	fun `ctrl shift F opens global search`() {
+		assertEquals(
+			WindowShortcut.GlobalSearch,
+			keyDown(Key.F, ctrl = true, shift = true).toProjectEditorShortcut(),
+		)
+	}
+
+	@Test
+	fun `escape navigates back on key up only`() {
+		val keyUp = KeyEvent(key = Key.Escape, type = KeyEventType.KeyUp)
+
+		assertEquals(WindowShortcut.Back, keyUp.toProjectSelectionShortcut())
+		assertEquals(WindowShortcut.Back, keyUp.toProjectEditorShortcut())
+		assertNull(keyDown(Key.Escape).toProjectEditorShortcut())
+	}
+
+	@Test
+	fun `unmodified keys are not shortcuts`() {
+		assertNull(keyDown(Key.Q).toProjectSelectionShortcut())
+		assertNull(keyDown(Key.W).toProjectEditorShortcut())
+	}
+}

--- a/desktop/src/jvmTest/kotlin/com/darkrockstudios/apps/hammer/desktop/WindowShortcutsTest.kt
+++ b/desktop/src/jvmTest/kotlin/com/darkrockstudios/apps/hammer/desktop/WindowShortcutsTest.kt
@@ -76,4 +76,26 @@ class WindowShortcutsTest {
 		assertNull(keyDown(Key.Q).toProjectSelectionShortcut())
 		assertNull(keyDown(Key.W).toProjectEditorShortcut())
 	}
+
+	@Test
+	fun `F3 starts a project sync`() {
+		assertEquals(ProjectShortcut.SyncProject, keyDown(Key.F3).toProjectShortcut())
+		assertNull(keyDown(Key.F3, ctrl = true).toProjectShortcut())
+	}
+
+	@Test
+	fun `ctrl shift S saves all buffers`() {
+		assertEquals(
+			ProjectShortcut.SaveAll,
+			keyDown(Key.S, ctrl = true, shift = true).toProjectShortcut(),
+		)
+	}
+
+	@Test
+	fun `AltGr S types its character instead of saving`() {
+		assertNull(keyDown(Key.S, ctrl = true, alt = true).toProjectShortcut())
+		assertNull(
+			keyDown(Key.S, ctrl = true, alt = true, shift = true).toProjectShortcut(),
+		)
+	}
 }

--- a/docs/KEYBOARD-SHORTCUTS.md
+++ b/docs/KEYBOARD-SHORTCUTS.md
@@ -7,6 +7,10 @@ Desktop, plus the two project shortcuts on Android and iOS with a hardware keybo
 treats `isCtrlPressed || isMetaPressed` as a single "ctrl" modifier, so these are not
 macOS-specific `Cmd` bindings, they work with either key on every platform.
 
+Every binding matches its modifiers exactly, and none of them uses `Alt`. Both rules are
+load bearing: Windows reports `AltGr` as `Ctrl+Alt`, so a loose or `Alt` based chord fires
+while a Turkish, German, or Polish layout types the character on that key (issue #859).
+
 ## Application
 
 These are matched in `desktop/.../WindowShortcuts.kt` and dispatched from each window's
@@ -18,9 +22,6 @@ These are matched in `desktop/.../WindowShortcuts.kt` and dispatched from each w
 | `Ctrl+Q`       | Quit application      | `ProjectEditorWindow.kt`, `ProjectSelectionWindow.kt` |
 | `Ctrl+W`       | Close current project | `ProjectEditorWindow.kt`                        |
 | `Ctrl+Shift+F` | Open global search    | `ProjectEditorWindow.kt`                        |
-
-Modifiers match exactly here too, which is what keeps `AltGr` (reported as `Ctrl+Alt` on
-Windows) from quitting the app while a non-US layout types `@`.
 
 ## Project (while a project is open)
 
@@ -40,13 +41,12 @@ above use the window's `onKeyEvent` instead and yield to a focused component tha
 the key. Modifier shortcuts (the editor ones below) only fire when focus sits inside the
 composable they are attached to.
 
-Modifiers match exactly: `F3` means F3 with nothing held, so `Ctrl+F3` and `Shift+F3` do
-not start a sync. On iOS the save-all chord is `Cmd+Opt+S` or `Ctrl+Opt+S`.
+`F3` means F3 with nothing held, so `Ctrl+F3` and `Shift+F3` do not start a sync.
 
-| Shortcut     | Action                                       |
-|--------------|----------------------------------------------|
-| `Ctrl+Alt+S` | Save all dirty buffers (scenes, notes, etc.) |
-| `F3`         | Start project sync (server-linked only)      |
+| Shortcut       | Action                                       |
+|----------------|----------------------------------------------|
+| `Ctrl+Shift+S` | Save all dirty buffers (scenes, notes, etc.) |
+| `F3`           | Start project sync (server-linked only)      |
 
 ## Editors (scene, note, timeline event, story idea)
 

--- a/docs/KEYBOARD-SHORTCUTS.md
+++ b/docs/KEYBOARD-SHORTCUTS.md
@@ -9,12 +9,18 @@ macOS-specific `Cmd` bindings, they work with either key on every platform.
 
 ## Application
 
-| Shortcut       | Action                | Source                                                               |
-|----------------|-----------------------|----------------------------------------------------------------------|
-| `Esc`          | Navigate back         | `ProjectEditorWindow.kt`, `ProjectSelectionWindow.kt` (`onKeyEvent`) |
-| `Ctrl+Q`       | Quit application      | `ProjectEditorWindow.kt`, `ProjectSelectionWindow.kt` (`onKeyEvent`) |
-| `Ctrl+W`       | Close current project | `ProjectEditorWindow.kt` (`onKeyEvent`)                              |
-| `Ctrl+Shift+F` | Open global search    | `ProjectEditorWindow.kt` (`onKeyEvent`)                              |
+These are matched in `desktop/.../WindowShortcuts.kt` and dispatched from each window's
+`onKeyEvent`.
+
+| Shortcut       | Action                | Window                                          |
+|----------------|-----------------------|-------------------------------------------------|
+| `Esc`          | Navigate back         | `ProjectEditorWindow.kt`, `ProjectSelectionWindow.kt` |
+| `Ctrl+Q`       | Quit application      | `ProjectEditorWindow.kt`, `ProjectSelectionWindow.kt` |
+| `Ctrl+W`       | Close current project | `ProjectEditorWindow.kt`                        |
+| `Ctrl+Shift+F` | Open global search    | `ProjectEditorWindow.kt`                        |
+
+Modifiers match exactly here too, which is what keeps `AltGr` (reported as `Ctrl+Alt` on
+Windows) from quitting the app while a non-US layout types `@`.
 
 ## Project (while a project is open)
 

--- a/ios/ios/ComposeContainer.swift
+++ b/ios/ios/ComposeContainer.swift
@@ -61,8 +61,8 @@ final class ShortcutHostController: UIViewController {
     override var keyCommands: [UIKeyCommand]? {
         [
             UIKeyCommand(input: Self.f3Input, modifierFlags: [], action: #selector(startSync)),
-            UIKeyCommand(input: "s", modifierFlags: [.command, .alternate], action: #selector(saveAll)),
-            UIKeyCommand(input: "s", modifierFlags: [.control, .alternate], action: #selector(saveAll)),
+            UIKeyCommand(input: "s", modifierFlags: [.command, .shift], action: #selector(saveAll)),
+            UIKeyCommand(input: "s", modifierFlags: [.control, .shift], action: #selector(saveAll)),
         ]
     }
 


### PR DESCRIPTION
Fixes #859.

## The bug

Windows reports `AltGr` as `Ctrl` + `Alt`. On a Turkish-Q or German QWERTZ layout, `@` is `AltGr+Q`, so typing an email address matched the window's loose quit test:

```kotlin
event.key == Key.Q && (event.isCtrlPressed || event.isMetaPressed) -> exitApplication()
```

The app wasn't crashing, it was quitting: clean exit, nothing in the log, and pasting `@` worked fine. The Sync Server Setup screen is just where people first type an email. `Ctrl+W` (close project) and `Ctrl+Shift+F` had the same looseness.

## The fix

Window shortcut matching moves into `WindowShortcuts.kt` as a pure `KeyEvent -> WindowShortcut?` mapping, built on the existing exact-modifier `matchesShortcut` helper that the `Modifier` shortcuts already use. Extra modifiers no longer count as a match, so `AltGr+Q` falls through to the focused text field and types `@`.

## Save-all rebound: `Ctrl+Alt+S` -> `Ctrl+Shift+S`

Exact matching alone doesn't save a chord that deliberately includes `Alt`. `Ctrl+Alt+S` **is** `AltGr+S`, which is `ś` on a Polish programmers layout, so save-all fired and swallowed the character. AltGr can't be told apart from Ctrl+Alt on Windows (AWT sets both, and X11 sets AltGraph instead, which Compose folds into `isAltPressed`), so the chord moves to the conventional Save All binding instead. Rebound on all three platforms: desktop `onPreviewKeyEvent`, `ProjectRootActivity.dispatchKeyEvent`, and the iOS `UIKeyCommand`s (`Cmd+Shift+S` / `Ctrl+Shift+S`). Android's global search now matches its modifiers exactly too.

No shortcut uses `Alt` anywhere now, so this class of bug can't recur. `AltGr+Shift+S` (`Ś`) doesn't match `Ctrl+Shift+S` either, because of the exact matching above.

## Tests

`WindowShortcutsTest` covers both handlers: the AltGr cases fail against the old logic and pass now, alongside `Ctrl+Q` / `Cmd+Q` / `Ctrl+W` / `Ctrl+Shift+F` / `Ctrl+Shift+S` / `F3` / `Esc`-on-key-up. `MatchesShortcutTest` follows the rebind.

## Also here

First commit is an unrelated build unblock: Koin compiler plugin 1.1.0 (bumped in 7c51f8a) emits compile-safety hint classes with duplicate method signatures, which aborts every `Test` task during JUnit's class scan. They're excluded from test detection. Worth retrying without the exclude on the next Koin plugin bump.
