### PR TITLE
Add scene selection to story export

### DIFF
--- a/common/src/commonMain/composeResources/values/strings_project_home.xml
+++ b/common/src/commonMain/composeResources/values/strings_project_home.xml
@@ -92,6 +92,12 @@
 	<string name="project_home_export_format_rtf">RTF (.rtf)</string>
 	<string name="project_home_export_cancel">Cancel</string>
 	<string name="project_home_export_execute">Export</string>
+	<string name="project_home_export_limit_scenes_label">Limit to specific scenes</string>
+	<string name="project_home_export_limit_scenes_hint">Only the selected scenes will be included in the export</string>
+	<string name="project_home_export_scenes_label">Scenes</string>
+	<string name="project_home_export_scenes_selected">%1$d of %2$d selected</string>
+	<string name="project_home_export_scenes_select_all">Select all</string>
+	<string name="project_home_export_scenes_clear_all">Clear all</string>
 
 	<string name="project_home_export_help_icon_description">Learn about export formats</string>
 	<string name="project_home_export_help_title">Choosing an Export Format</string>

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/projecthome/ExportStoryUseCase.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/projecthome/ExportStoryUseCase.kt
@@ -93,8 +93,8 @@ class ExportStoryUseCase(
 	/** Reads source data off [ioDispatcher], then renders the document into an in-memory buffer on [defaultDispatcher]. */
 	private suspend fun render(projectName: String, options: ExportOptions): Buffer {
 		val source = withContext(ioDispatcher) {
-			val perNodeChapters = sceneEditorRepository.getSceneTree().root.children.map { node ->
-				StoryChapter(name = node.value.name, markdown = collectMarkdown(node))
+			val perNodeChapters = sceneEditorRepository.getSceneTree().root.children.mapNotNull { node ->
+				chapterFor(node, options.sceneIds)
 			}
 			val projectData =
 				if (options.format == ExportFormat.Markdown) null else projectDataDatasource.load().data
@@ -174,13 +174,28 @@ class ExportStoryUseCase(
 		listOf(StoryChapter(projectName, perNodeChapters.joinToString("\n\n") { it.markdown }))
 	}
 
-	private fun collectMarkdown(node: TreeValue<SceneItem>): String {
-		return if (node.value.type == SceneItem.Type.Scene) {
-			sceneEditorRepository.loadSceneMarkdownRaw(node.value)
+	/**
+	 * Builds the chapter for one top-level node under an optional scene filter.
+	 * Returns null when a filter is active and the node contributes no selected scenes,
+	 * dropping it from the chapter list so later chapters renumber automatically.
+	 * A filter never widens: an empty or fully stale set yields zero chapters.
+	 */
+	private fun chapterFor(node: TreeValue<SceneItem>, sceneFilter: Set<Int>?): StoryChapter? {
+		val sceneNodes = if (node.value.type == SceneItem.Type.Scene) {
+			listOf(node)
 		} else {
 			node.filter { it.value.type == SceneItem.Type.Scene }
-				.joinToString("\n\n") { sceneEditorRepository.loadSceneMarkdownRaw(it.value) }
 		}
+		val included = if (sceneFilter == null) {
+			sceneNodes
+		} else {
+			sceneNodes.filter { it.value.id in sceneFilter }
+		}
+		if (sceneFilter != null && included.isEmpty()) return null
+		return StoryChapter(
+			name = node.value.name,
+			markdown = included.joinToString("\n\n") { sceneEditorRepository.loadSceneMarkdownRaw(it.value) },
+		)
 	}
 
 }

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/projecthome/ProjectHome.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/projecthome/ProjectHome.kt
@@ -8,6 +8,7 @@ import com.darkrockstudios.apps.hammer.common.components.ComponentToaster
 import com.darkrockstudios.apps.hammer.common.components.projectroot.Router
 import com.darkrockstudios.apps.hammer.common.data.ExportFormat
 import com.darkrockstudios.apps.hammer.common.data.ExportOptions
+import com.darkrockstudios.apps.hammer.common.data.ExportableScene
 import com.darkrockstudios.apps.hammer.common.data.ProjectDef
 import com.darkrockstudios.apps.hammer.common.data.encyclopediarepository.entry.EntryType
 import com.darkrockstudios.apps.hammer.common.data.projectbackup.ProjectBackupDef
@@ -27,6 +28,7 @@ interface ProjectHome : Router, HammerComponent, BackHandlerOwner, ComponentToas
 	suspend fun exportProjectToFile(filePath: String, options: ExportOptions): HPath
 	fun beginProjectExport()
 	fun cancelExportDialog()
+	fun updateExportOptions(options: ExportOptions)
 	fun confirmExportDialog(options: ExportOptions)
 	fun endProjectExport()
 
@@ -78,6 +80,7 @@ interface ProjectHome : Router, HammerComponent, BackHandlerOwner, ComponentToas
 		val showExportFilePicker: Boolean = false,
 		val isExporting: Boolean = false,
 		val exportOptions: ExportOptions = ExportOptions(),
+		val exportableScenes: List<ExportableScene> = emptyList(),
 		val hasServer: Boolean = false,
 		val isLoadingStats: Boolean = false,
 		val isStatsDirty: Boolean = false,

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/projecthome/ProjectHome.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/projecthome/ProjectHome.kt
@@ -32,6 +32,9 @@ interface ProjectHome : Router, HammerComponent, BackHandlerOwner, ComponentToas
 	fun confirmExportDialog(options: ExportOptions)
 	fun endProjectExport()
 
+	/** Called after the export dialog's close animation finishes; discards unconfirmed edits. */
+	fun exportDialogDismissed()
+
 	fun startProjectSync()
 	fun showGlobalSearch()
 	fun showGlobalSearchForTag(tag: String)

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/projecthome/ProjectHomeComponent.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/projecthome/ProjectHomeComponent.kt
@@ -75,9 +75,13 @@ class ProjectHomeComponent(
 	override val state: Value<ProjectHome.State> = _state
 
 	override fun beginProjectExport() {
+		val scenes = exportableScenes(sceneEditorRepository.getSceneTree())
 		_state.getAndUpdate {
 			it.copy(
-				showExportDialog = true
+				showExportDialog = true,
+				exportableScenes = scenes,
+				// A scene limit from a previous export would silently narrow this one.
+				exportOptions = it.exportOptions.copy(sceneIds = null),
 			)
 		}
 	}
@@ -85,8 +89,15 @@ class ProjectHomeComponent(
 	override fun cancelExportDialog() {
 		_state.getAndUpdate {
 			it.copy(
-				showExportDialog = false
+				showExportDialog = false,
+				exportableScenes = emptyList(),
 			)
+		}
+	}
+
+	override fun updateExportOptions(options: ExportOptions) {
+		_state.getAndUpdate {
+			it.copy(exportOptions = options)
 		}
 	}
 
@@ -106,6 +117,7 @@ class ProjectHomeComponent(
 				showExportDialog = false,
 				showExportFilePicker = false,
 				isExporting = false,
+				exportableScenes = emptyList(),
 			)
 		}
 	}

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/projecthome/ProjectHomeComponent.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/projecthome/ProjectHomeComponent.kt
@@ -74,15 +74,27 @@ class ProjectHomeComponent(
 	)
 	override val state: Value<ProjectHome.State> = _state
 
+	// The options to restore when the dialog is dismissed without confirming, so
+	// cancelled edits don't become the next export's defaults. Lives outside State:
+	// it is dialog-session bookkeeping, not something the UI renders.
+	private var exportOptionsBeforeDialog: ExportOptions? = null
+
 	override fun beginProjectExport() {
-		val scenes = exportableScenes(sceneEditorRepository.getSceneTree())
 		_state.getAndUpdate {
+			// A scene limit from a previous export would silently narrow this one.
+			val options = it.exportOptions.copy(sceneIds = null)
+			exportOptionsBeforeDialog = options
 			it.copy(
 				showExportDialog = true,
-				exportableScenes = scenes,
-				// A scene limit from a previous export would silently narrow this one.
-				exportOptions = it.exportOptions.copy(sceneIds = null),
+				exportOptions = options,
 			)
+		}
+		// The tree walk reads from the repository and can be large; keep it off the click handler.
+		scope.launch {
+			val scenes = exportableScenes(sceneEditorRepository.getSceneTree())
+			withContext(mainDispatcher) {
+				_state.getAndUpdate { it.copy(exportableScenes = scenes) }
+			}
 		}
 	}
 
@@ -90,7 +102,6 @@ class ProjectHomeComponent(
 		_state.getAndUpdate {
 			it.copy(
 				showExportDialog = false,
-				exportableScenes = emptyList(),
 			)
 		}
 	}
@@ -101,7 +112,22 @@ class ProjectHomeComponent(
 		}
 	}
 
+	override fun exportDialogDismissed() {
+		// Runs after the close animation, so restoring options and dropping the scene
+		// snapshot can't visibly change the still-composed dialog content.
+		val restore = exportOptionsBeforeDialog
+		exportOptionsBeforeDialog = null
+		_state.getAndUpdate {
+			it.copy(
+				exportOptions = restore ?: it.exportOptions,
+				exportableScenes = emptyList(),
+			)
+		}
+	}
+
 	override fun confirmExportDialog(options: ExportOptions) {
+		// Confirmed edits are the new defaults; nothing to restore on dismissal.
+		exportOptionsBeforeDialog = null
 		// Keep the dialog open through the file picker and export so it can show the working state.
 		_state.getAndUpdate {
 			it.copy(
@@ -117,7 +143,6 @@ class ProjectHomeComponent(
 				showExportDialog = false,
 				showExportFilePicker = false,
 				isExporting = false,
-				exportableScenes = emptyList(),
 			)
 		}
 	}

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/ExportOptions.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/ExportOptions.kt
@@ -9,4 +9,6 @@ enum class ExportFormat { Markdown, Epub, Pdf, Docx, Rtf }
 data class ExportOptions(
 	val treatTopLevelAsChapters: Boolean = true,
 	val format: ExportFormat = ExportFormat.Epub,
+	/** Scene ids the export is limited to; null exports the entire story. */
+	val sceneIds: Set<Int>? = null,
 )

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/ExportableScene.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/ExportableScene.kt
@@ -1,0 +1,27 @@
+package com.darkrockstudios.apps.hammer.common.data
+
+import com.darkrockstudios.apps.hammer.common.data.tree.ImmutableTree
+import kotlinx.serialization.Serializable
+
+/** One row of the flattened scene tree shown in the export dialog. */
+@Serializable
+data class ExportableScene(
+	val id: Int,
+	val name: String,
+	val isGroup: Boolean,
+	/** 0 for top-level nodes. */
+	val depth: Int,
+)
+
+/** Flattens [tree] in render order (preorder depth-first), excluding the root. */
+fun exportableScenes(tree: ImmutableTree<SceneItem>): List<ExportableScene> =
+	tree.root
+		.filter { it.value.type != SceneItem.Type.Root }
+		.map { node ->
+			ExportableScene(
+				id = node.value.id,
+				name = node.value.name,
+				isGroup = node.value.type.isCollection,
+				depth = node.depth - 1,
+			)
+		}

--- a/common/src/desktopTest/kotlin/components/projecthome/ExportStoryUseCaseTest.kt
+++ b/common/src/desktopTest/kotlin/components/projecthome/ExportStoryUseCaseTest.kt
@@ -259,7 +259,144 @@ class ExportStoryUseCaseTest : BaseIntegrationTest() {
 		assertTrue(bytes.size > 100, "Single-chapter EPUB should still produce a real file")
 	}
 
+	@Test
+	fun `scene filter keeps only selected scenes and renumbers chapters`() = runTest {
+		initRepo()
+
+		val exportPath = useCase().execute(
+			exportDir = projectPath,
+			options = ExportOptions(
+				format = ExportFormat.Markdown,
+				treatTopLevelAsChapters = true,
+				sceneIds = setOf(1, 4),
+			),
+		)
+
+		val text = ffs.read(exportPath.toOkioPath()) { readByteArray() }.decodeToString()
+		assertEquals(EXPECTED_FILTERED_MARKDOWN.trim(), text.trim())
+	}
+
+	@Test
+	fun `scene filter drops chapters with no selected scenes`() = runTest {
+		initRepo()
+
+		val exportPath = useCase().execute(
+			exportDir = projectPath,
+			options = ExportOptions(
+				format = ExportFormat.Markdown,
+				treatTopLevelAsChapters = true,
+				sceneIds = setOf(6),
+			),
+		)
+
+		val text = ffs.read(exportPath.toOkioPath()) { readByteArray() }.decodeToString()
+		val expected = """
+			# Test Project 1
+
+
+			## 1. Scene ID 6
+
+			Content of scene id 6
+		""".trimIndent()
+		assertEquals(expected, text.trim())
+	}
+
+	@Test
+	fun `scene filter applies when top-level scenes are not chapters`() = runTest {
+		initRepo()
+
+		val exportPath = useCase().execute(
+			exportDir = projectPath,
+			options = ExportOptions(
+				format = ExportFormat.Markdown,
+				treatTopLevelAsChapters = false,
+				sceneIds = setOf(3, 6),
+			),
+		)
+
+		val text = ffs.read(exportPath.toOkioPath()) { readByteArray() }.decodeToString()
+		assertEquals(
+			"# Test Project 1\n\nContent of scene id 3\n\n\nContent of scene id 6",
+			text.trim(),
+		)
+	}
+
+	@Test
+	fun `scene ids missing from the tree are silently ignored`() = runTest {
+		initRepo()
+
+		val exportPath = useCase().execute(
+			exportDir = projectPath,
+			options = ExportOptions(
+				format = ExportFormat.Markdown,
+				treatTopLevelAsChapters = true,
+				sceneIds = setOf(1, 4, 999),
+			),
+		)
+
+		val text = ffs.read(exportPath.toOkioPath()) { readByteArray() }.decodeToString()
+		assertEquals(EXPECTED_FILTERED_MARKDOWN.trim(), text.trim())
+	}
+
+	@Test
+	fun `an empty scene filter fails closed instead of exporting the whole story`() = runTest {
+		initRepo()
+
+		val exportPath = useCase().execute(
+			exportDir = projectPath,
+			options = ExportOptions(
+				format = ExportFormat.Markdown,
+				treatTopLevelAsChapters = true,
+				sceneIds = emptySet(),
+			),
+		)
+
+		val text = ffs.read(exportPath.toOkioPath()) { readByteArray() }.decodeToString()
+		assertEquals("# Test Project 1", text.trim())
+	}
+
+	@Test
+	fun `epub export honors the scene filter`() = runTest {
+		initRepo()
+		storedProjectData = StoredProjectData(data = ProjectData(authorName = "Test Author"))
+
+		val exportPath = useCase().execute(
+			exportDir = projectPath,
+			options = ExportOptions(
+				format = ExportFormat.Epub,
+				treatTopLevelAsChapters = true,
+				sceneIds = setOf(4),
+			),
+		)
+
+		val bytes = ffs.read(exportPath.toOkioPath()) { readByteArray() }
+		assertEquals('P'.code.toByte(), bytes[0])
+		assertEquals('K'.code.toByte(), bytes[1])
+		val chapterText = zipEntryText(bytes, "ch1.xhtml")
+		assertTrue(
+			"Content of scene id 4" in chapterText,
+			"Filtered EPUB chapter should contain the selected scene, got: $chapterText",
+		)
+		assertTrue(
+			"Content of scene id 3" !in chapterText,
+			"Filtered EPUB chapter should not contain unselected scenes, got: $chapterText",
+		)
+	}
+
 	companion object {
+		private val EXPECTED_FILTERED_MARKDOWN = """
+			# Test Project 1
+
+
+			## 1. Scene ID 1
+
+			Content of scene id 1
+
+			## 2. Chapter ID 2
+
+			Content of scene id 4
+		""".trimIndent()
+
 		private val EXPECTED_PROJECT_1_MARKDOWN = """
 			# Test Project 1
 

--- a/common/src/desktopTest/kotlin/components/projecthome/ProjectHomeComponentTest.kt
+++ b/common/src/desktopTest/kotlin/components/projecthome/ProjectHomeComponentTest.kt
@@ -277,6 +277,7 @@ class ProjectHomeComponentTest : ComponentTest() {
 		context.resume()
 
 		comp.beginProjectExport()
+		advanceUntilIdle()
 
 		val expected = listOf(
 			ExportableScene(id = 1, name = "Scene 1", isGroup = false, depth = 0),
@@ -341,18 +342,38 @@ class ProjectHomeComponentTest : ComponentTest() {
 	}
 
 	@Test
-	fun `cancel and end clear the exportable scenes snapshot`() = runTest(mainTestDispatcher) {
+	fun `dismissal after cancel discards in-dialog edits and drops the scenes snapshot`() = runTest(mainTestDispatcher) {
+		val comp = newComponent()
+		context.resume()
+
+		val defaults = comp.state.value.exportOptions
+		comp.beginProjectExport()
+		advanceUntilIdle()
+		assertTrue(comp.state.value.exportableScenes.isNotEmpty())
+
+		comp.updateExportOptions(ExportOptions(treatTopLevelAsChapters = false, format = ExportFormat.Pdf))
+		comp.cancelExportDialog()
+		// The snapshot survives until the close animation finishes, no mid-animation flash.
+		assertTrue(comp.state.value.exportableScenes.isNotEmpty())
+
+		comp.exportDialogDismissed()
+		assertEquals(defaults.copy(sceneIds = null), comp.state.value.exportOptions)
+		assertTrue(comp.state.value.exportableScenes.isEmpty())
+	}
+
+	@Test
+	fun `dismissal after confirm keeps the confirmed options`() = runTest(mainTestDispatcher) {
 		val comp = newComponent()
 		context.resume()
 
 		comp.beginProjectExport()
-		assertTrue(comp.state.value.exportableScenes.isNotEmpty())
-		comp.cancelExportDialog()
-		assertTrue(comp.state.value.exportableScenes.isEmpty())
-
-		comp.beginProjectExport()
+		val confirmed = ExportOptions(format = ExportFormat.Rtf, sceneIds = setOf(3))
+		comp.updateExportOptions(confirmed)
+		comp.confirmExportDialog(confirmed)
 		comp.endProjectExport()
-		assertTrue(comp.state.value.exportableScenes.isEmpty())
+		comp.exportDialogDismissed()
+
+		assertEquals(confirmed, comp.state.value.exportOptions)
 	}
 
 	@Test

--- a/common/src/desktopTest/kotlin/components/projecthome/ProjectHomeComponentTest.kt
+++ b/common/src/desktopTest/kotlin/components/projecthome/ProjectHomeComponentTest.kt
@@ -10,7 +10,11 @@ import com.darkrockstudios.apps.hammer.common.components.storyeditor.metadata.In
 import com.darkrockstudios.apps.hammer.common.components.storyeditor.metadata.ProjectMetadata
 import com.darkrockstudios.apps.hammer.common.data.ExportFormat
 import com.darkrockstudios.apps.hammer.common.data.ExportOptions
+import com.darkrockstudios.apps.hammer.common.data.ExportableScene
 import com.darkrockstudios.apps.hammer.common.data.SceneItem
+import com.darkrockstudios.apps.hammer.common.data.tree.ImmutableTree
+import com.darkrockstudios.apps.hammer.common.data.tree.Tree
+import com.darkrockstudios.apps.hammer.common.data.tree.TreeNode
 import com.darkrockstudios.apps.hammer.common.data.encyclopediarepository.EncyclopediaService
 import com.darkrockstudios.apps.hammer.common.data.encyclopediarepository.entry.EntryDef
 import com.darkrockstudios.apps.hammer.common.data.encyclopediarepository.entry.EntryType
@@ -111,6 +115,7 @@ class ProjectHomeComponentTest : ComponentTest() {
 		coEvery { sceneEditor.getMetadata() } returns ProjectMetadata(
 			Info(created = Instant.parse("2024-01-15T12:00:00Z"))
 		)
+		every { sceneEditor.getSceneTree() } returns buildSceneTree()
 
 		exportStoryUseCase = mockk()
 		encyclopediaService = mockk()
@@ -167,6 +172,26 @@ class ProjectHomeComponentTest : ComponentTest() {
 		onShowEntry = { shownEntry = it },
 		onCloseProject = { projectClosed = true },
 	)
+
+	private fun scene(id: Int, name: String, type: SceneItem.Type = SceneItem.Type.Scene) =
+		SceneItem(projectDef = projectDef, type = type, id = id, name = name, order = id)
+
+	// Scene 1, Group 2 [Scene 3, Scene 4, Group 5 [Scene 6]], Scene 7
+	private fun buildSceneTree(): ImmutableTree<SceneItem> {
+		val tree = Tree<SceneItem>()
+		val root = TreeNode(scene(0, "", SceneItem.Type.Root))
+		root.addChild(TreeNode(scene(1, "Scene 1")))
+		val group = TreeNode(scene(2, "Group 2", SceneItem.Type.Group))
+		group.addChild(TreeNode(scene(3, "Scene 3")))
+		group.addChild(TreeNode(scene(4, "Scene 4")))
+		val nested = TreeNode(scene(5, "Group 5", SceneItem.Type.Group))
+		nested.addChild(TreeNode(scene(6, "Scene 6")))
+		group.addChild(nested)
+		root.addChild(group)
+		root.addChild(TreeNode(scene(7, "Scene 7")))
+		tree.setRoot(root)
+		return tree.toImmutableTree()
+	}
 
 	private fun stats() = ProjectStatistics(
 		numberOfScenes = 4,
@@ -244,6 +269,90 @@ class ProjectHomeComponentTest : ComponentTest() {
 
 		comp.cancelExportDialog()
 		assertFalse(comp.state.value.showExportDialog)
+	}
+
+	@Test
+	fun `beginProjectExport flattens the scene tree into exportable scenes`() = runTest(mainTestDispatcher) {
+		val comp = newComponent()
+		context.resume()
+
+		comp.beginProjectExport()
+
+		val expected = listOf(
+			ExportableScene(id = 1, name = "Scene 1", isGroup = false, depth = 0),
+			ExportableScene(id = 2, name = "Group 2", isGroup = true, depth = 0),
+			ExportableScene(id = 3, name = "Scene 3", isGroup = false, depth = 1),
+			ExportableScene(id = 4, name = "Scene 4", isGroup = false, depth = 1),
+			ExportableScene(id = 5, name = "Group 5", isGroup = true, depth = 1),
+			ExportableScene(id = 6, name = "Scene 6", isGroup = false, depth = 2),
+			ExportableScene(id = 7, name = "Scene 7", isGroup = false, depth = 0),
+		)
+		assertEquals(expected, comp.state.value.exportableScenes)
+	}
+
+	@Test
+	fun `beginProjectExport resets a scene limit left over from a previous export`() = runTest(mainTestDispatcher) {
+		val comp = newComponent()
+		context.resume()
+
+		comp.beginProjectExport()
+		comp.updateExportOptions(ExportOptions(sceneIds = setOf(3)))
+		comp.confirmExportDialog(comp.state.value.exportOptions)
+		comp.endProjectExport()
+
+		comp.beginProjectExport()
+		assertNull(comp.state.value.exportOptions.sceneIds)
+	}
+
+	@Test
+	fun `updateExportOptions persists in-dialog edits in component state`() = runTest(mainTestDispatcher) {
+		val comp = newComponent()
+		context.resume()
+
+		comp.beginProjectExport()
+		val edited = ExportOptions(
+			treatTopLevelAsChapters = false,
+			format = ExportFormat.Pdf,
+			sceneIds = setOf(3, 4),
+		)
+		comp.updateExportOptions(edited)
+
+		// The dialog composition holds no option state, so surviving here is surviving rotation.
+		assertEquals(edited, comp.state.value.exportOptions)
+	}
+
+	@Test
+	fun `confirmExportDialog carries the scene filter through to the use case`() = runTest(mainTestDispatcher) {
+		val options = ExportOptions(format = ExportFormat.Markdown, sceneIds = setOf(3, 6))
+		val exported = HPath("/out/Test.md", "Test.md", true)
+		coEvery { exportStoryUseCase.execute(any(), any()) } returns exported
+
+		val comp = newComponent()
+		context.resume()
+		advanceUntilIdle()
+		comp.beginProjectExport()
+		comp.confirmExportDialog(options)
+		assertEquals(options, comp.state.value.exportOptions)
+
+		comp.exportProject("/out", options)
+		advanceUntilIdle()
+
+		coVerify { exportStoryUseCase.execute(any(), match { it.sceneIds == setOf(3, 6) }) }
+	}
+
+	@Test
+	fun `cancel and end clear the exportable scenes snapshot`() = runTest(mainTestDispatcher) {
+		val comp = newComponent()
+		context.resume()
+
+		comp.beginProjectExport()
+		assertTrue(comp.state.value.exportableScenes.isNotEmpty())
+		comp.cancelExportDialog()
+		assertTrue(comp.state.value.exportableScenes.isEmpty())
+
+		comp.beginProjectExport()
+		comp.endProjectExport()
+		assertTrue(comp.state.value.exportableScenes.isEmpty())
 	}
 
 	@Test

--- a/composeUi/src/androidMain/kotlin/com/darkrockstudios/apps/hammer/common/projecthome/ExportDirectoryPicker.kt
+++ b/composeUi/src/androidMain/kotlin/com/darkrockstudios/apps/hammer/common/projecthome/ExportDirectoryPicker.kt
@@ -5,13 +5,16 @@ import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import com.arkivanov.decompose.extensions.compose.subscribeAsState
 import com.darkrockstudios.apps.hammer.Res
 import com.darkrockstudios.apps.hammer.common.components.projecthome.ProjectHome
 import com.darkrockstudios.apps.hammer.common.compose.rememberIoDispatcher
 import com.darkrockstudios.apps.hammer.common.compose.rememberKoinInject
 import com.darkrockstudios.apps.hammer.common.data.ExportFormat
+import com.darkrockstudios.apps.hammer.common.data.ExportOptions
 import com.darkrockstudios.apps.hammer.common.fileio.ExternalFileIo
 import com.darkrockstudios.apps.hammer.common.getCacheDirectory
 import com.darkrockstudios.apps.hammer.project_home_action_export_toast_failure
@@ -30,11 +33,14 @@ actual fun ExportDirectoryPicker(
 	val externalFileIo: ExternalFileIo = rememberKoinInject()
 	val state by component.state.subscribeAsState()
 	val format = state.exportOptions.format
+	// Snapshot of the confirmed options taken when the SAF picker launches; the
+	// picker does not block the app, so options must not be re-read afterwards.
+	var confirmedOptions by remember { mutableStateOf<ExportOptions?>(null) }
 	val launcher = rememberLauncherForActivityResult(
 		remember(format) { ActivityResultContracts.CreateDocument(mimeTypeFor(format)) }
 	) { uri ->
-		if (uri != null) {
-			val options = state.exportOptions
+		val options = confirmedOptions
+		if (uri != null && options != null) {
 			scope.launch(ioDispatcher) {
 				val exportTempFile = getCacheDirectory()
 				val tempFilePath = component.exportProject(exportTempFile, options)
@@ -60,7 +66,9 @@ actual fun ExportDirectoryPicker(
 
 	LaunchedEffect(show) {
 		if (show) {
-			launcher.launch(component.getExportStoryFileName(format))
+			val options = component.state.value.exportOptions
+			confirmedOptions = options
+			launcher.launch(component.getExportStoryFileName(options.format))
 		}
 	}
 }

--- a/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/compose/designsystem/HdPickerList.kt
+++ b/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/compose/designsystem/HdPickerList.kt
@@ -1,0 +1,118 @@
+package com.darkrockstudios.apps.hammer.common.compose.designsystem
+
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.RowScope
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyListScope
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.RectangleShape
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.isSpecified
+import com.darkrockstudios.apps.hammer.common.compose.Ui
+
+/** Rows deeper than this share the same indent so long names keep room. */
+private const val MAX_INDENT_DEPTH = 4
+
+/**
+ * Hairline-bordered list for picking from an indented tree inside a dialog.
+ * The visible height is capped at [maxVisibleRows] rows derived from the text
+ * size, so the row count holds steady across font scales; overflow scrolls.
+ */
+@Composable
+fun HdPickerList(
+	modifier: Modifier = Modifier,
+	maxVisibleRows: Int = 6,
+	emptyText: String? = null,
+	content: LazyListScope.() -> Unit,
+) {
+	Column(
+		modifier = modifier
+			.fillMaxWidth()
+			.border(
+				width = Dp.Hairline,
+				color = MaterialTheme.colorScheme.outlineVariant,
+				shape = RectangleShape,
+			),
+	) {
+		if (emptyText != null) {
+			Text(
+				text = emptyText,
+				style = MaterialTheme.typography.bodyMedium,
+				color = MaterialTheme.colorScheme.onSurfaceVariant,
+				modifier = Modifier.padding(Ui.Padding.XL),
+			)
+		} else {
+			val lineHeight = MaterialTheme.typography.bodyMedium.lineHeight
+			val rowHeight = with(LocalDensity.current) {
+				(if (lineHeight.isSpecified) lineHeight.toDp() else 20.dp) + (Ui.Padding.M * 2)
+			}
+			LazyColumn(
+				modifier = Modifier.heightIn(max = rowHeight * maxVisibleRows),
+				content = content,
+			)
+		}
+	}
+}
+
+/**
+ * One row of an [HdPickerList]: depth-based indent, optional leading icon,
+ * ellipsized label, and a trailing slot (count label, checkbox, ...).
+ * Interaction (clickable/toggleable), selection background, and test tags are
+ * the caller's, passed through [modifier].
+ */
+@Composable
+fun HdPickerRow(
+	label: String,
+	modifier: Modifier = Modifier,
+	depth: Int = 0,
+	icon: ImageVector? = null,
+	trailing: @Composable RowScope.() -> Unit = {},
+) {
+	Row(
+		modifier = Modifier
+			.fillMaxWidth()
+			.then(modifier)
+			.padding(
+				start = Ui.Padding.L + (Ui.Padding.XL * depth.coerceAtMost(MAX_INDENT_DEPTH)),
+				end = Ui.Padding.L,
+				top = Ui.Padding.M,
+				bottom = Ui.Padding.M,
+			),
+		verticalAlignment = Alignment.CenterVertically,
+		horizontalArrangement = Arrangement.spacedBy(Ui.Padding.M),
+	) {
+		if (icon != null) {
+			Icon(
+				imageVector = icon,
+				contentDescription = null,
+				tint = MaterialTheme.colorScheme.onSurfaceVariant,
+				modifier = Modifier.size(16.dp),
+			)
+		}
+		Text(
+			text = label,
+			style = MaterialTheme.typography.bodyMedium,
+			color = MaterialTheme.colorScheme.onSurface,
+			maxLines = 1,
+			overflow = TextOverflow.Ellipsis,
+			modifier = Modifier.weight(1f),
+		)
+		trailing()
+	}
+}

--- a/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/compose/designsystem/HdPickerList.kt
+++ b/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/compose/designsystem/HdPickerList.kt
@@ -2,6 +2,7 @@ package com.darkrockstudios.apps.hammer.common.compose.designsystem
 
 import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.RowScope
@@ -11,6 +12,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListScope
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
@@ -24,7 +26,9 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.isSpecified
+import com.darkrockstudios.apps.hammer.common.compose.MpScrollBarList
 import com.darkrockstudios.apps.hammer.common.compose.Ui
+import com.darkrockstudios.apps.hammer.common.compose.scrollBarOverlay
 
 /** Rows deeper than this share the same indent so long names keep room. */
 private const val MAX_INDENT_DEPTH = 4
@@ -62,10 +66,20 @@ fun HdPickerList(
 			val rowHeight = with(LocalDensity.current) {
 				(if (lineHeight.isSpecified) lineHeight.toDp() else 20.dp) + (Ui.Padding.M * 2)
 			}
-			LazyColumn(
-				modifier = Modifier.heightIn(max = rowHeight * maxVisibleRows),
-				content = content,
-			)
+			val listState = rememberLazyListState()
+			Box {
+				LazyColumn(
+					state = listState,
+					modifier = Modifier
+						.heightIn(max = rowHeight * maxVisibleRows)
+						.padding(end = Ui.Padding.S),
+					content = content,
+				)
+				MpScrollBarList(
+					modifier = scrollBarOverlay(),
+					state = listState,
+				)
+			}
 		}
 	}
 }

--- a/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/projecthome/ExportOptionsDialog.kt
+++ b/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/projecthome/ExportOptionsDialog.kt
@@ -1,26 +1,21 @@
 package com.darkrockstudios.apps.hammer.common.projecthome
 
 import androidx.compose.foundation.BorderStroke
-import androidx.compose.foundation.border
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.widthIn
-import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.selection.toggleable
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Folder
 import androidx.compose.material3.HorizontalDivider
-import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
@@ -32,18 +27,16 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.RectangleShape
-import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.semantics.Role
-import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.isSpecified
 import com.darkrockstudios.apps.hammer.Res
 import com.darkrockstudios.apps.hammer.common.compose.AnimatedDialog
 import com.darkrockstudios.apps.hammer.common.compose.Ui
 import com.darkrockstudios.apps.hammer.common.compose.designsystem.HdButtonBar
 import com.darkrockstudios.apps.hammer.common.compose.designsystem.HdFolioDivider
+import com.darkrockstudios.apps.hammer.common.compose.designsystem.HdHairlineButton
 import com.darkrockstudios.apps.hammer.common.compose.designsystem.HdHairlineCheckbox
 import com.darkrockstudios.apps.hammer.common.compose.designsystem.HdHairlineDropdown
 import com.darkrockstudios.apps.hammer.common.compose.designsystem.HdHairlineToggleRow
@@ -51,6 +44,8 @@ import com.darkrockstudios.apps.hammer.common.compose.designsystem.HdHelpButton
 import com.darkrockstudios.apps.hammer.common.compose.designsystem.HdMasthead
 import com.darkrockstudios.apps.hammer.common.compose.designsystem.HdMastheadAction
 import com.darkrockstudios.apps.hammer.common.compose.designsystem.HdMonoLabel
+import com.darkrockstudios.apps.hammer.common.compose.designsystem.HdPickerList
+import com.darkrockstudios.apps.hammer.common.compose.designsystem.HdPickerRow
 import com.darkrockstudios.apps.hammer.common.compose.resources.get
 import com.darkrockstudios.apps.hammer.common.data.ExportFormat
 import com.darkrockstudios.apps.hammer.common.data.ExportOptions
@@ -78,6 +73,10 @@ import org.jetbrains.compose.resources.StringResource
 
 private val DialogMaxWidth = 520.dp
 
+internal fun exportSceneRowTag(id: Int) = "export-scene-row-$id"
+internal fun exportGroupRowTag(id: Int) = "export-group-row-$id"
+internal const val EXPORT_SCENE_MASTER_TOGGLE_TAG = "export-scene-master-toggle"
+
 /**
  * Fully controlled: all option state lives in the component's retained state so
  * in-dialog edits survive configuration changes (see issue #885).
@@ -90,6 +89,7 @@ fun ExportOptionsDialog(
 	onOptionsChanged: (ExportOptions) -> Unit,
 	onCancel: () -> Unit,
 	onConfirm: (ExportOptions) -> Unit,
+	onDismissed: () -> Unit = {},
 	working: Boolean = false,
 ) {
 	var showHelp by remember { mutableStateOf(false) }
@@ -98,6 +98,7 @@ fun ExportOptionsDialog(
 		visible = visible,
 		onCloseRequest = { if (!working) onCancel() },
 		dismissOnTapOutside = !working,
+		onDismissed = onDismissed,
 	) {
 		ExportOptionsDialogContent(
 			options = options,
@@ -125,6 +126,8 @@ internal fun ExportOptionsDialogContent(
 	onShowHelp: () -> Unit,
 	working: Boolean = false,
 ) {
+	val allSceneIds = remember(exportableScenes) { allSceneIds(exportableScenes) }
+
 	Surface(
 		modifier = Modifier
 			.padding(Ui.Padding.M)
@@ -178,10 +181,15 @@ internal fun ExportOptionsDialogContent(
 			)
 
 			Column(
-				modifier = Modifier.padding(
-					horizontal = Ui.Padding.XL,
-					vertical = Ui.Padding.XL,
-				),
+				modifier = Modifier
+					// Short screens and large font scales must scroll the options rather
+					// than push the button bar off-screen.
+					.weight(1f, fill = false)
+					.verticalScroll(rememberScrollState())
+					.padding(
+						horizontal = Ui.Padding.XL,
+						vertical = Ui.Padding.XL,
+					),
 				verticalArrangement = Arrangement.spacedBy(Ui.Padding.XL),
 			) {
 				HdHairlineToggleRow(
@@ -198,22 +206,25 @@ internal fun ExportOptionsDialogContent(
 					label = { (it.labelRes()).get() },
 				)
 
-				HdHairlineToggleRow(
-					checked = options.sceneIds != null,
-					onCheckedChange = { limit ->
-						onOptionsChanged(options.copy(sceneIds = if (limit) emptySet() else null))
-					},
-					label = Res.string.project_home_export_limit_scenes_label.get(),
-					hint = Res.string.project_home_export_limit_scenes_hint.get(),
-				)
-
-				val selectedIds = options.sceneIds
-				if (selectedIds != null) {
-					ExportSceneSelector(
-						entries = exportableScenes,
-						selected = selectedIds,
-						onSelectionChanged = { onOptionsChanged(options.copy(sceneIds = it)) },
+				if (allSceneIds.isNotEmpty()) {
+					HdHairlineToggleRow(
+						checked = options.sceneIds != null,
+						onCheckedChange = { limit ->
+							onOptionsChanged(options.copy(sceneIds = if (limit) emptySet() else null))
+						},
+						label = Res.string.project_home_export_limit_scenes_label.get(),
+						hint = Res.string.project_home_export_limit_scenes_hint.get(),
 					)
+
+					val selectedIds = options.sceneIds
+					if (selectedIds != null) {
+						ExportSceneSelector(
+							entries = exportableScenes,
+							allIds = allSceneIds,
+							selected = selectedIds,
+							onSelectionChanged = { onOptionsChanged(options.copy(sceneIds = it)) },
+						)
+					}
 				}
 			}
 
@@ -223,7 +234,17 @@ internal fun ExportOptionsDialogContent(
 				cancelLabel = Res.string.project_home_export_cancel.get(),
 				primaryLabel = Res.string.project_home_export_execute.get(),
 				onCancel = onCancel,
-				onPrimary = { onConfirm(options) },
+				onPrimary = {
+					// Selecting every scene means no limit at all: exporting the full story
+					// keeps empty chapter groups instead of silently dropping them.
+					val selectedIds = options.sceneIds
+					val confirmed = if (selectedIds != null && isFullSelection(exportableScenes, selectedIds)) {
+						options.copy(sceneIds = null)
+					} else {
+						options
+					}
+					onConfirm(confirmed)
+				},
 				primaryLoading = working,
 				primaryEnabled = options.sceneIds?.isNotEmpty() ?: true,
 				cancelEnabled = !working,
@@ -232,20 +253,13 @@ internal fun ExportOptionsDialogContent(
 	}
 }
 
-internal fun exportSceneRowTag(id: Int) = "export-scene-row-$id"
-internal fun exportGroupRowTag(id: Int) = "export-group-row-$id"
-internal const val EXPORT_SCENE_MASTER_TOGGLE_TAG = "export-scene-master-toggle"
-
-private const val MAX_VISIBLE_SCENES = 6
-private const val MAX_INDENT_DEPTH = 4
-
 @Composable
 private fun ExportSceneSelector(
 	entries: List<ExportableScene>,
+	allIds: Set<Int>,
 	selected: Set<Int>,
 	onSelectionChanged: (Set<Int>) -> Unit,
 ) {
-	val allIds = remember(entries) { allSceneIds(entries) }
 	val allSelected = allIds.isNotEmpty() && selected.containsAll(allIds)
 
 	Column(verticalArrangement = Arrangement.spacedBy(Ui.Padding.M)) {
@@ -261,51 +275,32 @@ private fun ExportSceneSelector(
 				color = MaterialTheme.colorScheme.onSurfaceVariant,
 				modifier = Modifier.weight(1f),
 			)
-			Text(
-				text = if (allSelected) {
+			HdHairlineButton(
+				label = if (allSelected) {
 					Res.string.project_home_export_scenes_clear_all.get()
 				} else {
 					Res.string.project_home_export_scenes_select_all.get()
 				},
-				style = MaterialTheme.typography.labelMedium,
-				color = MaterialTheme.colorScheme.primary,
-				modifier = Modifier
-					.clickable { onSelectionChanged(if (allSelected) emptySet() else allIds) }
-					.testTag(EXPORT_SCENE_MASTER_TOGGLE_TAG)
-					.padding(Ui.Padding.S),
+				onClick = { onSelectionChanged(if (allSelected) emptySet() else allIds) },
+				modifier = Modifier.testTag(EXPORT_SCENE_MASTER_TOGGLE_TAG),
 			)
 		}
 
-		Column(
-			modifier = Modifier
-				.fillMaxWidth()
-				.border(
-					width = Dp.Hairline,
-					color = MaterialTheme.colorScheme.outlineVariant,
-					shape = RectangleShape,
-				),
-		) {
-			// Cap derived from the text-driven row height so the visible row count
-			// holds steady across font scales.
-			val lineHeight = MaterialTheme.typography.bodyMedium.lineHeight
-			val rowHeight = with(LocalDensity.current) {
-				(if (lineHeight.isSpecified) lineHeight.toDp() else 20.dp) + (Ui.Padding.M * 2)
-			}
-			LazyColumn(modifier = Modifier.heightIn(max = rowHeight * MAX_VISIBLE_SCENES)) {
-				items(items = entries, key = { it.id }) { entry ->
-					if (entry.isGroup) {
-						ExportGroupRow(
-							entry = entry,
-							fullySelected = isGroupFullySelected(entries, selected, entry),
-							onToggle = { onSelectionChanged(toggleGroup(entries, selected, entry)) },
-						)
-					} else {
-						ExportSceneRow(
-							entry = entry,
-							isSelected = entry.id in selected,
-							onToggle = { onSelectionChanged(toggleScene(selected, entry.id)) },
-						)
-					}
+		HdPickerList {
+			items(items = entries, key = { it.id }) { entry ->
+				if (entry.isGroup) {
+					ExportGroupRow(
+						entry = entry,
+						fullySelected = isGroupFullySelected(entries, selected, entry),
+						hasScenes = descendantSceneIds(entries, entry).isNotEmpty(),
+						onToggle = { onSelectionChanged(toggleGroup(entries, selected, entry)) },
+					)
+				} else {
+					ExportSceneRow(
+						entry = entry,
+						isSelected = entry.id in selected,
+						onToggle = { onSelectionChanged(toggleScene(selected, entry.id)) },
+					)
 				}
 			}
 		}
@@ -316,33 +311,26 @@ private fun ExportSceneSelector(
 private fun ExportGroupRow(
 	entry: ExportableScene,
 	fullySelected: Boolean,
+	hasScenes: Boolean,
 	onToggle: () -> Unit,
 ) {
-	Row(
-		modifier = Modifier
-			.fillMaxWidth()
-			.clickable(onClick = onToggle)
-			.testTag(exportGroupRowTag(entry.id))
-			.padding(sceneRowPadding(entry)),
-		verticalAlignment = Alignment.CenterVertically,
-		horizontalArrangement = Arrangement.spacedBy(Ui.Padding.M),
-	) {
-		Icon(
-			imageVector = Icons.Filled.Folder,
-			contentDescription = null,
-			tint = MaterialTheme.colorScheme.onSurfaceVariant,
-			modifier = Modifier.size(16.dp),
+	val interaction = if (hasScenes) {
+		Modifier.toggleable(
+			value = fullySelected,
+			role = Role.Checkbox,
+			onValueChange = { onToggle() },
 		)
-		Text(
-			text = entry.name,
-			style = MaterialTheme.typography.bodyMedium,
-			color = MaterialTheme.colorScheme.onSurface,
-			maxLines = 1,
-			overflow = TextOverflow.Ellipsis,
-			modifier = Modifier.weight(1f),
-		)
-		HdHairlineCheckbox(checked = fullySelected)
+	} else {
+		// Nothing beneath it to select; an inert checkbox would just mislead.
+		Modifier
 	}
+	HdPickerRow(
+		label = entry.name,
+		depth = entry.depth,
+		icon = Icons.Filled.Folder,
+		modifier = interaction.testTag(exportGroupRowTag(entry.id)),
+		trailing = { if (hasScenes) HdHairlineCheckbox(checked = fullySelected) },
+	)
 }
 
 @Composable
@@ -351,37 +339,19 @@ private fun ExportSceneRow(
 	isSelected: Boolean,
 	onToggle: () -> Unit,
 ) {
-	Row(
+	HdPickerRow(
+		label = entry.name,
+		depth = entry.depth,
 		modifier = Modifier
-			.fillMaxWidth()
 			.toggleable(
 				value = isSelected,
 				role = Role.Checkbox,
 				onValueChange = { onToggle() },
 			)
-			.testTag(exportSceneRowTag(entry.id))
-			.padding(sceneRowPadding(entry)),
-		verticalAlignment = Alignment.CenterVertically,
-		horizontalArrangement = Arrangement.spacedBy(Ui.Padding.M),
-	) {
-		HdHairlineCheckbox(checked = isSelected)
-		Text(
-			text = entry.name,
-			style = MaterialTheme.typography.bodyMedium,
-			color = MaterialTheme.colorScheme.onSurface,
-			maxLines = 1,
-			overflow = TextOverflow.Ellipsis,
-			modifier = Modifier.weight(1f),
-		)
-	}
+			.testTag(exportSceneRowTag(entry.id)),
+		trailing = { HdHairlineCheckbox(checked = isSelected) },
+	)
 }
-
-private fun sceneRowPadding(entry: ExportableScene) = PaddingValues(
-	start = Ui.Padding.L + (Ui.Padding.XL * entry.depth.coerceAtMost(MAX_INDENT_DEPTH)),
-	end = Ui.Padding.L,
-	top = Ui.Padding.M,
-	bottom = Ui.Padding.M,
-)
 
 private val AVAILABLE_EXPORT_FORMATS =
 	listOf(

--- a/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/projecthome/ExportOptionsDialog.kt
+++ b/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/projecthome/ExportOptionsDialog.kt
@@ -1,15 +1,26 @@
 package com.darkrockstudios.apps.hammer.common.projecthome
 
 import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.selection.toggleable
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Folder
 import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
@@ -21,21 +32,29 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.RectangleShape
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.isSpecified
 import com.darkrockstudios.apps.hammer.Res
 import com.darkrockstudios.apps.hammer.common.compose.AnimatedDialog
 import com.darkrockstudios.apps.hammer.common.compose.Ui
 import com.darkrockstudios.apps.hammer.common.compose.designsystem.HdButtonBar
 import com.darkrockstudios.apps.hammer.common.compose.designsystem.HdFolioDivider
+import com.darkrockstudios.apps.hammer.common.compose.designsystem.HdHairlineCheckbox
 import com.darkrockstudios.apps.hammer.common.compose.designsystem.HdHairlineDropdown
 import com.darkrockstudios.apps.hammer.common.compose.designsystem.HdHairlineToggleRow
 import com.darkrockstudios.apps.hammer.common.compose.designsystem.HdHelpButton
 import com.darkrockstudios.apps.hammer.common.compose.designsystem.HdMasthead
 import com.darkrockstudios.apps.hammer.common.compose.designsystem.HdMastheadAction
+import com.darkrockstudios.apps.hammer.common.compose.designsystem.HdMonoLabel
 import com.darkrockstudios.apps.hammer.common.compose.resources.get
 import com.darkrockstudios.apps.hammer.common.data.ExportFormat
 import com.darkrockstudios.apps.hammer.common.data.ExportOptions
+import com.darkrockstudios.apps.hammer.common.data.ExportableScene
 import com.darkrockstudios.apps.hammer.project_home_export_cancel
 import com.darkrockstudios.apps.hammer.project_home_export_chapters_label
 import com.darkrockstudios.apps.hammer.project_home_export_close
@@ -48,25 +67,31 @@ import com.darkrockstudios.apps.hammer.project_home_export_format_markdown
 import com.darkrockstudios.apps.hammer.project_home_export_format_pdf
 import com.darkrockstudios.apps.hammer.project_home_export_format_rtf
 import com.darkrockstudios.apps.hammer.project_home_export_help_icon_description
+import com.darkrockstudios.apps.hammer.project_home_export_limit_scenes_hint
+import com.darkrockstudios.apps.hammer.project_home_export_limit_scenes_label
+import com.darkrockstudios.apps.hammer.project_home_export_scenes_clear_all
+import com.darkrockstudios.apps.hammer.project_home_export_scenes_label
+import com.darkrockstudios.apps.hammer.project_home_export_scenes_select_all
+import com.darkrockstudios.apps.hammer.project_home_export_scenes_selected
 import com.darkrockstudios.apps.hammer.project_home_export_section
 import org.jetbrains.compose.resources.StringResource
 
 private val DialogMaxWidth = 520.dp
 
+/**
+ * Fully controlled: all option state lives in the component's retained state so
+ * in-dialog edits survive configuration changes (see issue #885).
+ */
 @Composable
 fun ExportOptionsDialog(
 	visible: Boolean,
-	initialOptions: ExportOptions,
+	options: ExportOptions,
+	exportableScenes: List<ExportableScene>,
+	onOptionsChanged: (ExportOptions) -> Unit,
 	onCancel: () -> Unit,
 	onConfirm: (ExportOptions) -> Unit,
 	working: Boolean = false,
 ) {
-	var treatAsChapters by remember(initialOptions, visible) {
-		mutableStateOf(initialOptions.treatTopLevelAsChapters)
-	}
-	var format by remember(initialOptions, visible) {
-		mutableStateOf(initialOptions.format)
-	}
 	var showHelp by remember { mutableStateOf(false) }
 
 	AnimatedDialog(
@@ -74,105 +99,289 @@ fun ExportOptionsDialog(
 		onCloseRequest = { if (!working) onCancel() },
 		dismissOnTapOutside = !working,
 	) {
-		Surface(
-			modifier = Modifier
-				.padding(Ui.Padding.M)
-				.widthIn(max = DialogMaxWidth)
-				.fillMaxWidth(),
-			shape = RectangleShape,
-			color = MaterialTheme.colorScheme.surface,
-			contentColor = MaterialTheme.colorScheme.onSurface,
-			border = BorderStroke(
-				width = Dp.Hairline,
-				color = MaterialTheme.colorScheme.outlineVariant,
-			),
-		) {
-			Column {
-				HdMasthead(
-					section = Res.string.project_home_export_section.get(),
-					trailing = {
-						HdHelpButton(
-							onClick = { showHelp = true },
-							contentDescription = Res.string.project_home_export_help_icon_description.get(),
-						)
-						HdMastheadAction(
-							label = Res.string.project_home_export_close.get(),
-							onClick = { if (!working) onCancel() },
-						)
-					},
-				)
-				HdFolioDivider()
-
-				Row(
-					modifier = Modifier
-						.fillMaxWidth()
-						.padding(
-							start = Ui.Padding.XL,
-							end = Ui.Padding.XL,
-							top = Ui.Padding.L,
-							bottom = Ui.Padding.M,
-						),
-					verticalAlignment = Alignment.CenterVertically,
-				) {
-					Text(
-						text = Res.string.project_home_export_dialog_title.get(),
-						style = MaterialTheme.typography.headlineSmall,
-						color = MaterialTheme.colorScheme.onSurface,
-					)
-				}
-
-				HorizontalDivider(
-					thickness = Dp.Hairline,
-					color = MaterialTheme.colorScheme.outlineVariant,
-				)
-
-				Column(
-					modifier = Modifier.padding(
-						horizontal = Ui.Padding.XL,
-						vertical = Ui.Padding.XL,
-					),
-					verticalArrangement = Arrangement.spacedBy(Ui.Padding.XL),
-				) {
-					HdHairlineToggleRow(
-						checked = treatAsChapters,
-						onCheckedChange = { treatAsChapters = it },
-						label = Res.string.project_home_export_chapters_label.get(),
-					)
-
-					HdHairlineDropdown(
-						title = Res.string.project_home_export_format_label.get(),
-						options = AVAILABLE_EXPORT_FORMATS,
-						selected = format,
-						onSelect = { format = it },
-						label = { (it.labelRes()).get() },
-					)
-				}
-
-				Spacer(modifier = Modifier.height(Ui.Padding.M))
-
-				HdButtonBar(
-					cancelLabel = Res.string.project_home_export_cancel.get(),
-					primaryLabel = Res.string.project_home_export_execute.get(),
-					onCancel = onCancel,
-					onPrimary = {
-						onConfirm(
-							ExportOptions(
-								treatTopLevelAsChapters = treatAsChapters,
-								format = format,
-							)
-						)
-					},
-					primaryLoading = working,
-					cancelEnabled = !working,
-				)
-			}
-		}
+		ExportOptionsDialogContent(
+			options = options,
+			exportableScenes = exportableScenes,
+			onOptionsChanged = onOptionsChanged,
+			onCancel = onCancel,
+			onConfirm = onConfirm,
+			onShowHelp = { showHelp = true },
+			working = working,
+		)
 	}
 
 	if (showHelp) {
 		ExportHelpDialog(onDismiss = { showHelp = false })
 	}
 }
+
+@Composable
+internal fun ExportOptionsDialogContent(
+	options: ExportOptions,
+	exportableScenes: List<ExportableScene>,
+	onOptionsChanged: (ExportOptions) -> Unit,
+	onCancel: () -> Unit,
+	onConfirm: (ExportOptions) -> Unit,
+	onShowHelp: () -> Unit,
+	working: Boolean = false,
+) {
+	Surface(
+		modifier = Modifier
+			.padding(Ui.Padding.M)
+			.widthIn(max = DialogMaxWidth)
+			.fillMaxWidth(),
+		shape = RectangleShape,
+		color = MaterialTheme.colorScheme.surface,
+		contentColor = MaterialTheme.colorScheme.onSurface,
+		border = BorderStroke(
+			width = Dp.Hairline,
+			color = MaterialTheme.colorScheme.outlineVariant,
+		),
+	) {
+		Column {
+			HdMasthead(
+				section = Res.string.project_home_export_section.get(),
+				trailing = {
+					HdHelpButton(
+						onClick = onShowHelp,
+						contentDescription = Res.string.project_home_export_help_icon_description.get(),
+					)
+					HdMastheadAction(
+						label = Res.string.project_home_export_close.get(),
+						onClick = { if (!working) onCancel() },
+					)
+				},
+			)
+			HdFolioDivider()
+
+			Row(
+				modifier = Modifier
+					.fillMaxWidth()
+					.padding(
+						start = Ui.Padding.XL,
+						end = Ui.Padding.XL,
+						top = Ui.Padding.L,
+						bottom = Ui.Padding.M,
+					),
+				verticalAlignment = Alignment.CenterVertically,
+			) {
+				Text(
+					text = Res.string.project_home_export_dialog_title.get(),
+					style = MaterialTheme.typography.headlineSmall,
+					color = MaterialTheme.colorScheme.onSurface,
+				)
+			}
+
+			HorizontalDivider(
+				thickness = Dp.Hairline,
+				color = MaterialTheme.colorScheme.outlineVariant,
+			)
+
+			Column(
+				modifier = Modifier.padding(
+					horizontal = Ui.Padding.XL,
+					vertical = Ui.Padding.XL,
+				),
+				verticalArrangement = Arrangement.spacedBy(Ui.Padding.XL),
+			) {
+				HdHairlineToggleRow(
+					checked = options.treatTopLevelAsChapters,
+					onCheckedChange = { onOptionsChanged(options.copy(treatTopLevelAsChapters = it)) },
+					label = Res.string.project_home_export_chapters_label.get(),
+				)
+
+				HdHairlineDropdown(
+					title = Res.string.project_home_export_format_label.get(),
+					options = AVAILABLE_EXPORT_FORMATS,
+					selected = options.format,
+					onSelect = { onOptionsChanged(options.copy(format = it)) },
+					label = { (it.labelRes()).get() },
+				)
+
+				HdHairlineToggleRow(
+					checked = options.sceneIds != null,
+					onCheckedChange = { limit ->
+						onOptionsChanged(options.copy(sceneIds = if (limit) emptySet() else null))
+					},
+					label = Res.string.project_home_export_limit_scenes_label.get(),
+					hint = Res.string.project_home_export_limit_scenes_hint.get(),
+				)
+
+				val selectedIds = options.sceneIds
+				if (selectedIds != null) {
+					ExportSceneSelector(
+						entries = exportableScenes,
+						selected = selectedIds,
+						onSelectionChanged = { onOptionsChanged(options.copy(sceneIds = it)) },
+					)
+				}
+			}
+
+			Spacer(modifier = Modifier.height(Ui.Padding.M))
+
+			HdButtonBar(
+				cancelLabel = Res.string.project_home_export_cancel.get(),
+				primaryLabel = Res.string.project_home_export_execute.get(),
+				onCancel = onCancel,
+				onPrimary = { onConfirm(options) },
+				primaryLoading = working,
+				primaryEnabled = options.sceneIds?.isNotEmpty() ?: true,
+				cancelEnabled = !working,
+			)
+		}
+	}
+}
+
+internal fun exportSceneRowTag(id: Int) = "export-scene-row-$id"
+internal fun exportGroupRowTag(id: Int) = "export-group-row-$id"
+internal const val EXPORT_SCENE_MASTER_TOGGLE_TAG = "export-scene-master-toggle"
+
+private const val MAX_VISIBLE_SCENES = 6
+private const val MAX_INDENT_DEPTH = 4
+
+@Composable
+private fun ExportSceneSelector(
+	entries: List<ExportableScene>,
+	selected: Set<Int>,
+	onSelectionChanged: (Set<Int>) -> Unit,
+) {
+	val allIds = remember(entries) { allSceneIds(entries) }
+	val allSelected = allIds.isNotEmpty() && selected.containsAll(allIds)
+
+	Column(verticalArrangement = Arrangement.spacedBy(Ui.Padding.M)) {
+		Row(
+			modifier = Modifier.fillMaxWidth(),
+			verticalAlignment = Alignment.CenterVertically,
+			horizontalArrangement = Arrangement.spacedBy(Ui.Padding.M),
+		) {
+			HdMonoLabel(text = Res.string.project_home_export_scenes_label.get())
+			Text(
+				text = Res.string.project_home_export_scenes_selected.get(selected.size, allIds.size),
+				style = MaterialTheme.typography.bodySmall,
+				color = MaterialTheme.colorScheme.onSurfaceVariant,
+				modifier = Modifier.weight(1f),
+			)
+			Text(
+				text = if (allSelected) {
+					Res.string.project_home_export_scenes_clear_all.get()
+				} else {
+					Res.string.project_home_export_scenes_select_all.get()
+				},
+				style = MaterialTheme.typography.labelMedium,
+				color = MaterialTheme.colorScheme.primary,
+				modifier = Modifier
+					.clickable { onSelectionChanged(if (allSelected) emptySet() else allIds) }
+					.testTag(EXPORT_SCENE_MASTER_TOGGLE_TAG)
+					.padding(Ui.Padding.S),
+			)
+		}
+
+		Column(
+			modifier = Modifier
+				.fillMaxWidth()
+				.border(
+					width = Dp.Hairline,
+					color = MaterialTheme.colorScheme.outlineVariant,
+					shape = RectangleShape,
+				),
+		) {
+			// Cap derived from the text-driven row height so the visible row count
+			// holds steady across font scales.
+			val lineHeight = MaterialTheme.typography.bodyMedium.lineHeight
+			val rowHeight = with(LocalDensity.current) {
+				(if (lineHeight.isSpecified) lineHeight.toDp() else 20.dp) + (Ui.Padding.M * 2)
+			}
+			LazyColumn(modifier = Modifier.heightIn(max = rowHeight * MAX_VISIBLE_SCENES)) {
+				items(items = entries, key = { it.id }) { entry ->
+					if (entry.isGroup) {
+						ExportGroupRow(
+							entry = entry,
+							fullySelected = isGroupFullySelected(entries, selected, entry),
+							onToggle = { onSelectionChanged(toggleGroup(entries, selected, entry)) },
+						)
+					} else {
+						ExportSceneRow(
+							entry = entry,
+							isSelected = entry.id in selected,
+							onToggle = { onSelectionChanged(toggleScene(selected, entry.id)) },
+						)
+					}
+				}
+			}
+		}
+	}
+}
+
+@Composable
+private fun ExportGroupRow(
+	entry: ExportableScene,
+	fullySelected: Boolean,
+	onToggle: () -> Unit,
+) {
+	Row(
+		modifier = Modifier
+			.fillMaxWidth()
+			.clickable(onClick = onToggle)
+			.testTag(exportGroupRowTag(entry.id))
+			.padding(sceneRowPadding(entry)),
+		verticalAlignment = Alignment.CenterVertically,
+		horizontalArrangement = Arrangement.spacedBy(Ui.Padding.M),
+	) {
+		Icon(
+			imageVector = Icons.Filled.Folder,
+			contentDescription = null,
+			tint = MaterialTheme.colorScheme.onSurfaceVariant,
+			modifier = Modifier.size(16.dp),
+		)
+		Text(
+			text = entry.name,
+			style = MaterialTheme.typography.bodyMedium,
+			color = MaterialTheme.colorScheme.onSurface,
+			maxLines = 1,
+			overflow = TextOverflow.Ellipsis,
+			modifier = Modifier.weight(1f),
+		)
+		HdHairlineCheckbox(checked = fullySelected)
+	}
+}
+
+@Composable
+private fun ExportSceneRow(
+	entry: ExportableScene,
+	isSelected: Boolean,
+	onToggle: () -> Unit,
+) {
+	Row(
+		modifier = Modifier
+			.fillMaxWidth()
+			.toggleable(
+				value = isSelected,
+				role = Role.Checkbox,
+				onValueChange = { onToggle() },
+			)
+			.testTag(exportSceneRowTag(entry.id))
+			.padding(sceneRowPadding(entry)),
+		verticalAlignment = Alignment.CenterVertically,
+		horizontalArrangement = Arrangement.spacedBy(Ui.Padding.M),
+	) {
+		HdHairlineCheckbox(checked = isSelected)
+		Text(
+			text = entry.name,
+			style = MaterialTheme.typography.bodyMedium,
+			color = MaterialTheme.colorScheme.onSurface,
+			maxLines = 1,
+			overflow = TextOverflow.Ellipsis,
+			modifier = Modifier.weight(1f),
+		)
+	}
+}
+
+private fun sceneRowPadding(entry: ExportableScene) = PaddingValues(
+	start = Ui.Padding.L + (Ui.Padding.XL * entry.depth.coerceAtMost(MAX_INDENT_DEPTH)),
+	end = Ui.Padding.L,
+	top = Ui.Padding.M,
+	bottom = Ui.Padding.M,
+)
 
 private val AVAILABLE_EXPORT_FORMATS =
 	listOf(

--- a/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/projecthome/ExportSceneSelection.kt
+++ b/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/projecthome/ExportSceneSelection.kt
@@ -1,0 +1,48 @@
+package com.darkrockstudios.apps.hammer.common.projecthome
+
+import com.darkrockstudios.apps.hammer.common.data.ExportableScene
+
+/** Every selectable (leaf scene) id in [entries]. */
+internal fun allSceneIds(entries: List<ExportableScene>): Set<Int> =
+	entries.filterNot { it.isGroup }.map { it.id }.toSet()
+
+/**
+ * Scene ids of every descendant of [group]: the contiguous entries following it
+ * while their depth stays greater than the group's.
+ */
+internal fun descendantSceneIds(entries: List<ExportableScene>, group: ExportableScene): List<Int> {
+	val start = entries.indexOf(group) + 1
+	if (start <= 0) return emptyList()
+	return entries.asSequence()
+		.drop(start)
+		.takeWhile { it.depth > group.depth }
+		.filterNot { it.isGroup }
+		.map { it.id }
+		.toList()
+}
+
+internal fun isGroupFullySelected(
+	entries: List<ExportableScene>,
+	selected: Set<Int>,
+	group: ExportableScene,
+): Boolean {
+	val ids = descendantSceneIds(entries, group)
+	return ids.isNotEmpty() && selected.containsAll(ids)
+}
+
+internal fun toggleScene(selected: Set<Int>, id: Int): Set<Int> =
+	if (id in selected) selected - id else selected + id
+
+/**
+ * Group rows act as select-all/clear toggles for their subtree; a partially
+ * selected group toggles to fully selected. An empty group is inert.
+ */
+internal fun toggleGroup(
+	entries: List<ExportableScene>,
+	selected: Set<Int>,
+	group: ExportableScene,
+): Set<Int> {
+	val ids = descendantSceneIds(entries, group)
+	if (ids.isEmpty()) return selected
+	return if (selected.containsAll(ids)) selected - ids.toSet() else selected + ids
+}

--- a/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/projecthome/ExportSceneSelection.kt
+++ b/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/projecthome/ExportSceneSelection.kt
@@ -30,6 +30,12 @@ internal fun isGroupFullySelected(
 	return ids.isNotEmpty() && selected.containsAll(ids)
 }
 
+/** True when [selected] covers every leaf scene in [entries] and there is at least one. */
+internal fun isFullSelection(entries: List<ExportableScene>, selected: Set<Int>): Boolean {
+	val all = allSceneIds(entries)
+	return all.isNotEmpty() && selected.containsAll(all)
+}
+
 internal fun toggleScene(selected: Set<Int>, id: Int): Set<Int> =
 	if (id in selected) selected - id else selected + id
 

--- a/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/projecthome/ProjectStatsUi.kt
+++ b/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/projecthome/ProjectStatsUi.kt
@@ -130,7 +130,9 @@ fun ProjectStatsUi(
 
 	ExportOptionsDialog(
 		visible = state.showExportDialog,
-		initialOptions = state.exportOptions,
+		options = state.exportOptions,
+		exportableScenes = state.exportableScenes,
+		onOptionsChanged = component::updateExportOptions,
 		onCancel = component::cancelExportDialog,
 		onConfirm = component::confirmExportDialog,
 		working = state.isExporting,

--- a/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/projecthome/ProjectStatsUi.kt
+++ b/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/projecthome/ProjectStatsUi.kt
@@ -135,7 +135,11 @@ fun ProjectStatsUi(
 		onOptionsChanged = component::updateExportOptions,
 		onCancel = component::cancelExportDialog,
 		onConfirm = component::confirmExportDialog,
-		working = state.isExporting,
+		onDismissed = component::exportDialogDismissed,
+		// The platform save dialog does not block this window on desktop, so the
+		// options must freeze once the picker is up or the written file's extension
+		// and contents could disagree.
+		working = state.isExporting || state.showExportFilePicker,
 	)
 	ExportDirectoryPicker(state.showExportFilePicker, component, scope)
 }

--- a/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/storyeditor/scenelist/MoveSceneDialog.kt
+++ b/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/storyeditor/scenelist/MoveSceneDialog.kt
@@ -41,6 +41,8 @@ import com.darkrockstudios.apps.hammer.common.compose.FormDialog
 import com.darkrockstudios.apps.hammer.common.compose.FormField
 import com.darkrockstudios.apps.hammer.common.compose.Ui
 import com.darkrockstudios.apps.hammer.common.compose.designsystem.HdMonoLabel
+import com.darkrockstudios.apps.hammer.common.compose.designsystem.HdPickerList
+import com.darkrockstudios.apps.hammer.common.compose.designsystem.HdPickerRow
 import com.darkrockstudios.apps.hammer.common.compose.designsystem.HdSearchField
 import com.darkrockstudios.apps.hammer.common.compose.leftBorder
 import com.darkrockstudios.apps.hammer.common.compose.resources.get
@@ -221,39 +223,17 @@ private fun DestinationList(
 	selectedDestId: Int?,
 	onSelect: (Int) -> Unit,
 ) {
-	Column(
-		modifier = Modifier
-			.fillMaxWidth()
-			.border(
-				width = Dp.Hairline,
-				color = MaterialTheme.colorScheme.outlineVariant,
-				shape = RectangleShape
-			),
+	HdPickerList(
+		maxVisibleRows = MAX_VISIBLE_DESTINATIONS,
+		emptyText = if (destinations.isEmpty()) Res.string.scene_move_dialog_no_results.get() else null,
 	) {
-		if (destinations.isEmpty()) {
-			Text(
-				text = Res.string.scene_move_dialog_no_results.get(),
-				style = MaterialTheme.typography.bodyMedium,
-				color = MaterialTheme.colorScheme.onSurfaceVariant,
-				modifier = Modifier.padding(Ui.Padding.XL),
+		items(items = destinations, key = { it.value.id }) { node ->
+			DestinationRow(
+				node = node,
+				topLevelLabel = topLevelLabel,
+				isSelected = node.value.id == selectedDestId,
+				onSelect = onSelect,
 			)
-		} else {
-			// Cap derived from the text-driven row height so the visible row count
-			// holds steady across font scales.
-			val lineHeight = MaterialTheme.typography.bodyMedium.lineHeight
-			val rowHeight = with(LocalDensity.current) {
-				(if (lineHeight.isSpecified) lineHeight.toDp() else 20.dp) + (Ui.Padding.M * 2)
-			}
-			LazyColumn(modifier = Modifier.heightIn(max = rowHeight * MAX_VISIBLE_DESTINATIONS)) {
-				items(items = destinations, key = { it.value.id }) { node ->
-					DestinationRow(
-						node = node,
-						topLevelLabel = topLevelLabel,
-						isSelected = node.value.id == selectedDestId,
-						onSelect = onSelect,
-					)
-				}
-			}
 		}
 	}
 }
@@ -269,36 +249,15 @@ private fun DestinationRow(
 	val bg = if (isSelected) MaterialTheme.colorScheme.surfaceContainer else Color.Transparent
 	val accent = if (isSelected) MaterialTheme.colorScheme.primary else Color.Transparent
 
-	Row(
+	HdPickerRow(
+		label = if (isTopLevel) topLevelLabel else node.value.name,
+		depth = node.depth,
+		icon = if (isTopLevel) Icons.Outlined.Home else Icons.Filled.Folder,
 		modifier = Modifier
-			.fillMaxWidth()
 			.background(bg)
 			.leftBorder(2.dp, accent)
 			.clickable { onSelect(node.value.id) }
-			.testTag(moveDestinationTag(node.value.id))
-			.padding(
-				start = Ui.Padding.L + (Ui.Padding.XL * node.depth),
-				end = Ui.Padding.L,
-				top = Ui.Padding.M,
-				bottom = Ui.Padding.M,
-			),
-		verticalAlignment = Alignment.CenterVertically,
-		horizontalArrangement = Arrangement.spacedBy(Ui.Padding.M),
-	) {
-		Icon(
-			imageVector = if (isTopLevel) Icons.Outlined.Home else Icons.Filled.Folder,
-			contentDescription = null,
-			tint = MaterialTheme.colorScheme.onSurfaceVariant,
-			modifier = Modifier.size(16.dp),
-		)
-		Text(
-			text = if (isTopLevel) topLevelLabel else node.value.name,
-			style = MaterialTheme.typography.bodyMedium,
-			color = MaterialTheme.colorScheme.onSurface,
-			maxLines = 1,
-			overflow = TextOverflow.Ellipsis,
-			modifier = Modifier.weight(1f),
-		)
-		HdMonoLabel(text = node.children.size.toString())
-	}
+			.testTag(moveDestinationTag(node.value.id)),
+		trailing = { HdMonoLabel(text = node.children.size.toString()) },
+	)
 }

--- a/composeUi/src/desktopMain/kotlin/com/darkrockstudios/apps/hammer/common/preview/projecthome/ExportOptionsDialog.Preview.kt
+++ b/composeUi/src/desktopMain/kotlin/com/darkrockstudios/apps/hammer/common/preview/projecthome/ExportOptionsDialog.Preview.kt
@@ -1,0 +1,61 @@
+package com.darkrockstudios.apps.hammer.common.preview.projecthome
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import com.darkrockstudios.apps.hammer.common.compose.theme.AppTheme
+import com.darkrockstudios.apps.hammer.common.data.ExportOptions
+import com.darkrockstudios.apps.hammer.common.data.ExportableScene
+import com.darkrockstudios.apps.hammer.common.preview.KoinApplicationPreview
+import com.darkrockstudios.apps.hammer.common.preview.globalSettingsPreview
+import com.darkrockstudios.apps.hammer.common.projecthome.ExportOptionsDialogContent
+
+private val previewScenes = listOf(
+	ExportableScene(id = 1, name = "Prologue", isGroup = false, depth = 0),
+	ExportableScene(id = 2, name = "Chapter 1: The Door", isGroup = true, depth = 0),
+	ExportableScene(id = 3, name = "The Door Opens", isGroup = false, depth = 1),
+	ExportableScene(id = 4, name = "The Discovery", isGroup = false, depth = 1),
+	ExportableScene(id = 5, name = "Interludes", isGroup = true, depth = 1),
+	ExportableScene(id = 6, name = "A Quiet Moment", isGroup = false, depth = 2),
+	ExportableScene(id = 7, name = "Epilogue", isGroup = false, depth = 0),
+)
+
+@Composable
+private fun ExportOptionsPreviewFrame(options: ExportOptions) {
+	KoinApplicationPreview {
+		AppTheme(globalSettingsPreview, true) {
+			Box(
+				modifier = Modifier
+					.fillMaxSize()
+					.background(MaterialTheme.colorScheme.background),
+				contentAlignment = Alignment.Center,
+			) {
+				ExportOptionsDialogContent(
+					options = options,
+					exportableScenes = previewScenes,
+					onOptionsChanged = {},
+					onCancel = {},
+					onConfirm = {},
+					onShowHelp = {},
+				)
+			}
+		}
+	}
+}
+
+@Preview(widthDp = 600, heightDp = 480)
+@Composable
+fun ExportOptionsDialogPreview() {
+	ExportOptionsPreviewFrame(ExportOptions())
+}
+
+@Preview(widthDp = 600, heightDp = 760)
+@Composable
+fun ExportOptionsDialogLimitScenesPreview() {
+	ExportOptionsPreviewFrame(ExportOptions(sceneIds = setOf(3, 4, 6)))
+}

--- a/composeUi/src/desktopMain/kotlin/com/darkrockstudios/apps/hammer/common/preview/projecthome/ProjectStatsUi.Preview.kt
+++ b/composeUi/src/desktopMain/kotlin/com/darkrockstudios/apps/hammer/common/preview/projecthome/ProjectStatsUi.Preview.kt
@@ -113,6 +113,7 @@ private val component = object : ProjectHome {
 	override suspend fun exportProjectToFile(filePath: String, options: ExportOptions): HPath = fakeProjectDef().path
 	override fun beginProjectExport() {}
 	override fun cancelExportDialog() {}
+	override fun updateExportOptions(options: ExportOptions) {}
 	override fun confirmExportDialog(options: ExportOptions) {}
 	override fun endProjectExport() {}
 	override fun startProjectSync() {}

--- a/composeUi/src/desktopMain/kotlin/com/darkrockstudios/apps/hammer/common/preview/projecthome/ProjectStatsUi.Preview.kt
+++ b/composeUi/src/desktopMain/kotlin/com/darkrockstudios/apps/hammer/common/preview/projecthome/ProjectStatsUi.Preview.kt
@@ -116,6 +116,7 @@ private val component = object : ProjectHome {
 	override fun updateExportOptions(options: ExportOptions) {}
 	override fun confirmExportDialog(options: ExportOptions) {}
 	override fun endProjectExport() {}
+	override fun exportDialogDismissed() {}
 	override fun startProjectSync() {}
 	override fun showGlobalSearch() {}
 	override fun showGlobalSearchForTag(tag: String) {}

--- a/composeUi/src/desktopMain/kotlin/com/darkrockstudios/apps/hammer/common/projecthome/ExportDirectoryPicker.kt
+++ b/composeUi/src/desktopMain/kotlin/com/darkrockstudios/apps/hammer/common/projecthome/ExportDirectoryPicker.kt
@@ -2,8 +2,6 @@ package com.darkrockstudios.apps.hammer.common.projecthome
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.getValue
-import com.arkivanov.decompose.extensions.compose.subscribeAsState
 import com.darkrockstudios.apps.hammer.Res
 import com.darkrockstudios.apps.hammer.common.components.projecthome.ProjectHome
 import com.darkrockstudios.apps.hammer.common.components.projecthome.fileExtension
@@ -22,17 +20,18 @@ actual fun ExportDirectoryPicker(
 	scope: CoroutineScope,
 ) {
 	val defaultDispatcher = rememberDefaultDispatcher()
-	val state by component.state.subscribeAsState()
-	val format = state.exportOptions.format
 
 	LaunchedEffect(show) {
 		if (show) {
+			// Snapshot before the save dialog: it does not block this window, so the
+			// options must not be re-read after the suspend.
+			val options = component.state.value.exportOptions
+			val format = options.format
 			val suggested = component.getExportStoryFileName(format)
 			val extension = format.fileExtension
 			val baseName = suggested.removeSuffix(".$extension")
 			val file = FileKit.openFileSaver(suggestedName = baseName, defaultExtension = extension)
 			if (file != null) {
-				val options = state.exportOptions
 				scope.launch(defaultDispatcher) {
 					component.exportProjectToFile(file.absolutePath(), options)
 					component.showToast(Res.string.project_home_action_export_toast_success)

--- a/composeUi/src/desktopTest/kotlin/ExportOptionsDialogRotationTest.kt
+++ b/composeUi/src/desktopTest/kotlin/ExportOptionsDialogRotationTest.kt
@@ -1,0 +1,70 @@
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.key
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.test.assertIsOn
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
+import com.darkrockstudios.apps.hammer.common.data.ExportOptions
+import com.darkrockstudios.apps.hammer.common.data.ExportableScene
+import com.darkrockstudios.apps.hammer.common.preview.KoinApplicationPreview
+import com.darkrockstudios.apps.hammer.common.projecthome.ExportOptionsDialog
+import com.darkrockstudios.apps.hammer.common.projecthome.exportSceneRowTag
+import org.junit.Rule
+import org.junit.Test
+import kotlin.test.assertEquals
+
+/**
+ * Rotation cover in the spirit of #885: the dialog holds no option state of its own, so a
+ * configuration change (modeled by bumping the `key` while the option holder lives outside it,
+ * like a retained Decompose component) must not lose the in-dialog scene selection.
+ * `StateRestorationTester` would be the closer fit but is an unimplemented stub on desktop.
+ */
+class ExportOptionsDialogRotationTest : BaseTest() {
+
+	@get:Rule
+	val compose = createComposeRule()
+
+	private val entries = listOf(
+		ExportableScene(id = 1, name = "Scene 1", isGroup = false, depth = 0),
+		ExportableScene(id = 2, name = "Group 2", isGroup = true, depth = 0),
+		ExportableScene(id = 3, name = "Scene 3", isGroup = false, depth = 1),
+	)
+
+	@Test
+	fun `An in-dialog scene selection survives the composition being recreated`() {
+		// Stands in for ProjectHome.State.exportOptions in the retained component.
+		var options by mutableStateOf(ExportOptions(sceneIds = emptySet()))
+		val epoch = mutableStateOf(0)
+		var buildCount = 0
+
+		compose.setContent {
+			// Koin stays outside the key: its teardown would otherwise race the rebuilt subtree.
+			KoinApplicationPreview {
+				key(epoch.value) {
+					remember { buildCount++ }
+					ExportOptionsDialog(
+						visible = true,
+						options = options,
+						exportableScenes = entries,
+						onOptionsChanged = { options = it },
+						onCancel = {},
+						onConfirm = {},
+					)
+				}
+			}
+		}
+
+		compose.onNodeWithTag(exportSceneRowTag(3)).performClick()
+		compose.waitForIdle()
+		assertEquals(setOf(3), options.sceneIds)
+
+		epoch.value++
+		compose.waitForIdle()
+
+		assertEquals(2, buildCount, "The subtree should have been thrown away and built again")
+		compose.onNodeWithTag(exportSceneRowTag(3)).assertIsOn()
+	}
+}

--- a/composeUi/src/desktopTest/kotlin/ExportOptionsDialogTest.kt
+++ b/composeUi/src/desktopTest/kotlin/ExportOptionsDialogTest.kt
@@ -1,0 +1,96 @@
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import com.darkrockstudios.apps.hammer.common.data.ExportOptions
+import com.darkrockstudios.apps.hammer.common.data.ExportableScene
+import com.darkrockstudios.apps.hammer.common.preview.KoinApplicationPreview
+import com.darkrockstudios.apps.hammer.common.projecthome.ExportOptionsDialogContent
+import org.junit.Rule
+import org.junit.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class ExportOptionsDialogTest : BaseTest() {
+
+	@get:Rule
+	val compose = createComposeRule()
+
+	private val entries = listOf(
+		ExportableScene(id = 1, name = "Scene 1", isGroup = false, depth = 0),
+		ExportableScene(id = 2, name = "Scene 2", isGroup = false, depth = 0),
+	)
+
+	@Test
+	fun `Confirming with every scene selected exports without a limit`() {
+		var options by mutableStateOf(ExportOptions(sceneIds = setOf(1, 2)))
+		var confirmed: ExportOptions? = null
+
+		compose.setContent {
+			KoinApplicationPreview {
+				ExportOptionsDialogContent(
+					options = options,
+					exportableScenes = entries,
+					onOptionsChanged = { options = it },
+					onCancel = {},
+					onConfirm = { confirmed = it },
+					onShowHelp = {},
+				)
+			}
+		}
+
+		compose.onNodeWithText("Export").performClick()
+		compose.waitForIdle()
+
+		assertNull(
+			confirmed?.sceneIds,
+			"A full selection must export the entire story, keeping empty chapter groups",
+		)
+	}
+
+	@Test
+	fun `Confirming a partial selection keeps the scene limit`() {
+		var options by mutableStateOf(ExportOptions(sceneIds = setOf(2)))
+		var confirmed: ExportOptions? = null
+
+		compose.setContent {
+			KoinApplicationPreview {
+				ExportOptionsDialogContent(
+					options = options,
+					exportableScenes = entries,
+					onOptionsChanged = { options = it },
+					onCancel = {},
+					onConfirm = { confirmed = it },
+					onShowHelp = {},
+				)
+			}
+		}
+
+		compose.onNodeWithText("Export").performClick()
+		compose.waitForIdle()
+
+		assertEquals(setOf(2), confirmed?.sceneIds)
+	}
+
+	@Test
+	fun `A project without leaf scenes offers no scene limit`() {
+		compose.setContent {
+			KoinApplicationPreview {
+				ExportOptionsDialogContent(
+					options = ExportOptions(),
+					exportableScenes = listOf(
+						ExportableScene(id = 9, name = "Empty Group", isGroup = true, depth = 0),
+					),
+					onOptionsChanged = {},
+					onCancel = {},
+					onConfirm = {},
+					onShowHelp = {},
+				)
+			}
+		}
+
+		compose.onNodeWithText("Limit to specific scenes").assertDoesNotExist()
+	}
+}

--- a/composeUi/src/desktopTest/kotlin/ExportSceneSelectionTest.kt
+++ b/composeUi/src/desktopTest/kotlin/ExportSceneSelectionTest.kt
@@ -1,0 +1,82 @@
+import com.darkrockstudios.apps.hammer.common.data.ExportableScene
+import com.darkrockstudios.apps.hammer.common.projecthome.allSceneIds
+import com.darkrockstudios.apps.hammer.common.projecthome.descendantSceneIds
+import com.darkrockstudios.apps.hammer.common.projecthome.isGroupFullySelected
+import com.darkrockstudios.apps.hammer.common.projecthome.toggleGroup
+import com.darkrockstudios.apps.hammer.common.projecthome.toggleScene
+import org.junit.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class ExportSceneSelectionTest {
+
+	// Scene 1, Group 2 [Scene 3, Scene 4, Group 5 [Scene 6]], Scene 7, Group 8 (empty)
+	private val entries = listOf(
+		ExportableScene(id = 1, name = "Scene 1", isGroup = false, depth = 0),
+		ExportableScene(id = 2, name = "Group 2", isGroup = true, depth = 0),
+		ExportableScene(id = 3, name = "Scene 3", isGroup = false, depth = 1),
+		ExportableScene(id = 4, name = "Scene 4", isGroup = false, depth = 1),
+		ExportableScene(id = 5, name = "Group 5", isGroup = true, depth = 1),
+		ExportableScene(id = 6, name = "Scene 6", isGroup = false, depth = 2),
+		ExportableScene(id = 7, name = "Scene 7", isGroup = false, depth = 0),
+		ExportableScene(id = 8, name = "Group 8", isGroup = true, depth = 0),
+	)
+
+	private val topGroup = entries[1]
+	private val nestedGroup = entries[4]
+	private val emptyGroup = entries[7]
+
+	@Test
+	fun `allSceneIds contains only leaf scenes`() {
+		assertEquals(setOf(1, 3, 4, 6, 7), allSceneIds(entries))
+	}
+
+	@Test
+	fun `descendantSceneIds spans the whole subtree including nested groups`() {
+		assertEquals(listOf(3, 4, 6), descendantSceneIds(entries, topGroup))
+		assertEquals(listOf(6), descendantSceneIds(entries, nestedGroup))
+		assertEquals(emptyList(), descendantSceneIds(entries, emptyGroup))
+	}
+
+	@Test
+	fun `descendantSceneIds stops at the next sibling of the same depth`() {
+		assertFalse(7 in descendantSceneIds(entries, topGroup))
+	}
+
+	@Test
+	fun `toggleScene adds and removes a single id`() {
+		val selected = toggleScene(emptySet(), 3)
+		assertEquals(setOf(3), selected)
+		assertEquals(emptySet(), toggleScene(selected, 3))
+	}
+
+	@Test
+	fun `toggleGroup selects every descendant scene`() {
+		assertEquals(setOf(3, 4, 6), toggleGroup(entries, emptySet(), topGroup))
+	}
+
+	@Test
+	fun `toggleGroup on a fully selected group clears its descendants only`() {
+		val selected = setOf(1, 3, 4, 6, 7)
+		assertEquals(setOf(1, 7), toggleGroup(entries, selected, topGroup))
+	}
+
+	@Test
+	fun `toggleGroup on a partially selected group completes the selection`() {
+		assertEquals(setOf(3, 4, 6), toggleGroup(entries, setOf(3), topGroup))
+	}
+
+	@Test
+	fun `toggleGroup on an empty group changes nothing`() {
+		val selected = setOf(1)
+		assertEquals(selected, toggleGroup(entries, selected, emptyGroup))
+	}
+
+	@Test
+	fun `isGroupFullySelected requires every descendant and is never true for empty groups`() {
+		assertTrue(isGroupFullySelected(entries, setOf(3, 4, 6), topGroup))
+		assertFalse(isGroupFullySelected(entries, setOf(3, 4), topGroup))
+		assertFalse(isGroupFullySelected(entries, setOf(1, 3, 4, 6, 7), emptyGroup))
+	}
+}

--- a/composeUi/src/desktopTest/kotlin/ExportSceneSelectionTest.kt
+++ b/composeUi/src/desktopTest/kotlin/ExportSceneSelectionTest.kt
@@ -1,6 +1,7 @@
 import com.darkrockstudios.apps.hammer.common.data.ExportableScene
 import com.darkrockstudios.apps.hammer.common.projecthome.allSceneIds
 import com.darkrockstudios.apps.hammer.common.projecthome.descendantSceneIds
+import com.darkrockstudios.apps.hammer.common.projecthome.isFullSelection
 import com.darkrockstudios.apps.hammer.common.projecthome.isGroupFullySelected
 import com.darkrockstudios.apps.hammer.common.projecthome.toggleGroup
 import com.darkrockstudios.apps.hammer.common.projecthome.toggleScene
@@ -42,6 +43,14 @@ class ExportSceneSelectionTest {
 	@Test
 	fun `descendantSceneIds stops at the next sibling of the same depth`() {
 		assertFalse(7 in descendantSceneIds(entries, topGroup))
+	}
+
+	@Test
+	fun `isFullSelection requires every leaf scene and a non-empty tree`() {
+		assertTrue(isFullSelection(entries, setOf(1, 3, 4, 6, 7)))
+		assertTrue(isFullSelection(entries, setOf(1, 3, 4, 6, 7, 999)))
+		assertFalse(isFullSelection(entries, setOf(1, 3, 4, 6)))
+		assertFalse(isFullSelection(emptyList(), emptySet()))
 	}
 
 	@Test

--- a/composeUi/src/iosMain/kotlin/com/darkrockstudios/apps/hammer/common/projecthome/ExportDirectoryPicker.kt
+++ b/composeUi/src/iosMain/kotlin/com/darkrockstudios/apps/hammer/common/projecthome/ExportDirectoryPicker.kt
@@ -3,10 +3,13 @@ package com.darkrockstudios.apps.hammer.common.projecthome
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
-import com.arkivanov.decompose.extensions.compose.subscribeAsState
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import com.darkrockstudios.apps.hammer.Res
 import com.darkrockstudios.apps.hammer.common.components.projecthome.ProjectHome
 import com.darkrockstudios.apps.hammer.common.compose.rememberDefaultDispatcher
+import com.darkrockstudios.apps.hammer.common.data.ExportOptions
 import com.darkrockstudios.apps.hammer.project_home_action_export_toast_success
 import io.github.vinceglb.filekit.dialogs.compose.rememberDirectoryPickerLauncher
 import io.github.vinceglb.filekit.path
@@ -22,11 +25,13 @@ actual fun ExportDirectoryPicker(
 	scope: CoroutineScope,
 ) {
 	val defaultDispatcher = rememberDefaultDispatcher()
-	val state by component.state.subscribeAsState()
+	// Snapshot of the confirmed options taken when the picker launches; the picker
+	// does not block the app, so options must not be re-read afterwards.
+	var confirmedOptions by remember { mutableStateOf<ExportOptions?>(null) }
 
 	val directoryPickerLauncher = rememberDirectoryPickerLauncher { directory ->
-		if (directory != null) {
-			val options = state.exportOptions
+		val options = confirmedOptions
+		if (directory != null && options != null) {
 			scope.launch(defaultDispatcher) {
 				// FileKit's absolutePath() returns nsUrl.absoluteString (with "file://" scheme), which okio's
 				// posix sink can't open — use .path for the bare filesystem path. UIDocumentPicker URLs are
@@ -46,6 +51,7 @@ actual fun ExportDirectoryPicker(
 
 	LaunchedEffect(show) {
 		if (show) {
+			confirmedOptions = component.state.value.exportOptions
 			directoryPickerLauncher.launch()
 		}
 	}


### PR DESCRIPTION
## What

Adds "Limit to specific scenes" to the client Export dialog, mirroring the web scene-limited shares feature: pick a subset of scenes (e.g. one new chapter for beta readers) and only those are exported, in all five formats.

## How

- `ExportOptions.sceneIds: Set<Int>?` — null exports the entire story, an empty or fully stale set fails closed (title-only document, never widens to a full export), unknown ids are silently ignored. Same contract as the web `sceneFilter`.
- Filtering happens at the single chapter-building point in `ExportStoryUseCase`, so chapters with no selected scenes drop out and the index-based numbering in every renderer renumbers automatically. Renderers untouched.
- The dialog shows a depth-indented checkbox tree (flattened preorder, like the web picker): group rows toggle their whole subtree, plus a master Select all/Clear all and an "N of M selected" counter. Export is disabled while the limit is on with nothing selected.
- **Rotation fix**: the export dialog is now fully controlled — all option state (format, chapters toggle, scene selection) lives in `ProjectHome.State` inside the retained component instead of dialog-local `remember`s. This also fixes the pre-existing #885-class reset of the format/chapters controls on configuration change.

## Testing

- Use case: subset-within-a-group golden, dropped-chapter renumbering, filter with `treatTopLevelAsChapters=false`, stale-id tolerance, empty-set fail-closed, filtered EPUB smoke.
- Component: tree flattening (order/depth), `updateExportOptions` persistence, stale-limit reset on dialog open, filter round-trip to the use case.
- ComposeUi: pure selection-logic tests, and a rotation test modeling a configuration change with a `key()` bump (StateRestorationTester is a desktop stub).
- Both dialog states ship with rendered `@Preview`s.