### PR TITLE
Replace the native Argon2 binding with a pure-JVM implementation

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -28,6 +28,12 @@ RUN groupadd --gid 1000 hammer \
 # setting JAVA_OPTS for heap would otherwise silently relocate all durable state.
 ENV SERVER_OPTS="-Duser.home=/data"
 
+# JNA, which the CLI's terminal library pulls in, extracts a shared object and executes
+# it. On Linux it ignores java.io.tmpdir and uses $XDG_CACHE_HOME (defaulting to
+# <user.home>/.cache), so without this it lands on the /data volume, which many hosts
+# mount noexec. Keep it on the image layer instead.
+ENV XDG_CACHE_HOME=/home/hammer/.cache
+
 ARG DIST_DIR=server/build/install/server
 COPY --chown=1000:1000 ${DIST_DIR}/ /opt/hammer/
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -82,7 +82,6 @@ mockk = "1.14.11"
 tomlkt = "0.5.0"
 
 krypto = "4.0.10"
-argon2_jvm = "2.12"
 owasp_html_sanitizer = "20260313.1"
 
 sqldelight = "2.3.2"
@@ -284,7 +283,6 @@ work-runtime-ktx = { module = "androidx.work:work-runtime-ktx", version.ref = "w
 korlibs_krypto = { group = "com.soywiz.korlibs.krypto", name = "krypto", version.ref = "krypto" }
 korlibs_korio = { group = "com.soywiz.korlibs.korio", name = "korio", version.ref = "krypto" }
 
-argon2_jvm = { group = "de.mkammerer", name = "argon2-jvm", version.ref = "argon2_jvm" }
 owasp-html-sanitizer = { group = "com.googlecode.owasp-java-html-sanitizer", name = "owasp-java-html-sanitizer", version.ref = "owasp_html_sanitizer" }
 
 sqldelight_driver = { group = "app.cash.sqldelight", name = "sqlite-driver", version.ref = "sqldelight" }
@@ -329,6 +327,7 @@ compose-texteditor-spellcheck = { group = "com.darkrockstudios", name = "compose
 platform-spellcheckerkt = { module = "com.darkrockstudios:platform-spellcheckerkt", version.ref = "platform-spellcheckerkt" }
 
 bouncycastle-bcpkix = { group = "org.bouncycastle", name = "bcpkix-jdk18on", version.ref = "bouncycastle" }
+bouncycastle-bcprov = { group = "org.bouncycastle", name = "bcprov-jdk18on", version.ref = "bouncycastle" }
 
 nucleus_darkmode_detector = { module = "dev.nucleusframework:nucleus.darkmode-detector", version.ref = "nucleus" }
 nucleus_application = { module = "dev.nucleusframework:nucleus.nucleus-application", version.ref = "nucleus" }

--- a/server/build.gradle.kts
+++ b/server/build.gradle.kts
@@ -87,6 +87,8 @@ dependencies {
 	implementation(libs.ktor.server.forwarded.header)
 	implementation(libs.ktor.network.tlscertificates)
 	implementation(libs.bouncycastle.bcpkix)
+	// Argon2 password hashing; also pulled in transitively by bcpkix, declared for the direct use.
+	implementation(libs.bouncycastle.bcprov)
 	implementation(libs.jakarta.mail)
 
 	// Logback is the active SLF4J binding (replaces slf4j-simple) so logback.xml's
@@ -134,7 +136,6 @@ dependencies {
 //	implementation(libs.cryptography.core)
 //	implementation(libs.cryptography.provider.jdk)
 	implementation(libs.kache)
-	implementation(libs.argon2.jvm)
 
 	testImplementation(libs.bundles.ktor.client)
 	testImplementation(libs.ktor.serialization.kotlinx.json)

--- a/server/src/main/kotlin/com/darkrockstudios/apps/hammer/account/AccountsRepository.kt
+++ b/server/src/main/kotlin/com/darkrockstudios/apps/hammer/account/AccountsRepository.kt
@@ -10,7 +10,6 @@ import com.darkrockstudios.apps.hammer.database.AccountDao
 import com.darkrockstudios.apps.hammer.database.AuthTokenDao
 import com.darkrockstudios.apps.hammer.database.CommunityAuthor
 import com.darkrockstudios.apps.hammer.utilities.*
-import de.mkammerer.argon2.Argon2Factory
 import kotlin.io.encoding.Base64
 import kotlin.time.Clock
 import kotlin.time.Duration.Companion.days
@@ -149,19 +148,14 @@ class AccountsRepository(
 	private fun checkPassword(account: Account, plainTextPassword: String): Boolean =
 		checkPassword(plainTextPassword, account.password_hash)
 
-	// Any verify failure (invalid/old hash format) is treated as a wrong password.
-	@Suppress("TooGenericExceptionCaught", "SwallowedException")
+	// An unreadable stored hash is treated as a wrong password.
 	private fun checkPassword(plainTextPassword: String, passwordHash: String): Boolean {
-		val argon2 = Argon2Factory.create()
 		val passwordChars = plainTextPassword.toCharArray()
 
 		return try {
-			argon2.verify(passwordHash, passwordChars)
-		} catch (_: Exception) {
-			// If verification fails (e.g., invalid format, old hash), return false
-			false
+			Argon2PasswordHasher.verify(passwordHash, passwordChars)
 		} finally {
-			argon2.wipeArray(passwordChars)
+			passwordChars.fill('\u0000')
 		}
 	}
 
@@ -345,18 +339,17 @@ class AccountsRepository(
 		const val ARGON2_PARALLELISM = 2  // threads
 
 		fun hashPassword(password: String): String {
-			val argon2 = Argon2Factory.create()
 			val passwordChars = password.toCharArray()
 
 			try {
-				return argon2.hash(
-					ARGON2_TIME_COST,
-					ARGON2_MEMORY_COST_KIB,
-					ARGON2_PARALLELISM,
-					passwordChars
+				return Argon2PasswordHasher.hash(
+					password = passwordChars,
+					memoryKib = ARGON2_MEMORY_COST_KIB,
+					iterations = ARGON2_TIME_COST,
+					parallelism = ARGON2_PARALLELISM,
 				)
 			} finally {
-				argon2.wipeArray(passwordChars)
+				passwordChars.fill('\u0000')
 			}
 		}
 	}

--- a/server/src/main/kotlin/com/darkrockstudios/apps/hammer/utilities/Argon2PasswordHasher.kt
+++ b/server/src/main/kotlin/com/darkrockstudios/apps/hammer/utilities/Argon2PasswordHasher.kt
@@ -1,0 +1,176 @@
+package com.darkrockstudios.apps.hammer.utilities
+
+import org.bouncycastle.crypto.generators.Argon2BytesGenerator
+import org.bouncycastle.crypto.params.Argon2Parameters
+import java.security.MessageDigest
+import java.security.SecureRandom
+import java.util.Base64
+
+/**
+ * Argon2 password hashing that reads and writes the standard PHC encoded string:
+ * `$argon2i$v=19$m=65536,t=3,p=2$<b64 salt>$<b64 hash>`.
+ *
+ * [verify] takes every parameter from the stored string, so hashes written with any
+ * variant, version, or cost settings keep working.
+ *
+ * Pure JVM on purpose: a libargon2 binding extracts a shared object at runtime and
+ * executes it, which fails outright wherever the extraction directory is mounted
+ * noexec, as it commonly is on hardened container hosts.
+ */
+object Argon2PasswordHasher {
+
+	const val SALT_LENGTH = 16
+	const val HASH_LENGTH = 32
+
+	private const val ARGON2_I = "argon2i"
+	private const val ARGON2_D = "argon2d"
+	private const val ARGON2_ID = "argon2id"
+
+	private const val MAX_MEMORY_KIB = 1024 * 1024
+	private const val MAX_ITERATIONS = 100
+	private const val MAX_PARALLELISM = 64
+
+	// Absent `v=` means the original Argon2 version, which predates the marker.
+	private val DEFAULT_VERSION = Argon2Parameters.ARGON2_VERSION_10
+
+	private val secureRandom = SecureRandom()
+	private val encoder = Base64.getEncoder().withoutPadding()
+	private val decoder = Base64.getDecoder()
+
+	fun hash(password: CharArray, memoryKib: Int, iterations: Int, parallelism: Int): String {
+		val salt = ByteArray(SALT_LENGTH)
+		secureRandom.nextBytes(salt)
+
+		val hash = derive(
+			type = Argon2Parameters.ARGON2_i,
+			version = Argon2Parameters.ARGON2_VERSION_13,
+			salt = salt,
+			memoryKib = memoryKib,
+			iterations = iterations,
+			parallelism = parallelism,
+			password = password,
+			outputLength = HASH_LENGTH,
+		)
+
+		return buildString {
+			append('$').append(ARGON2_I)
+			append("\$v=").append(Argon2Parameters.ARGON2_VERSION_13)
+			append("\$m=").append(memoryKib)
+			append(",t=").append(iterations)
+			append(",p=").append(parallelism)
+			append('$').append(encoder.encodeToString(salt))
+			append('$').append(encoder.encodeToString(hash))
+		}
+	}
+
+	/** Returns false for anything that isn't a well-formed hash of [password]. */
+	fun verify(encoded: String, password: CharArray): Boolean {
+		val parsed = parse(encoded) ?: return false
+
+		val computed = derive(
+			type = parsed.type,
+			version = parsed.version,
+			salt = parsed.salt,
+			memoryKib = parsed.memoryKib,
+			iterations = parsed.iterations,
+			parallelism = parsed.parallelism,
+			password = password,
+			outputLength = parsed.hash.size,
+		)
+
+		return MessageDigest.isEqual(parsed.hash, computed)
+	}
+
+	@Suppress("LongParameterList")
+	private fun derive(
+		type: Int,
+		version: Int,
+		salt: ByteArray,
+		memoryKib: Int,
+		iterations: Int,
+		parallelism: Int,
+		password: CharArray,
+		outputLength: Int,
+	): ByteArray {
+		val parameters = Argon2Parameters.Builder(type)
+			.withVersion(version)
+			.withSalt(salt)
+			.withMemoryAsKB(memoryKib)
+			.withIterations(iterations)
+			.withParallelism(parallelism)
+			.build()
+
+		val generator = Argon2BytesGenerator()
+		generator.init(parameters)
+
+		val output = ByteArray(outputLength)
+		generator.generateBytes(password, output)
+		return output
+	}
+
+	private class Parsed(
+		val type: Int,
+		val version: Int,
+		val memoryKib: Int,
+		val iterations: Int,
+		val parallelism: Int,
+		val salt: ByteArray,
+		val hash: ByteArray,
+	)
+
+	@Suppress("ReturnCount", "MagicNumber")
+	private fun parse(encoded: String): Parsed? {
+		// The leading '$' makes the first field empty, so a full hash splits into six.
+		val fields = encoded.split('$')
+		if (fields.size !in 5..6 || fields[0].isNotEmpty()) return null
+
+		val type = when (fields[1]) {
+			ARGON2_I -> Argon2Parameters.ARGON2_i
+			ARGON2_D -> Argon2Parameters.ARGON2_d
+			ARGON2_ID -> Argon2Parameters.ARGON2_id
+			else -> return null
+		}
+
+		val hasVersion = fields.size == 6
+		val version = if (hasVersion) {
+			val field = fields[2]
+			if (!field.startsWith("v=")) return null
+			field.removePrefix("v=").toIntOrNull() ?: return null
+		} else {
+			DEFAULT_VERSION
+		}
+		if (version != Argon2Parameters.ARGON2_VERSION_10 && version != Argon2Parameters.ARGON2_VERSION_13) return null
+
+		val costs = fields[if (hasVersion) 3 else 2]
+			.split(',')
+			.map { it.split('=', limit = 2) }
+		if (costs.any { it.size != 2 }) return null
+		val costsByKey = costs.associate { it[0] to it[1] }
+
+		// keyid/data would change the derivation and we never write them.
+		if (costsByKey.keys != setOf("m", "t", "p")) return null
+
+		val memoryKib = costsByKey.getValue("m").toIntOrNull() ?: return null
+		val iterations = costsByKey.getValue("t").toIntOrNull() ?: return null
+		val parallelism = costsByKey.getValue("p").toIntOrNull() ?: return null
+
+		// The lower bounds are what the algorithm requires. The upper bounds keep a
+		// corrupt stored value from allocating the heap away or hashing for hours.
+		if (parallelism < 1 || parallelism > MAX_PARALLELISM) return null
+		if (iterations < 1 || iterations > MAX_ITERATIONS) return null
+		if (memoryKib < 8 * parallelism || memoryKib > MAX_MEMORY_KIB) return null
+
+		val salt = decodeOrNull(fields[if (hasVersion) 4 else 3]) ?: return null
+		val hash = decodeOrNull(fields[if (hasVersion) 5 else 4]) ?: return null
+		if (salt.isEmpty() || hash.isEmpty()) return null
+
+		return Parsed(type, version, memoryKib, iterations, parallelism, salt, hash)
+	}
+
+	@Suppress("SwallowedException")
+	private fun decodeOrNull(value: String): ByteArray? = try {
+		decoder.decode(value)
+	} catch (_: IllegalArgumentException) {
+		null
+	}
+}

--- a/server/src/test/kotlin/com/darkrockstudios/apps/hammer/account/PasswordResetRepositoryTest.kt
+++ b/server/src/test/kotlin/com/darkrockstudios/apps/hammer/account/PasswordResetRepositoryTest.kt
@@ -8,11 +8,11 @@ import com.darkrockstudios.apps.hammer.database.AuthTokenDao
 import com.darkrockstudios.apps.hammer.database.PasswordResetTokenDao
 import com.darkrockstudios.apps.hammer.email.EmailResult
 import com.darkrockstudios.apps.hammer.email.EmailService
+import com.darkrockstudios.apps.hammer.utilities.Argon2PasswordHasher
 import com.darkrockstudios.apps.hammer.utilities.isFailure
 import com.darkrockstudios.apps.hammer.utilities.isSuccess
 import com.darkrockstudios.apps.hammer.utils.BaseTest
 import com.darkrockstudios.apps.hammer.utils.TestClock
-import de.mkammerer.argon2.Argon2Factory
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.mockk
@@ -221,7 +221,7 @@ class PasswordResetRepositoryTest : BaseTest() {
 		val newHash = slot<String>()
 		coVerify(exactly = 1) { accountDao.updatePassword(userId, capture(newHash)) }
 		assertTrue(
-			Argon2Factory.create().verify(newHash.captured, "BrandNewPass123".toCharArray()),
+			Argon2PasswordHasher.verify(newHash.captured, "BrandNewPass123".toCharArray()),
 			"Stored hash must verify against the new password",
 		)
 		coVerify(exactly = 1) { authTokenDao.deleteTokensByUserId(userId) }

--- a/server/src/test/kotlin/com/darkrockstudios/apps/hammer/utilities/Argon2PasswordHasherTest.kt
+++ b/server/src/test/kotlin/com/darkrockstudios/apps/hammer/utilities/Argon2PasswordHasherTest.kt
@@ -1,0 +1,129 @@
+package com.darkrockstudios.apps.hammer.utilities
+
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotEquals
+import kotlin.test.assertTrue
+
+/**
+ * The reference-hash fixtures below come from the Argon2 C implementation (libargon2,
+ * via de.mkammerer:argon2-jvm 2.12), which wrote every password hash on deployed
+ * servers. They must keep verifying.
+ */
+class Argon2PasswordHasherTest {
+
+	private val referenceHashes = listOf(
+		// argon2i at the parameters AccountsRepository hashes with.
+		"correct horse battery staple" to
+			"\$argon2i\$v=19\$m=65536,t=3,p=2\$k7m7gU9uModw2lSbVPJ8lQ\$iBwaiktAxMo5yNDbAyxMti4I2wtZjYgsL+jB2RCcKAw",
+		// A different variant and cost settings, all read back out of the string.
+		"correct horse battery staple" to
+			"\$argon2id\$v=19\$m=19456,t=2,p=1\$tlovharpYfIUfTm1m0FOpQ\$s0nGX03Qf8gy426+jDwY0p+kaXmjyiaGpAlXMPcjxTY",
+		"a" to
+			"\$argon2d\$v=19\$m=8,t=1,p=1\$FciDFN4R17rjWQgcpzuBLQ\$5sFXlzqDGdvVE3PLHftVmbgIPeD0+ROLXDoD6Ug2fk0",
+		// A non-ASCII password, which only verifies if both sides encode it as UTF-8.
+		"caf\u00e9 na\u00efve \u00dfeta" to
+			"\$argon2i\$v=19\$m=32768,t=2,p=4\$K4OYE6n5R01UtQGT3lgcKA\$al0ciei4LlOHcylR1ZZsYmNXBHDlZ6JJJMSdSZ3f+ec",
+	)
+
+	@Test
+	fun `verifies hashes written by the reference implementation`() {
+		referenceHashes.forEach { (password, hash) ->
+			assertTrue(
+				Argon2PasswordHasher.verify(hash, password.toCharArray()),
+				"Reference hash $hash must verify",
+			)
+		}
+	}
+
+	@Test
+	fun `rejects a wrong password against a reference hash`() {
+		referenceHashes.forEach { (_, hash) ->
+			assertFalse(
+				Argon2PasswordHasher.verify(hash, "not the password".toCharArray()),
+				"Reference hash $hash must not verify against another password",
+			)
+		}
+	}
+
+	@Test
+	fun `verifies a hash carrying no version marker`() {
+		val hash = "\$argon2i\$m=1024,t=2,p=1\$c2l4dGVlbmJ5dGVzYWx0IQ\$l/Rt3Va9SLakmdDaJnB+MRNtwcxBR8XKsJpNKSEGnro"
+
+		assertTrue(Argon2PasswordHasher.verify(hash, "legacy-format".toCharArray()))
+		assertFalse(Argon2PasswordHasher.verify(hash, "legacy-formaT".toCharArray()))
+	}
+
+	@Test
+	fun `verifies its own hashes`() {
+		val password = "a password with spaces & symbols !@#"
+
+		val hash = Argon2PasswordHasher.hash(password.toCharArray(), memoryKib = 1024, iterations = 2, parallelism = 1)
+
+		assertTrue(Argon2PasswordHasher.verify(hash, password.toCharArray()))
+		assertFalse(Argon2PasswordHasher.verify(hash, "a password with spaces & symbols !@".toCharArray()))
+		assertFalse(Argon2PasswordHasher.verify(hash, "".toCharArray()))
+	}
+
+	@Test
+	fun `writes the encoded form the parameters describe`() {
+		val hash = Argon2PasswordHasher.hash("pw".toCharArray(), memoryKib = 4096, iterations = 5, parallelism = 3)
+
+		val fields = hash.split("$")
+		assertEquals(listOf("", "argon2i", "v=19", "m=4096,t=5,p=3"), fields.take(4))
+		// Base64 without padding: 16 salt bytes and 32 hash bytes.
+		assertEquals(22, fields[4].length)
+		assertEquals(43, fields[5].length)
+	}
+
+	@Test
+	fun `salts every hash separately`() {
+		val password = "same password".toCharArray()
+
+		val first = Argon2PasswordHasher.hash(password, memoryKib = 1024, iterations = 2, parallelism = 1)
+		val second = Argon2PasswordHasher.hash(password, memoryKib = 1024, iterations = 2, parallelism = 1)
+
+		assertNotEquals(first, second)
+		assertTrue(Argon2PasswordHasher.verify(first, password))
+		assertTrue(Argon2PasswordHasher.verify(second, password))
+	}
+
+	@Test
+	fun `treats an unreadable stored hash as a failed verification`() {
+		val salt = "c2l4dGVlbmJ5dGVzYWx0IQ"
+		val hash = "l/Rt3Va9SLakmdDaJnB+MRNtwcxBR8XKsJpNKSEGnro"
+
+		val malformed = listOf(
+			"",
+			"not a hash at all",
+			// Bcrypt, in case a server was ever seeded from another tool.
+			"\$2y\$10\$N9qo8uLOickgx2ZMRZoMyeIjZAgcfl7p92ldGxad68LJZdL17lhWy",
+			// Unknown variant.
+			"\$argon2x\$v=19\$m=1024,t=2,p=1\$$salt\$$hash",
+			// Unsupported version.
+			"\$argon2i\$v=99\$m=1024,t=2,p=1\$$salt\$$hash",
+			// Missing the hash field.
+			"\$argon2i\$v=19\$m=1024,t=2,p=1\$$salt",
+			// Non-numeric and missing cost parameters.
+			"\$argon2i\$v=19\$m=lots,t=2,p=1\$$salt\$$hash",
+			"\$argon2i\$v=19\$m=1024,p=1\$$salt\$$hash",
+			// Memory below the parallelism floor, which the generator silently clamps.
+			"\$argon2i\$v=19\$m=4,t=2,p=4\$$salt\$$hash",
+			// Costs a corrupt row could carry that would exhaust the heap or the clock.
+			"\$argon2i\$v=19\$m=2000000000,t=2,p=1\$$salt\$$hash",
+			"\$argon2i\$v=19\$m=1024,t=2000000000,p=1\$$salt\$$hash",
+			// Keyed and associated-data hashes need inputs we don't hold.
+			"\$argon2i\$v=19\$m=1024,t=2,p=1,keyid=Zm9v\$$salt\$$hash",
+			// Salt outside the base64 alphabet.
+			"\$argon2i\$v=19\$m=1024,t=2,p=1\$!!!!\$$hash",
+		)
+
+		malformed.forEach {
+			assertFalse(
+				Argon2PasswordHasher.verify(it, "legacy-format".toCharArray()),
+				"Must not verify: $it",
+			)
+		}
+	}
+}


### PR DESCRIPTION
Fixes #884.

## The bug

Self-hosters got a 500 on `POST /setup` with `UnsatisfiedLinkError: failed to map segment from shared object`.

Argon2 hashing went through JNA, which extracts `libjnidispatch.so` at runtime. On Linux **JNA ignores `java.io.tmpdir`**: it uses `$XDG_CACHE_HOME`, falling back to `<user.home>/.cache`, then appends `JNA/temp`. Our image sets `-Duser.home=/data`, so the shared object gets extracted onto the data volume. Where that volume is mounted `noexec`, the executable mapping is refused and the load fails.

The load is lazy and only happens when a password is hashed, which is why the server boots, serves pages, and runs embedded PostgreSQL fine (Zonky extracts to `java.io.tmpdir`) and only account creation and login break.

## The fix

`Argon2PasswordHasher` derives with BouncyCastle's `Argon2BytesGenerator`, which is pure JVM, and reads and writes the standard PHC encoded string. `verify` takes the variant, version, and cost parameters out of the stored hash, so anything previously written keeps working.

**No migration and no password resets.** BouncyCastle produces byte-identical output to libargon2 for the same inputs, and both encode the password as UTF-8 (`argon2-jvm`'s `BaseArgon2` defaults to UTF-8), so non-ASCII passwords verify too. `Argon2PasswordHasherTest` pins this against hashes generated by the C implementation, covering argon2i, argon2d, argon2id, several cost settings, an accented password, and the version-less encoding.

Parsing rejects anything it cannot reproduce (unknown variant, unsupported version, `keyid`/`data`, absurd cost values) so an unreadable stored hash is a failed login rather than a thrown exception or an OOM.

`XDG_CACHE_HOME` also moves to the image layer in the Dockerfile, because JNA is *still* on the runtime classpath after this change: `mordant-jvm-jna` comes in via Clikt for terminal handling.

## Cost

Pure-JVM Argon2 is slower than the C implementation. Measured at our parameters (m=64 MiB, t=3, p=2), warm:

| | ms per hash |
|---|---|
| argon2-jvm (native, JNA) | 88 |
| BouncyCastle (pure JVM) | 160 |

That is paid once per signup, login, and password reset. The gap is narrower on small VPSs, where the native library's threading of `p=2` has fewer cores to exploit.

## Testing

- `:server:test` 1170 tests, 0 failures
- `:integrationTests:jvmTest` 60 tests, 0 failures (real signup and login e2e)
- Re-verified after rebasing onto `develop`
- Not verified inside a container; Docker was unavailable on this machine. The `noexec` reproduction is worth a manual check before release.

## Follow-up, not done here

New hashes are still argon2i, matching the previous default. Switching to argon2id is a one-line change now that `verify` reads the variant from the stored string.
