### PR TITLE
Drop the redundant per-call English message fallback

### DIFF
--- a/server/src/main/kotlin/com/darkrockstudios/apps/hammer/projects/ProjectsRoutes.kt
+++ b/server/src/main/kotlin/com/darkrockstudios/apps/hammer/projects/ProjectsRoutes.kt
@@ -231,26 +231,17 @@ private suspend fun RoutingContext.respondRenameFailure(exception: Throwable?) {
 	when (exception) {
 		is InvalidProjectName -> call.respond(
 			status = HttpStatusCode.NotAcceptable,
-			HttpResponseError(
-				error = ERROR_GENERIC,
-				displayMessage = call.tWithEnglishFallback(ERR_KEY_INVALID_PROJECT_NAME),
-			),
+			HttpResponseError(error = ERROR_GENERIC, displayMessage = call.t(R(ERR_KEY_INVALID_PROJECT_NAME))),
 		)
 
 		is ProjectNotFound -> call.respond(
 			status = HttpStatusCode.NotFound,
-			HttpResponseError(
-				error = ERROR_GENERIC,
-				displayMessage = call.tWithEnglishFallback(ERR_KEY_PROJECT_NOT_FOUND),
-			),
+			HttpResponseError(error = ERROR_GENERIC, displayMessage = call.t(R(ERR_KEY_PROJECT_NOT_FOUND))),
 		)
 
 		is ProjectNameTaken -> call.respond(
 			status = HttpStatusCode.Conflict,
-			HttpResponseError(
-				error = ERROR_GENERIC,
-				displayMessage = call.tWithEnglishFallback(ERR_KEY_PROJECT_NAME_TAKEN),
-			),
+			HttpResponseError(error = ERROR_GENERIC, displayMessage = call.t(R(ERR_KEY_PROJECT_NAME_TAKEN))),
 		)
 
 		else -> call.respondSyncFailure(exception)

--- a/server/src/main/kotlin/com/darkrockstudios/apps/hammer/utilities/RouteHelpers.kt
+++ b/server/src/main/kotlin/com/darkrockstudios/apps/hammer/utilities/RouteHelpers.kt
@@ -11,9 +11,6 @@ import io.ktor.http.*
 import io.ktor.server.application.*
 import io.ktor.server.response.*
 import org.koin.ktor.ext.get
-import java.util.Locale
-import java.util.MissingResourceException
-import java.util.ResourceBundle
 
 internal const val ERROR_MISSING_PARAMETER = "Missing Parameter"
 internal const val ERROR_MISSING_HEADER = "Missing Header"
@@ -25,22 +22,6 @@ internal const val ERR_KEY_SYNC_ID_MISSING = "api_project_sync_error_syncidmissi
 internal const val ERR_KEY_ENTITY_ID_MISSING = "api_project_error_entityidmissing"
 internal const val ERR_KEY_INVALID_SYNC_ID = "api_project_sync_end_invalidid"
 internal const val ERR_KEY_UNKNOWN = "api_error_unknown"
-
-/**
- * Localized API message with an English fallback.
- *
- * Thar be dragons: the `i18n/Messages_*` bundles have no base `Messages.properties`, so a
- * translation that lacks the key has no parent to resolve through and [t] throws
- * MissingResourceException — turning the error response into a 500 for every locale but
- * English. Clients send `Accept-Language` on every API call, so any key Crowdin has not
- * translated yet (or has dropped) needs this.
- */
-fun ApplicationCall.tWithEnglishFallback(messageKey: String): String =
-	try {
-		t(R(messageKey))
-	} catch (_: MissingResourceException) {
-		ResourceBundle.getBundle("i18n.Messages", Locale.ENGLISH).getString(messageKey)
-	}
 
 /** Responds 400 BadRequest with the given error name and a plain-text display message. */
 suspend fun ApplicationCall.respondBadRequest(error: String, displayMessage: String) {

--- a/server/src/test/kotlin/com/darkrockstudios/apps/hammer/e2e/ProjectsTest.kt
+++ b/server/src/test/kotlin/com/darkrockstudios/apps/hammer/e2e/ProjectsTest.kt
@@ -408,7 +408,7 @@ class ProjectsTest : EndToEndTest() {
 			}
 			assertEquals(HttpStatusCode.Conflict, renameResponse.status)
 
-			// Every client sends its device locale, and the locale bundles have no English parent.
+			// Every client sends its device locale, and this key has no translation yet.
 			val translatedRenameResponse = get(api("projects/$userId/rename")) {
 				headers {
 					append(HAMMER_PROTOCOL_HEADER, HAMMER_PROTOCOL_VERSION.toString())


### PR DESCRIPTION
Follow-up to #915, cleaning up a duplicate mechanism.

#909 installs `EnglishFallbackMessageResolver` on the `I18n` plugin, so **every** `call.t(R(...))` / `Msg.r(...)` site already falls back to English when a locale bundle lacks the key. #915 was in flight off an older base and added `tWithEnglishFallback` to do the same thing for three call sites in `respondRenameFailure`.

It isn't harmful — the inner `t()` now succeeds and the catch never fires — but it's misleading: a second, narrower mechanism plus a "thar be dragons" comment describing a hazard that no longer exists.

Removes the helper and its now-unused `java.util` imports, and points the three call sites back at `call.t(R(...))`. The `ERR_KEY_PROJECT_NOT_FOUND` fix from #915 stays.

The German-locale rename-conflict assertion in `ProjectsTest` stays too and still passes, now through the resolver. It's worth keeping: it pins the behavior independently of which mechanism provides it, and it covers the API path rather than the web frontend path #909's own test exercises.

`:server:test` passes.
