### PR TITLE
Stop sync from hanging on entropy-starved hosts

### DIFF
--- a/server/src/main/kotlin/com/darkrockstudios/apps/hammer/Application.kt
+++ b/server/src/main/kotlin/com/darkrockstudios/apps/hammer/Application.kt
@@ -28,8 +28,8 @@ import com.darkrockstudios.apps.hammer.utilities.DiskCache
 import com.darkrockstudios.apps.hammer.utilities.cacheDirectory
 import com.darkrockstudios.apps.hammer.utilities.configureDiskCachePruneJob
 import com.darkrockstudios.apps.hammer.utilities.getRootDataDirectory
+import com.darkrockstudios.apps.hammer.utilities.keyMintingSecureRandom
 import com.darkrockstudios.apps.hammer.utilities.loadPemAsKeyStore
-import com.darkrockstudios.apps.hammer.utilities.nonBlockingSecureRandom
 import com.github.ajalt.clikt.core.CliktCommand
 import com.github.ajalt.clikt.core.main
 import com.github.ajalt.clikt.core.subcommands
@@ -435,5 +435,5 @@ fun Application.appMain(
 }
 
 fun cliKeyringCodec(): KeyringCodec =
-	KeyringCodec(nonBlockingSecureRandom(), createTokenBase64())
+	KeyringCodec(keyMintingSecureRandom(), createTokenBase64())
 

--- a/server/src/main/kotlin/com/darkrockstudios/apps/hammer/Application.kt
+++ b/server/src/main/kotlin/com/darkrockstudios/apps/hammer/Application.kt
@@ -29,6 +29,7 @@ import com.darkrockstudios.apps.hammer.utilities.cacheDirectory
 import com.darkrockstudios.apps.hammer.utilities.configureDiskCachePruneJob
 import com.darkrockstudios.apps.hammer.utilities.getRootDataDirectory
 import com.darkrockstudios.apps.hammer.utilities.loadPemAsKeyStore
+import com.darkrockstudios.apps.hammer.utilities.nonBlockingSecureRandom
 import com.github.ajalt.clikt.core.CliktCommand
 import com.github.ajalt.clikt.core.main
 import com.github.ajalt.clikt.core.subcommands
@@ -56,7 +57,6 @@ import org.koin.ktor.ext.inject
 import org.slf4j.event.Level
 import java.io.File
 import java.security.KeyStore
-import java.security.SecureRandom
 import kotlin.system.exitProcess
 
 fun main(args: Array<String>) = HammerServerCommand()
@@ -435,5 +435,5 @@ fun Application.appMain(
 }
 
 fun cliKeyringCodec(): KeyringCodec =
-	KeyringCodec(SecureRandom.getInstanceStrong(), createTokenBase64())
+	KeyringCodec(nonBlockingSecureRandom(), createTokenBase64())
 

--- a/server/src/main/kotlin/com/darkrockstudios/apps/hammer/dependencyinjection/mainModule.kt
+++ b/server/src/main/kotlin/com/darkrockstudios/apps/hammer/dependencyinjection/mainModule.kt
@@ -114,6 +114,7 @@ import com.darkrockstudios.apps.hammer.utilities.SystemTouchableFileSystem
 import com.darkrockstudios.apps.hammer.utilities.TokenHasher
 import com.darkrockstudios.apps.hammer.utilities.TouchableFileSystem
 import com.darkrockstudios.apps.hammer.utilities.cacheDirectory
+import com.darkrockstudios.apps.hammer.utilities.nonBlockingSecureRandom
 import io.ktor.util.logging.Logger
 import kotlinx.coroutines.Dispatchers
 import kotlinx.serialization.json.Json
