### PR TITLE
Fall back to English when a locale bundle is missing a key

### DIFF
--- a/server/src/main/kotlin/com/darkrockstudios/apps/hammer/plugins/Localization.kt
+++ b/server/src/main/kotlin/com/darkrockstudios/apps/hammer/plugins/Localization.kt
@@ -2,6 +2,9 @@ package com.darkrockstudios.apps.hammer.plugins
 
 import com.darkrockstudios.apps.hammer.utilities.ResUtils
 import com.github.aymanizz.ktori18n.I18n
+import com.github.aymanizz.ktori18n.KeyGenerator
+import com.github.aymanizz.ktori18n.MessageResolver
+import com.github.aymanizz.ktori18n.ResourceBundleMessageResolver
 import io.ktor.server.application.*
 import java.util.*
 
@@ -9,8 +12,26 @@ fun Application.configureLocalization() {
 	install(I18n) {
 		supportedLocales = ResUtils.getTranslatedLocales()
 		defaultLocale = Locale.ENGLISH
+		messageResolver = EnglishFallbackMessageResolver()
 		//useOfCookie = true
 		//useOfRedirection = true
 		//excludePrefixes("/api")
 	}
+}
+
+/**
+ * A locale bundle has no parent bundle to inherit from, so a key its translation
+ * doesn't carry yet resolves against English rather than throwing
+ * MissingResourceException at the caller.
+ */
+private class EnglishFallbackMessageResolver : MessageResolver {
+	private val delegate = ResourceBundleMessageResolver()
+
+	override fun t(locale: Locale, keyGenerator: KeyGenerator, vararg args: Any): String =
+		try {
+			delegate.t(locale, keyGenerator, *args)
+		} catch (e: MissingResourceException) {
+			if (locale.language == Locale.ENGLISH.language) throw e
+			delegate.t(Locale.ENGLISH, keyGenerator, *args)
+		}
 }

--- a/server/src/test/kotlin/com/darkrockstudios/apps/hammer/frontend/SignupPageTest.kt
+++ b/server/src/test/kotlin/com/darkrockstudios/apps/hammer/frontend/SignupPageTest.kt
@@ -22,8 +22,10 @@ import com.darkrockstudios.apps.hammer.utils.testAccount
 import io.ktor.client.request.forms.submitForm
 import io.ktor.client.request.cookie
 import io.ktor.client.request.get
+import io.ktor.client.request.header
 import io.ktor.client.request.post
 import io.ktor.client.statement.bodyAsText
+import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.parameters
 import io.ktor.http.parseServerSetCookieHeader
@@ -111,6 +113,7 @@ class SignupPageTest : BaseTest() {
 		confirmPassword: String,
 		tosAccepted: Boolean = false,
 		acceptedTosVersion: String? = null,
+		acceptLanguage: String? = null,
 	) = createClient { followRedirects = false }.submitForm(
 		url = "/signup",
 		formParameters = parameters {
@@ -120,7 +123,9 @@ class SignupPageTest : BaseTest() {
 			if (tosAccepted) append("tosAccepted", "true")
 			if (acceptedTosVersion != null) append("acceptedTosVersion", acceptedTosVersion)
 		}
-	)
+	) {
+		if (acceptLanguage != null) header(HttpHeaders.AcceptLanguage, acceptLanguage)
+	}
 
 	@Test
 	fun `GET renders the signup form without a ToS block when no terms are configured`() = testApplication {
@@ -236,6 +241,31 @@ class SignupPageTest : BaseTest() {
 		coVerify(exactly = 1) {
 			securityRepository.recordLoginAttempt("stranger@test.com", any(), false)
 		}
+	}
+
+	@Test
+	fun `POST for a not-allowed email falls back to English when the locale lacks the message`() = testApplication {
+		mockPageModelDependencies()
+		coEvery {
+			accountsComponent.createAccount("stranger@test.com", "web", "password123", null)
+		} returns CreateAccountResult.Failure(
+			SResult.failure<Token>(
+				"User not on whitelist",
+				Msg.r("api_allowedusers_rejected"),
+			)
+		)
+		coEvery { accountsComponent.checkIfWhiteListRejected("stranger@test.com") } returns true
+		configureApp()
+
+		// "xx" resolves to the deliberately incomplete test-resource bundle
+		// (Messages_xx.properties); real locales are kept complete by Crowdin.
+		val response = postSignupForm(
+			"stranger@test.com", "password123", "password123",
+			acceptLanguage = "xx",
+		)
+
+		assertEquals(HttpStatusCode.OK, response.status)
+		assertContains(response.bodyAsText(), "not allowed on this server")
 	}
 
 	@Test


### PR DESCRIPTION
Fixes the registration half of #883.

## The bug

Signing up with an email that is not on the Allowed Users list returned a
500 error page instead of the rejection message, but only for users whose
browser asked for a non-English locale.

`ktor-i18n`'s `ResourceBundleMessageResolver` resolves `Msg.r(...)` /
`call.t(...)` against `Messages_<locale>.properties`. We ship no base
`Messages.properties`, so those bundles have no parent to inherit from and
a key the translation has not picked up yet throws
`MissingResourceException` straight out of the route handler.

The whitelist rejection needs `api_allowedusers_rejected`, which Crowdin
had not yet delivered to German at 3.8.2, so a German browser hit the
throw. Nothing about the signup path itself was wrong: any `t()` call site
was one untranslated key away from the same 500, and five keys are missing
from every non-English bundle on `develop` right now.

The Mustache-side helper (`localizedString` in `frontend/utils/Localization.kt`)
already had this fallback; the `t()` path did not.

## The fix

Wrap the resolver so a `MissingResourceException` retries against English
before escaping. A key missing from English too still throws, which is a
real bug and stays covered by `MessageBundleParityTest`.

## Test

`SignupPageTest` gains a case that posts a not-allowed email with
`Accept-Language: xx`, the deliberately incomplete test-resource bundle.
It fails on `develop` with exactly the reported symptom:

```
MissingResourceException: Can't find resource for bundle
java.util.PropertyResourceBundle, key api_allowedusers_rejected
...
assertEquals(HttpStatusCode.OK, response.status)
                                |
                                500 Internal Server Error
```

Full `:server:test` suite passes with the fix.

## Not covered

The 401-on-`begin_sync` half of #883 is untouched and still needs a repro.
