### PR TITLE
Fix renaming a project onto a deleted project's name (#862)

### DIFF
--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/sync/accountsync/ClientAccountSynchronizer.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/sync/accountsync/ClientAccountSynchronizer.kt
@@ -85,11 +85,13 @@ class ClientAccountSynchronizer(
 
 				yield()
 
-				syncRenamedProjects(clientSyncData, serverSyncData, serverKnownIds, onLog, onUnauthorized)
+				// Deletions go first: a project name is unique per account on the server, so a
+				// rename into a name still held by a project queued for deletion is rejected.
+				syncDeletedProjects(clientSyncData, serverSyncData, onLog, onUnauthorized)
 
 				yield()
 
-				syncDeletedProjects(clientSyncData, serverSyncData, onLog, onUnauthorized)
+				syncRenamedProjects(clientSyncData, serverSyncData, serverKnownIds, onLog, onUnauthorized)
 
 				yield()
 
@@ -289,8 +291,9 @@ class ClientAccountSynchronizer(
 		clientSyncData.projectsToRename.forEach { (projectId, newName) ->
 			// The server can't rename an id it never issued, and would fail this every session
 			// forever. Recreation covers the rename anyway: it creates under the local name,
-			// which a local rename has already updated.
-			if (projectId !in serverKnownIds) {
+			// which a local rename has already updated. A tombstoned id is just as unrenamable,
+			// and its local project has already been deleted by syncDeletedProjects.
+			if (projectId !in serverKnownIds || projectId in serverSyncData.deletedProjects) {
 				dropQueuedRename(projectId)
 				return@forEach
 			}

--- a/common/src/desktopTest/kotlin/synchronizer/ClientAccountSynchronizerTest.kt
+++ b/common/src/desktopTest/kotlin/synchronizer/ClientAccountSynchronizerTest.kt
@@ -630,6 +630,61 @@ class ClientAccountSynchronizerTest {
 	}
 
 	@Test
+	fun `syncProjects frees a deleted project's name before renaming another project into it`() = runTest {
+		val deletedId = ProjectId.randomUUID()
+		val keptId = ProjectId.randomUUID()
+		val keptDef = projectDef("FooBar")
+
+		writeSyncData(
+			emptySyncData().copy(
+				projectsToDelete = setOf(deletedId),
+				projectsToRename = setOf(RenamedProject(keptId, "FooBar")),
+			)
+		)
+		coEvery { serverProjectsApi.beginProjectsSync() } returns Result.success(
+			emptyServerResponse().copy(
+				projects = setOf(
+					ApiProjectDefinition("FooBar", deletedId),
+					ApiProjectDefinition("FooBar V2", keptId),
+				)
+			)
+		)
+		coEvery { serverProjectsApi.deleteProject(deletedId, "sync-1") } returns Result.success("ok")
+		coEvery { serverProjectsApi.renameProject(keptId, "sync-1", "FooBar") } returns Result.success("ok")
+		every { projectsRepository.getProjects(any()) } returns listOf(keptDef)
+		every { projectsRepository.getProjectId(keptDef) } returns keptId
+
+		val result = createSynchronizer().syncProjects(onLog = {}, onUnauthorized = {})
+
+		assertTrue(result)
+		// A project name is unique per account on the server, so renaming first collides with
+		// the project this same sync is about to delete.
+		coVerifyOrder {
+			serverProjectsApi.deleteProject(deletedId, "sync-1")
+			serverProjectsApi.renameProject(keptId, "sync-1", "FooBar")
+		}
+		assertTrue(readSyncData().projectsToRename.isEmpty())
+	}
+
+	@Test
+	fun `syncProjects drops a rename queued against a project the server has deleted`() = runTest {
+		val id = ProjectId.randomUUID()
+		val def = projectDef("GoneNovel")
+		writeSyncData(emptySyncData().copy(projectsToRename = setOf(RenamedProject(id, "NewName"))))
+		coEvery { serverProjectsApi.beginProjectsSync() } returns
+			Result.success(emptyServerResponse().copy(deletedProjects = setOf(id)))
+		every { projectsRepository.findProject(id) } returns def
+		every { projectsRepository.getProjects(any()) } returns emptyList()
+
+		val result = createSynchronizer().syncProjects(onLog = {}, onUnauthorized = {})
+
+		assertTrue(result)
+		// The project is gone on both sides; the rename could only 404 and requeue forever.
+		coVerify(exactly = 0) { serverProjectsApi.renameProject(any(), any(), any()) }
+		assertTrue(readSyncData().projectsToRename.isEmpty())
+	}
+
+	@Test
 	fun `syncProjects does not recreate a project deleted locally that the server still lists`() = runTest {
 		val id = ProjectId.randomUUID()
 		val serverProject = ApiProjectDefinition(name = "DeadNovel", uuid = id)

--- a/docs/SYNCING-PROTOCOL.md
+++ b/docs/SYNCING-PROTOCOL.md
@@ -23,6 +23,13 @@ parity with each other.
 Additionally, it will find or create a `projectId` for the client's local projects. These are the
 key to being able to sync a local project with the server.
 
+### Phase ordering
+
+The phases run **delete, then rename, then create**, and the order is load-bearing. A project name is
+unique per account server-side, so a rename or a creation that takes the name of a project the same
+session is about to delete is rejected until the delete has freed it. Renaming a project onto a name
+another live project still holds answers `409 Conflict`.
+
 ### Stale project IDs
 
 A local project caches the `projectId` it was assigned, so a client that last synced against a
@@ -40,7 +47,9 @@ rather than retried:
 
 - A **rename** queued against an ID the server does not know is dropped without being sent. The
   server cannot rename an ID it never issued, so retrying only logs an error every session;
-  recreation already covers it, because the project is created under its current local name.
+  recreation already covers it, because the project is created under its current local name. A
+  rename queued against a **tombstoned** ID is dropped for the same reason: the delete phase has
+  already removed the project locally, and the server has nothing left to rename.
 - A **creation** queued for a name with no local project is dropped. The project was deleted before
   it ever reached the server, so creating it would push an empty project out to every device.
 
@@ -74,21 +83,6 @@ sequenceDiagram
 			Server -x Client: 400 Bad Request (sync ends here)
 		end
 	end
-	rect rgb(11, 0, 74)
-		loop Rename Projects
-			Client ->> Server: POST /api/projects/{userId}/rename
-			deactivate Client
-			activate Server
-			Note right of Client: bearer token <br/> syncId <br/> projectId <br/> projectName
-			Server -->> Client: 200 OK (Rename successful)
-			deactivate Server
-			activate Client
-			alt Rename fails
-				Server -->> Client: 4XX Bad Request
-			end
-		end
-	end
-
 	rect rgb(74, 0, 9)
 		loop Delete Projects
 			Client ->> Server: POST /api/projects/{userId}/delete
@@ -99,6 +93,21 @@ sequenceDiagram
 			deactivate Server
 			activate Client
 			alt Delete fails
+				Server -->> Client: 4XX Bad Request
+			end
+		end
+	end
+
+	rect rgb(11, 0, 74)
+		loop Rename Projects
+			Client ->> Server: POST /api/projects/{userId}/rename
+			deactivate Client
+			activate Server
+			Note right of Client: bearer token <br/> syncId <br/> projectId <br/> projectName
+			Server -->> Client: 200 OK (Rename successful)
+			deactivate Server
+			activate Client
+			alt Rename fails
 				Server -->> Client: 4XX Bad Request
 			end
 		end

--- a/server/src/main/kotlin/com/darkrockstudios/apps/hammer/database/ProjectDao.kt
+++ b/server/src/main/kotlin/com/darkrockstudios/apps/hammer/database/ProjectDao.kt
@@ -7,7 +7,15 @@ import com.darkrockstudios.apps.hammer.project.ProjectDefinition
 import com.darkrockstudios.apps.hammer.utilities.injectIoDispatcher
 import kotlinx.coroutines.withContext
 import org.koin.core.component.KoinComponent
+import java.sql.SQLException
 import kotlin.time.Instant
+
+private const val SQLSTATE_UNIQUE_VIOLATION = "23505"
+
+// The cause chain is walked because the driver's violation can reach us wrapped by the pool.
+private fun SQLException.isUniqueViolation(): Boolean =
+	generateSequence(this as Throwable) { it.cause }
+		.any { it is SQLException && it.sqlState == SQLSTATE_UNIQUE_VIOLATION }
 
 class ProjectDao(
 	database: Database,
@@ -64,12 +72,18 @@ class ProjectDao(
 			queries.hasProjectById(userId, projectId.id).executeAsOne()
 		}
 
+	/** False when the account already has a project under [newName]; `project(name, user_id)` is unique. */
 	suspend fun updateProjectName(
 		userId: Long,
 		projectUuid: ProjectId,
 		newName: String
-	) = withContext(ioDispatcher) {
-		queries.updateProjectName(userId = userId, uuid = projectUuid.id, name = newName)
+	): Boolean = withContext(ioDispatcher) {
+		return@withContext try {
+			queries.updateProjectName(userId = userId, uuid = projectUuid.id, name = newName)
+			true
+		} catch (e: SQLException) {
+			if (e.isUniqueViolation()) false else throw e
+		}
 	}
 
 	suspend fun updateSyncData(

--- a/server/src/main/kotlin/com/darkrockstudios/apps/hammer/project/ProjectEntityDatabaseDatasource.kt
+++ b/server/src/main/kotlin/com/darkrockstudios/apps/hammer/project/ProjectEntityDatabaseDatasource.kt
@@ -329,15 +329,11 @@ class ProjectEntityDatabaseDatasource(
 		userId: Long,
 		projectId: ProjectId,
 		newProjectName: String
-	): Boolean {
-		projectDao.updateProjectName(
-			userId = userId,
-			projectUuid = projectId,
-			newName = newProjectName,
-		)
-
-		return true
-	}
+	): Boolean = projectDao.updateProjectName(
+		userId = userId,
+		projectUuid = projectId,
+		newName = newProjectName,
+	)
 
 	override suspend fun getProject(userId: Long, projectId: ProjectId): ProjectDefinition? {
 		val projectData = projectDao.getProjectData(userId, projectId)

--- a/server/src/main/kotlin/com/darkrockstudios/apps/hammer/project/ProjectEntityDatasource.kt
+++ b/server/src/main/kotlin/com/darkrockstudios/apps/hammer/project/ProjectEntityDatasource.kt
@@ -68,6 +68,7 @@ interface ProjectEntityDatasource {
 		type: ApiProjectEntity.Type
 	): List<EntityDefinition>
 
+	/** False when the account already holds another project under [newProjectName]. */
 	suspend fun renameProject(userId: Long, projectId: ProjectId, newProjectName: String): Boolean
 
 	/** All of a project's entity ids paired with their cached hashes, in one query, sorted by id. */

--- a/server/src/main/kotlin/com/darkrockstudios/apps/hammer/project/ProjectRepositoryExceptions.kt
+++ b/server/src/main/kotlin/com/darkrockstudios/apps/hammer/project/ProjectRepositoryExceptions.kt
@@ -29,3 +29,6 @@ class ProjectNotFound(val projectId: ProjectId) :
 
 class InvalidProjectName(val name: String) :
 	Exception("Invalid project name: $name")
+
+class ProjectNameTaken(val name: String) :
+	Exception("This account already has a project named: $name")

--- a/server/src/main/kotlin/com/darkrockstudios/apps/hammer/projects/ProjectsRepository.kt
+++ b/server/src/main/kotlin/com/darkrockstudios/apps/hammer/projects/ProjectsRepository.kt
@@ -227,11 +227,12 @@ class ProjectsRepository(
 			return SResult.failure(InvalidProjectName(newProjectName ?: "null"))
 
 		val existingProject = projectEntityDatasource.checkProjectExists(userId, projectId)
-		return if (existingProject) {
-			projectEntityDatasource.renameProject(userId, projectId, newProjectName)
+		if (existingProject.not()) return SResult.failure(ProjectNotFound(projectId))
+
+		return if (projectEntityDatasource.renameProject(userId, projectId, newProjectName)) {
 			SResult.success()
 		} else {
-			SResult.failure(ProjectNotFound(projectId))
+			SResult.failure(ProjectNameTaken(newProjectName))
 		}
 	}
 

--- a/server/src/main/kotlin/com/darkrockstudios/apps/hammer/projects/ProjectsRoutes.kt
+++ b/server/src/main/kotlin/com/darkrockstudios/apps/hammer/projects/ProjectsRoutes.kt
@@ -14,6 +14,7 @@ import com.darkrockstudios.apps.hammer.project.InvalidProjectName
 import com.darkrockstudios.apps.hammer.project.InvalidSyncIdException
 import com.darkrockstudios.apps.hammer.monitoring.ActivityType
 import com.darkrockstudios.apps.hammer.monitoring.UserActivityCollector
+import com.darkrockstudios.apps.hammer.project.ProjectNameTaken
 import com.darkrockstudios.apps.hammer.project.ProjectNotFound
 import com.darkrockstudios.apps.hammer.storyideas.ServerIdeasRepository
 import com.darkrockstudios.apps.hammer.utilities.*
@@ -30,6 +31,8 @@ import org.koin.ktor.ext.get
 
 private const val ERROR_GENERIC = "Error"
 private const val ERR_KEY_INVALID_PROJECT_NAME = "api_project_rename_error_invalidname"
+private const val ERR_KEY_PROJECT_NAME_TAKEN = "api_project_rename_error_nametaken"
+private const val ERR_KEY_PROJECT_NOT_FOUND = "api_project_getproject_error_notfound"
 
 /** Reads syncId from header, responding 400 "Missing Header" with a localized message if absent. */
 private suspend fun ApplicationCall.requireSyncIdFromHeader(): String? {
@@ -228,12 +231,26 @@ private suspend fun RoutingContext.respondRenameFailure(exception: Throwable?) {
 	when (exception) {
 		is InvalidProjectName -> call.respond(
 			status = HttpStatusCode.NotAcceptable,
-			HttpResponseError(error = ERROR_GENERIC, displayMessage = call.t(R(ERR_KEY_INVALID_PROJECT_NAME))),
+			HttpResponseError(
+				error = ERROR_GENERIC,
+				displayMessage = call.tWithEnglishFallback(ERR_KEY_INVALID_PROJECT_NAME),
+			),
 		)
 
 		is ProjectNotFound -> call.respond(
 			status = HttpStatusCode.NotFound,
-			HttpResponseError(error = ERROR_GENERIC, displayMessage = call.t(R(ERR_KEY_INVALID_PROJECT_NAME))),
+			HttpResponseError(
+				error = ERROR_GENERIC,
+				displayMessage = call.tWithEnglishFallback(ERR_KEY_PROJECT_NOT_FOUND),
+			),
+		)
+
+		is ProjectNameTaken -> call.respond(
+			status = HttpStatusCode.Conflict,
+			HttpResponseError(
+				error = ERROR_GENERIC,
+				displayMessage = call.tWithEnglishFallback(ERR_KEY_PROJECT_NAME_TAKEN),
+			),
 		)
 
 		else -> call.respondSyncFailure(exception)

--- a/server/src/main/kotlin/com/darkrockstudios/apps/hammer/utilities/RouteHelpers.kt
+++ b/server/src/main/kotlin/com/darkrockstudios/apps/hammer/utilities/RouteHelpers.kt
@@ -11,6 +11,9 @@ import io.ktor.http.*
 import io.ktor.server.application.*
 import io.ktor.server.response.*
 import org.koin.ktor.ext.get
+import java.util.Locale
+import java.util.MissingResourceException
+import java.util.ResourceBundle
 
 internal const val ERROR_MISSING_PARAMETER = "Missing Parameter"
 internal const val ERROR_MISSING_HEADER = "Missing Header"
@@ -22,6 +25,22 @@ internal const val ERR_KEY_SYNC_ID_MISSING = "api_project_sync_error_syncidmissi
 internal const val ERR_KEY_ENTITY_ID_MISSING = "api_project_error_entityidmissing"
 internal const val ERR_KEY_INVALID_SYNC_ID = "api_project_sync_end_invalidid"
 internal const val ERR_KEY_UNKNOWN = "api_error_unknown"
+
+/**
+ * Localized API message with an English fallback.
+ *
+ * Thar be dragons: the `i18n/Messages_*` bundles have no base `Messages.properties`, so a
+ * translation that lacks the key has no parent to resolve through and [t] throws
+ * MissingResourceException — turning the error response into a 500 for every locale but
+ * English. Clients send `Accept-Language` on every API call, so any key Crowdin has not
+ * translated yet (or has dropped) needs this.
+ */
+fun ApplicationCall.tWithEnglishFallback(messageKey: String): String =
+	try {
+		t(R(messageKey))
+	} catch (_: MissingResourceException) {
+		ResourceBundle.getBundle("i18n.Messages", Locale.ENGLISH).getString(messageKey)
+	}
 
 /** Responds 400 BadRequest with the given error name and a plain-text display message. */
 suspend fun ApplicationCall.respondBadRequest(error: String, displayMessage: String) {

--- a/server/src/main/resources/i18n/Messages_en.properties
+++ b/server/src/main/resources/i18n/Messages_en.properties
@@ -197,6 +197,7 @@ api_project_saveentity_error_typeconflict=Entity type mismatch. Server has an en
 api_project_error_entityidmissing=Entity ID missing
 api_project_error_entitytypemissing=Entity Type missing
 api_project_rename_error_invalidname=Invalid project name
+api_project_rename_error_nametaken=This account already has a project with that name
 api_project_writingactivity_error_deviceidmissing=Device ID missing
 # Login Page
 login_title=Author Login

--- a/server/src/test/kotlin/com/darkrockstudios/apps/hammer/e2e/ProjectsTest.kt
+++ b/server/src/test/kotlin/com/darkrockstudios/apps/hammer/e2e/ProjectsTest.kt
@@ -365,4 +365,92 @@ class ProjectsTest : EndToEndTest() {
 			assertEquals(HttpStatusCode.OK, endSyncResponse2.status)
 		}
 	}
+
+	@Test
+	fun `Project Sync - Rename onto a name another project still holds is a conflict`(): Unit = runBlocking {
+		val database = database()
+		createTestServer(SERVER_EMPTY_NO_WHITELIST, fileSystem, database)
+		TestDataSet1.createFullDataset(database, encryptor())
+		val userId = 1L
+		val authToken = createAuthToken(userId, "test-install-id", database = database, tokenHasher = tokenHasher())
+		doStartServer()
+
+		client().apply {
+			val beginSyncResponse = get(api("projects/$userId/begin_sync")) {
+				headers {
+					append(HAMMER_PROTOCOL_HEADER, HAMMER_PROTOCOL_VERSION.toString())
+					append("Authorization", "Bearer ${authToken.auth}")
+				}
+			}
+			assertEquals(HttpStatusCode.OK, beginSyncResponse.status)
+			val syncId = beginSyncResponse.body<BeginProjectsSyncResponse>().syncId
+
+			val occupiedName = "Occupied Project"
+			val createResponse = get(api("projects/$userId/create")) {
+				headers {
+					append(HAMMER_PROTOCOL_HEADER, HAMMER_PROTOCOL_VERSION.toString())
+					append("Authorization", "Bearer ${authToken.auth}")
+					append(HEADER_SYNC_ID, syncId)
+				}
+				parameter("projectName", occupiedName)
+			}
+			assertEquals(HttpStatusCode.OK, createResponse.status)
+			val occupyingProjectId = createResponse.body<CreateProjectResponse>().projectId
+
+			val renameResponse = get(api("projects/$userId/rename")) {
+				headers {
+					append(HAMMER_PROTOCOL_HEADER, HAMMER_PROTOCOL_VERSION.toString())
+					append("Authorization", "Bearer ${authToken.auth}")
+					append(HEADER_SYNC_ID, syncId)
+				}
+				parameter("projectId", TestDataSet1.project1.uuid)
+				parameter("projectName", occupiedName)
+			}
+			assertEquals(HttpStatusCode.Conflict, renameResponse.status)
+
+			// Every client sends its device locale, and the locale bundles have no English parent.
+			val translatedRenameResponse = get(api("projects/$userId/rename")) {
+				headers {
+					append(HAMMER_PROTOCOL_HEADER, HAMMER_PROTOCOL_VERSION.toString())
+					append("Authorization", "Bearer ${authToken.auth}")
+					append(HEADER_SYNC_ID, syncId)
+					append(HttpHeaders.AcceptLanguage, "de")
+				}
+				parameter("projectId", TestDataSet1.project1.uuid)
+				parameter("projectName", occupiedName)
+			}
+			assertEquals(HttpStatusCode.Conflict, translatedRenameResponse.status)
+
+			// Freeing the name first is what the client's delete-before-rename ordering guarantees.
+			val deleteResponse = get(api("projects/$userId/delete")) {
+				headers {
+					append(HAMMER_PROTOCOL_HEADER, HAMMER_PROTOCOL_VERSION.toString())
+					append("Authorization", "Bearer ${authToken.auth}")
+					append(HEADER_SYNC_ID, syncId)
+				}
+				parameter("projectId", occupyingProjectId.id)
+			}
+			assertEquals(HttpStatusCode.OK, deleteResponse.status)
+
+			val retryRenameResponse = get(api("projects/$userId/rename")) {
+				headers {
+					append(HAMMER_PROTOCOL_HEADER, HAMMER_PROTOCOL_VERSION.toString())
+					append("Authorization", "Bearer ${authToken.auth}")
+					append(HEADER_SYNC_ID, syncId)
+				}
+				parameter("projectId", TestDataSet1.project1.uuid)
+				parameter("projectName", occupiedName)
+			}
+			assertEquals(HttpStatusCode.OK, retryRenameResponse.status)
+
+			val endSyncResponse = get(api("projects/$userId/end_sync")) {
+				headers {
+					append(HAMMER_PROTOCOL_HEADER, HAMMER_PROTOCOL_VERSION.toString())
+					append("Authorization", "Bearer ${authToken.auth}")
+					append(HEADER_SYNC_ID, syncId)
+				}
+			}
+			assertEquals(HttpStatusCode.OK, endSyncResponse.status)
+		}
+	}
 }

--- a/server/src/test/kotlin/com/darkrockstudios/apps/hammer/projects/repository/ProjectsRepositoryRenameEntityTest.kt
+++ b/server/src/test/kotlin/com/darkrockstudios/apps/hammer/projects/repository/ProjectsRepositoryRenameEntityTest.kt
@@ -2,6 +2,8 @@ package com.darkrockstudios.apps.hammer.projects.repository
 
 import com.darkrockstudios.apps.hammer.base.ProjectId
 import com.darkrockstudios.apps.hammer.base.validate.MAX_PROJECT_NAME_LENGTH
+import com.darkrockstudios.apps.hammer.project.ProjectNameTaken
+import com.darkrockstudios.apps.hammer.utilities.isFailure
 import io.mockk.coEvery
 import io.mockk.coVerify
 import kotlinx.coroutines.test.runTest
@@ -9,6 +11,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.MethodSource
 import java.util.stream.Stream
+import kotlin.test.assertIs
 import kotlin.test.assertTrue
 
 class ProjectsRepositoryRenameEntityTest : ProjectsRepositoryBaseTest() {
@@ -26,6 +29,23 @@ class ProjectsRepositoryRenameEntityTest : ProjectsRepositoryBaseTest() {
 			val result = renameProject(userId, syncId, projectId, newProjectName)
 			assertTrue(result.isSuccess)
 			coVerify { projectEntityDatasource.renameProject(userId, projectId, newProjectName) }
+		}
+	}
+
+	@Test
+	fun `Rename Project - Failure - Name Already Taken`() = runTest {
+		val syncId = "sync-id"
+		val projectId = ProjectId("ProjectId")
+		val newProjectName = "Taken Project Name"
+
+		coEvery { projectsSessionManager.validateSyncId(any(), any(), any()) } returns true
+		coEvery { projectEntityDatasource.checkProjectExists(any(), projectId) } returns true
+		coEvery { projectEntityDatasource.renameProject(any(), any(), any()) } returns false
+
+		createProjectsRepository().apply {
+			val result = renameProject(userId, syncId, projectId, newProjectName)
+			assertTrue(isFailure(result))
+			assertIs<ProjectNameTaken>(result.exception)
 		}
 	}
 

--- a/server/src/test/kotlin/com/darkrockstudios/apps/hammer/projects/routes/ProjectsRoutesRenameProjectTest.kt
+++ b/server/src/test/kotlin/com/darkrockstudios/apps/hammer/projects/routes/ProjectsRoutesRenameProjectTest.kt
@@ -6,10 +6,12 @@ import com.darkrockstudios.apps.hammer.base.http.HAMMER_PROTOCOL_VERSION
 import com.darkrockstudios.apps.hammer.base.http.HEADER_SYNC_ID
 import com.darkrockstudios.apps.hammer.project.InvalidProjectName
 import com.darkrockstudios.apps.hammer.project.InvalidSyncIdException
+import com.darkrockstudios.apps.hammer.project.ProjectNameTaken
 import com.darkrockstudios.apps.hammer.project.ProjectNotFound
 import com.darkrockstudios.apps.hammer.utilities.SResult
 import com.darkrockstudios.apps.hammer.utilities.ServerResult
 import io.ktor.client.request.*
+import io.ktor.client.statement.*
 import io.ktor.http.*
 import io.ktor.server.testing.*
 import io.mockk.coEvery
@@ -19,6 +21,7 @@ import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.MethodSource
 import java.util.stream.Stream
+import kotlin.test.assertContains
 import kotlin.test.assertEquals
 
 class ProjectsRoutesRenameProjectTest : ProjectsRoutesBaseTest() {
@@ -61,6 +64,38 @@ class ProjectsRoutesRenameProjectTest : ProjectsRoutesBaseTest() {
 		}
 	}
 
+	@Test
+	fun `Unknown project reports that the project does not exist`() = testApplication {
+		val projectId = ProjectId("TestProjectId")
+		val syncId = "syncId-test"
+		val userId = 0L
+		val newName = "What Ever"
+
+		coEvery { accountsRepository.checkToken(userId, BEARER_TOKEN) } returns SResult.success(0L)
+		coEvery {
+			projectsRepository.renameProject(
+				userId = userId,
+				syncId = syncId,
+				projectId = projectId,
+				newProjectName = newName
+			)
+		} returns SResult.failure(ProjectNotFound(projectId))
+
+		defaultApplication()
+
+		client.get("api/projects/0/rename") {
+			header(HAMMER_PROTOCOL_HEADER, HAMMER_PROTOCOL_VERSION.toString())
+			header("Authorization", "Bearer $BEARER_TOKEN")
+			header(HEADER_SYNC_ID, syncId)
+
+			parameter("projectId", projectId.id)
+			parameter("projectName", newName)
+		}.apply {
+			assertEquals(HttpStatusCode.NotFound, status)
+			assertContains(bodyAsText(), "Project does not exist")
+		}
+	}
+
 	companion object {
 		@JvmStatic
 		fun provideFailureTestData(): Stream<Arguments> {
@@ -78,6 +113,10 @@ class ProjectsRoutesRenameProjectTest : ProjectsRoutesBaseTest() {
 						InvalidSyncIdException()
 					),
 					HttpStatusCode.BadRequest
+				),
+				Arguments.of(
+					SResult.failure<Unit>(ProjectNameTaken("What Ever")),
+					HttpStatusCode.Conflict
 				),
 			)
 		}


### PR DESCRIPTION
Fixes #862.

## The bug

Account sync pushes its queued phases as **rename → delete → create**. Deleting one project and renaming another onto its name in the same session therefore sent the rename while the server still held the old project under that name, violating `UNIQUE(name, user_id)`:

```
ERROR: duplicate key value violates unique constraint "project_name_user_id_key"
  Detail: Key (name, user_id)=(FooBar, 1) already exists.
```

The delete one step later would have freed the name. Nothing was lost — a failed rename stays queued and succeeds on the next sync, which is why the reporter saw it resolve itself.

The server made it worse: `ProjectDao.updateProjectName` had no error handling, so the `PSQLException` reached the generic handler as a 500 and landed in the admin error log.

## Changes

**Client**
- Phases now run **delete → rename → create**.
- A rename queued against a server-tombstoned id is dropped. The delete phase has already removed that project locally, so the rename could only 404 and requeue every session forever.

**Server**
- `ProjectDao.updateProjectName` returns `false` on SQLSTATE 23505; any other SQL error still propagates. That maps to a new `ProjectNameTaken` and **409 Conflict** on `/rename`.
- API error messages resolve through `tWithEnglishFallback`. The `i18n/Messages_*` bundles have no base `Messages.properties`, so a key present only in English throws `MissingResourceException` and turns the response into a 500 for every other locale — and clients send `Accept-Language` on every API call. This bit the new key during review; there's now a German-locale e2e case pinning it.
- Rename's `ProjectNotFound` reported "Invalid project name". It now uses the existing, already-translated `api_project_getproject_error_notfound`.

**Docs** — `SYNCING-PROTOCOL.md`'s sequence diagram had the phases in the wrong order too, so it couldn't have caught this. Fixed, with a new "Phase ordering" section on why the order is load-bearing.

## Tests

Written first and confirmed failing before each fix:

- `ClientAccountSynchronizerTest` — `coVerifyOrder` on delete-before-rename, plus the tombstoned-rename drop.
- `ProjectsTest` (e2e, real embedded Postgres) — rename onto an occupied name returns 409 in English **and** German, then delete → rename → 200.
- Repository and route cases for `ProjectNameTaken`, and a body assertion that the 404 actually says "Project does not exist".

`:server:test`, `:common:desktopTest` and `:integrationTests:jvmTest` all pass.

## Known follow-ups, not addressed here

- A rename rejected with 409 because a **live** project holds the name still retries every sync. That predates this PR (it looped on the 500 before) and resolving it means picking a winner between devices racing for one name.
- `updateProjectName` returns `true` when the UPDATE matches zero rows — the documented contract is only "false ⇒ name taken", and an exact result needs an affected-row count the generated SQLDelight mutator doesn't expose.
