### PR TITLE
Bump cairn to 0.3.0

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -106,7 +106,7 @@ platform-spellcheckerkt = "1.3.2"
 nucleus = "2.4.4"
 colorpicker-compose = "1.2.0"
 material-kolor = "5.0.0"
-cairn = "0.2.2"
+cairn = "0.3.0"
 
 [libraries]
 activity-compose = { module = "androidx.activity:activity-compose", version.ref = "activity-compose" }


### PR DESCRIPTION
## Summary
- Bumps `cairn` from 0.2.2 to 0.3.0 in `gradle/libs.versions.toml`.
- Checked the upstream diff (Darkrock-Studios/Cairn v0.2.2...v0.3.0): additions to sound engine, theme, and a new `SurveyRail` component; no changes to `CairnAboutOverlay`, `CairnConfig`, or `CairnAppId`, which are the only APIs this repo uses (in `desktop` and `composeUi`). No breaking changes, no code changes needed.

## Test plan
- [x] `./gradlew :desktop:compileKotlinJvm` — resolves cairn 0.3.0 and compiles `base`, `common`, `composeUi`, `desktop` successfully.