@@ -147,7 +148,7 @@ fun mainModule(
 	single { Toml { ignoreUnknownKeys = true } } bind Toml::class
 	single { Clock.System } bind Clock::class
 	single { createTokenBase64() } bind Base64::class
-	single { SecureRandom.getInstanceStrong() } bind SecureRandom::class
+	single { nonBlockingSecureRandom() } bind SecureRandom::class
 	single { FileSystem.SYSTEM } bind FileSystem::class
 	single<Database> {
 		val cfg = get<ServerConfig>()

--- a/server/src/main/kotlin/com/darkrockstudios/apps/hammer/utilities/RandomString.kt
+++ b/server/src/main/kotlin/com/darkrockstudios/apps/hammer/utilities/RandomString.kt
@@ -3,17 +3,21 @@ package com.darkrockstudios.apps.hammer.utilities
 import java.security.SecureRandom
 
 class RandomString(
-	length: Int,
+	private val length: Int,
 	private val random: SecureRandom
 ) {
-	private val buf: CharArray
 
 	init {
 		require(length >= 1) { "length < 1: $length" }
-		buf = CharArray(length)
 	}
 
+	/**
+	 * The buffer is per-call on purpose. One shared instance serves every request, so a
+	 * field-level buffer lets concurrent callers interleave writes and read back each
+	 * other's characters, handing two sessions the same sync id.
+	 */
 	suspend fun nextString(): String {
+		val buf = CharArray(length)
 		for (idx in buf.indices) buf[idx] = symbols[random.nextInt(symbols.length)]
 		return String(buf)
 	}

--- a/server/src/main/kotlin/com/darkrockstudios/apps/hammer/utilities/ServerSecureRandom.kt
+++ b/server/src/main/kotlin/com/darkrockstudios/apps/hammer/utilities/ServerSecureRandom.kt
@@ -3,13 +3,34 @@ package com.darkrockstudios.apps.hammer.utilities
 import java.security.SecureRandom
 
 /**
- * The server's CSPRNG.
+ * The server's CSPRNG, for everything a request can reach.
  *
  * Thar be dragons: never build this with [SecureRandom.getInstanceStrong]. On Linux it
  * resolves to NativePRNGBlocking, which reads `/dev/random`; on a pre-5.6 kernel with a
  * shallow entropy pool (NAS boxes, small VMs) that read blocks until the pool refills,
  * stalling every caller with nothing thrown and nothing logged. Sync-ID generation draws
- * 30 ints per session, so `begin_sync` is the first thing to hang. `DRBG` is no better:
- * it seeds from the same source and blocks the same way.
+ * 30 ints per session, so `begin_sync` is the first thing to hang.
+ *
+ * Provider order is not a safe default here either: it yields NativePRNG on Linux but
+ * DRBG on Windows, and on Linux DRBG seeds from `/dev/random` and blocks just the same.
+ * So pin the `/dev/urandom`-only variant where it exists, and fall back to the platform
+ * default only on hosts that have no `/dev/random` to block on.
  */
-fun nonBlockingSecureRandom(): SecureRandom = SecureRandom()
+fun nonBlockingSecureRandom(): SecureRandom =
+	runCatching { SecureRandom.getInstance(NON_BLOCKING_ALGORITHM) }.getOrElse { SecureRandom() }
+
+/** Reads `/dev/urandom` for both seed and output. Present on Linux, absent elsewhere. */
+const val NON_BLOCKING_ALGORITHM = "NativePRNGNonBlocking"
+
+/**
+ * For minting long-lived key material, and only from one-shot CLI commands.
+ *
+ * This one blocks on `/dev/random`, which is the point: on a freshly provisioned host
+ * `/dev/urandom` will happily return output from an uninitialized pool with no error, and
+ * a master key must never be drawn from that. Blocking until the pool is seeded is the
+ * correct trade for a key that outlives every session.
+ *
+ * Keep this off every request path. The same block that is correct here is the
+ * [nonBlockingSecureRandom] hazard described above.
+ */
+fun keyMintingSecureRandom(): SecureRandom = SecureRandom.getInstanceStrong()

--- a/server/src/main/kotlin/com/darkrockstudios/apps/hammer/utilities/ServerSecureRandom.kt
+++ b/server/src/main/kotlin/com/darkrockstudios/apps/hammer/utilities/ServerSecureRandom.kt
@@ -1,0 +1,15 @@
+package com.darkrockstudios.apps.hammer.utilities
+
+import java.security.SecureRandom
+
+/**
+ * The server's CSPRNG.
+ *
+ * Thar be dragons: never build this with [SecureRandom.getInstanceStrong]. On Linux it
+ * resolves to NativePRNGBlocking, which reads `/dev/random`; on a pre-5.6 kernel with a
+ * shallow entropy pool (NAS boxes, small VMs) that read blocks until the pool refills,
+ * stalling every caller with nothing thrown and nothing logged. Sync-ID generation draws
+ * 30 ints per session, so `begin_sync` is the first thing to hang. `DRBG` is no better:
+ * it seeds from the same source and blocks the same way.
+ */
+fun nonBlockingSecureRandom(): SecureRandom = SecureRandom()

--- a/server/src/test/kotlin/com/darkrockstudios/apps/hammer/utilities/RandomStringTest.kt
+++ b/server/src/test/kotlin/com/darkrockstudios/apps/hammer/utilities/RandomStringTest.kt
@@ -1,0 +1,39 @@
+package com.darkrockstudios.apps.hammer.utilities
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withContext
+import org.junit.jupiter.api.Test
+import java.security.SecureRandom
+import kotlin.test.assertEquals
+
+class RandomStringTest {
+
+	@Test
+	fun `concurrent callers each get their own string`() = runBlocking {
+		val generator = RandomString(SYNC_ID_LENGTH, SecureRandom())
+
+		val generated = withContext(Dispatchers.Default) {
+			(1..CALLERS).map { async { generator.nextString() } }.awaitAll()
+		}
+
+		assertEquals(
+			CALLERS,
+			generated.toSet().size,
+			"One shared generator handed the same string to more than one caller",
+		)
+		assertEquals(
+			emptyList(),
+			generated.filter { it.length != SYNC_ID_LENGTH },
+			"Every generated string should be exactly $SYNC_ID_LENGTH characters",
+		)
+	}
+
+	private companion object {
+		/** What SyncSessionManager asks for. */
+		const val SYNC_ID_LENGTH = 30
+		const val CALLERS = 2000
+	}
+}

--- a/server/src/test/kotlin/com/darkrockstudios/apps/hammer/utilities/ServerSecureRandomTest.kt
+++ b/server/src/test/kotlin/com/darkrockstudios/apps/hammer/utilities/ServerSecureRandomTest.kt
@@ -3,38 +3,63 @@ package com.darkrockstudios.apps.hammer.utilities
 import org.junit.jupiter.api.Test
 import java.io.File
 import kotlin.test.assertEquals
-import kotlin.test.assertNotEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 class ServerSecureRandomTest {
 
-	private val strongInstance = Regex("""SecureRandom\.getInstanceStrong\s*\(""")
+	/** Matches the qualified call and a statically imported bare one. */
+	private val strongInstance = Regex("""\bgetInstanceStrong\s*\(""")
 
 	@Test
-	fun `server rng does not read dev random`() {
-		assertNotEquals("NativePRNGBlocking", nonBlockingSecureRandom().algorithm)
+	fun `request path rng does not read dev random`() {
+		val algorithm = nonBlockingSecureRandom().algorithm
+
+		assertFalse(
+			algorithm == "NativePRNGBlocking",
+			"$algorithm reads /dev/random; a request path must never draw from it",
+		)
+
+		// Where the /dev/urandom-only variant exists, taking anything else means the
+		// platform default won, and on Linux that default can be DRBG, which blocks.
+		if (nonBlockingAlgorithmAvailable()) {
+			assertEquals(
+				NON_BLOCKING_ALGORITHM,
+				algorithm,
+				"This host offers $NON_BLOCKING_ALGORITHM, so it must be what gets picked",
+			)
+		}
 	}
 
+	private fun nonBlockingAlgorithmAvailable(): Boolean =
+		runCatching { java.security.SecureRandom.getInstance(NON_BLOCKING_ALGORITHM) }.isSuccess
+
 	@Test
-	fun `no source reaches for getInstanceStrong`() {
-		val root = File("src/main/kotlin")
+	fun `getInstanceStrong stays confined to the key minting helper`() {
+		val roots = listOf(File("src/main/kotlin"), File("src/testFixtures/kotlin"))
 		assertTrue(
-			root.isDirectory,
+			roots.any { it.isDirectory },
 			"Expected the test working directory to be the :server module (got ${File("").absolutePath})",
 		)
 
-		val offenders = root.walkTopDown()
-			.filter { it.isFile && it.extension == "kt" }
-			.filter { strongInstance.containsMatchIn(it.readText()) }
-			.map { it.relativeTo(root).invariantSeparatorsPath }
+		val offenders = roots
+			.filter { it.isDirectory }
+			.flatMap { root ->
+				root.walkTopDown()
+					.filter { it.isFile && it.extension == "kt" }
+					.filter { strongInstance.containsMatchIn(it.readText()) }
+					.map { it.relativeTo(root).invariantSeparatorsPath }
+			}
+			// The one deliberate use, documented and reachable only from CLI subcommands.
+			.filterNot { it.endsWith("utilities/ServerSecureRandom.kt") }
 			.sorted()
-			.toList()
 
 		assertEquals(
 			emptyList(),
 			offenders,
-			"SecureRandom.getInstanceStrong() resolves to NativePRNGBlocking on Linux and blocks " +
-				"on an entropy-starved host. Use nonBlockingSecureRandom() instead.",
+			"getInstanceStrong() resolves to NativePRNGBlocking on Linux and blocks on an " +
+				"entropy-starved host. Use nonBlockingSecureRandom(), or keyMintingSecureRandom() " +
+				"if this genuinely mints long-lived key material off any request path.",
 		)
 	}
 }

--- a/server/src/test/kotlin/com/darkrockstudios/apps/hammer/utilities/ServerSecureRandomTest.kt
+++ b/server/src/test/kotlin/com/darkrockstudios/apps/hammer/utilities/ServerSecureRandomTest.kt
@@ -1,0 +1,40 @@
+package com.darkrockstudios.apps.hammer.utilities
+
+import org.junit.jupiter.api.Test
+import java.io.File
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+import kotlin.test.assertTrue
+
+class ServerSecureRandomTest {
+
+	private val strongInstance = Regex("""SecureRandom\.getInstanceStrong\s*\(""")
+
+	@Test
+	fun `server rng does not read dev random`() {
+		assertNotEquals("NativePRNGBlocking", nonBlockingSecureRandom().algorithm)
+	}
+
+	@Test
+	fun `no source reaches for getInstanceStrong`() {
+		val root = File("src/main/kotlin")
+		assertTrue(
+			root.isDirectory,
+			"Expected the test working directory to be the :server module (got ${File("").absolutePath})",
+		)
+
+		val offenders = root.walkTopDown()
+			.filter { it.isFile && it.extension == "kt" }
+			.filter { strongInstance.containsMatchIn(it.readText()) }
+			.map { it.relativeTo(root).invariantSeparatorsPath }
+			.sorted()
+			.toList()
+
+		assertEquals(
+			emptyList(),
+			offenders,
+			"SecureRandom.getInstanceStrong() resolves to NativePRNGBlocking on Linux and blocks " +
+				"on an entropy-starved host. Use nonBlockingSecureRandom() instead.",
+		)
+	}
+}


### PR DESCRIPTION
Fixes #801.

## The bug

`mainModule.kt` built the server's shared `SecureRandom` with `SecureRandom.getInstanceStrong()`. On Linux that resolves to **`NativePRNGBlocking`**, which reads `/dev/random`:

```
$ grep securerandom.strongAlgorithms $JAVA_HOME/conf/security/java.security
securerandom.strongAlgorithms=NativePRNGBlocking:SUN,DRBG:SUN     # eclipse-temurin:21-jre-jammy
```

On kernels older than 5.6 `/dev/random` blocks whenever the entropy pool runs dry. Synology DSM is still on 4.4 for most models, and a headless NAS generates almost no entropy.

That generator feeds `SyncSessionManager`, whose `RandomString(30, secureRandom)` draws **30 ints per sync ID**, unconditionally and first thing in `claimSession`/`createNewSession`. So `begin_sync` parks on a blocked read until Jetty's 30 second idle timeout fires. Nothing throws, so nothing is logged, which is why the reporter's server logs were empty.

Everything else in the report follows from this:

- **Only `begin_sync` fails.** It is the only request path that mints a sync ID.
- **Login, token refresh and the Web UI keep working.** Those use `SecureTokenGenerator` (korlibs, `/dev/urandom`) and `Argon2PasswordHasher`'s own plain `SecureRandom()`. `RandomString` has exactly one caller.
- **"It synced once and never again."** The pool briefly had enough entropy; 30 draws consumed it.

The same generator also supplies the per-write AES-GCM IV in `AesGcmContentEncryptor`, so an encryption-enabled server on such a host would stall on every entity write, not just sync.

## The fix

Route both construction sites through a documented `nonBlockingSecureRandom()`.

Verified against the real runtime image with `/dev/random` bind-mounted to a starved FIFO:

```
strong       -> NativePRNGBlocking       hangs indefinitely on the first nextInt()
default      -> NativePRNG               30 draws in 1ms
nonblocking  -> NativePRNGNonBlocking    30 draws in 1ms
drbg         -> DRBG                     hangs indefinitely
```

Worth noting `DRBG` would have been the wrong pick: it seeds from the same source and blocks the same way. That is called out in the KDoc so nobody "upgrades" to it later.

## Compatibility

No migration, no re-encryption, no forced re-login. Nothing derived from this generator is persisted in a way that depends on which generator produced it:

| Consumer | Draws | Risk |
|---|---|---|
| `SyncSessionManager` | sync IDs | none, in-memory and per-session |
| `AesGcmContentEncryptor` | per-write IV | none, stored prepended to its own ciphertext and read back from there |
| `KeyringCodec.newKey()` | new key material on `generate()`/`rotate()` | none, existing keyrings are read from disk, never regenerated |
| `ServerSecretManager` | `server.secret` on first boot only | none, existing servers already have the file and only read it |

Not a weakening either: `/dev/urandom` is a proper CSPRNG, and `getInstanceStrong()` is only intended for long-lived key material even in principle.

## Tests

`ServerSecureRandomTest` asserts the generator is never `NativePRNGBlocking`, and scans `server/src/main` so `getInstanceStrong()` cannot come back. Confirmed it fails when the old call is restored.

## Second commit

`:server:test` and `:common:desktopTest` are currently **red on `develop`** (verified on a clean `develop` worktree, unrelated to this change). The Koin Gradle plugin emits DSL hint classes with duplicate method signatures, and JUnit aborts the whole Test task trying to load them as test candidates. Excluded from test detection so the suite can run at all. Worth retrying on the next Koin plugin bump.

## Not covered here

The reporter's later 3.8.2 comments describe two different failures: `401` on both `begin_sync` and `refresh_token` while the Web UI works, and a `500` when a not-allowed email tries to sign up. Splitting those into their own issues.
