### PR TITLE
Connect scenes to every encyclopedia entry type

### DIFF
--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/storyeditor/sceneeditor/scenemetadata/EntryAddSearch.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/storyeditor/sceneeditor/scenemetadata/EntryAddSearch.kt
@@ -1,6 +1,7 @@
 package com.darkrockstudios.apps.hammer.common.components.storyeditor.sceneeditor.scenemetadata
 
 import com.darkrockstudios.apps.hammer.common.data.encyclopediarepository.entry.EntryDef
+import com.darkrockstudios.apps.hammer.common.data.encyclopediarepository.entry.EntryType
 
 /**
  * Pre-loaded searchable representation of an encyclopedia entry: its [EntryDef]
@@ -24,6 +25,9 @@ internal data class SearchableEntry(
  * Behavior:
  * - Empty / blank query -> empty result.
  * - Match: case-insensitive substring against name and any alias.
+ * - Restricted to [types], so a caller showing one tab per entry-type group
+ *   narrows before [maxResults] truncates. Filtering after truncation would
+ *   let a run of alphabetically-early entries from one group starve another.
  * - Already-confirmed entries are excluded (they're already chips above the
  *   search field; surfacing them again is noise).
  * - Already-dismissed entries are included, with `isDismissed = true` so the
@@ -37,11 +41,13 @@ internal fun filterEntriesForAdd(
 	confirmedIds: Set<Int>,
 	dismissedIds: Set<Int>,
 	maxResults: Int,
+	types: Set<EntryType> = EntryType.entries.toSet(),
 ): List<SceneMetadataPanel.AddSuggestion> {
 	val q = query.trim().lowercase()
 	if (q.isEmpty()) return emptyList()
 	return entries
 		.asSequence()
+		.filter { it.entryDef.type in types }
 		.filter { it.entryDef.id !in confirmedIds }
 		.filter { entry -> entry.lowerCaseSearchTerms.any { it.contains(q) } }
 		.sortedBy { it.entryDef.name.lowercase() }

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/storyeditor/sceneeditor/scenemetadata/SceneMetadataPanel.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/storyeditor/sceneeditor/scenemetadata/SceneMetadataPanel.kt
@@ -3,6 +3,7 @@ package com.darkrockstudios.apps.hammer.common.components.storyeditor.sceneedito
 import com.arkivanov.decompose.value.Value
 import com.darkrockstudios.apps.hammer.common.data.SceneItem
 import com.darkrockstudios.apps.hammer.common.data.encyclopediarepository.entry.EntryDef
+import com.darkrockstudios.apps.hammer.common.data.encyclopediarepository.entry.EntryType
 import com.darkrockstudios.apps.hammer.common.data.sceneeditorrepository.scenemetadata.SceneMetadata
 import com.darkrockstudios.apps.hammer.common.data.tagindex.TagSuggesting
 import com.darkrockstudios.apps.hammer.common.dependencyinjection.HammerComponent
@@ -27,13 +28,18 @@ interface SceneMetadataPanel : HammerComponent, TagSuggesting {
 
 	/**
 	 * Search entries by name or alias for the manual "add reference" affordance.
-	 * Case-insensitive substring match across all entry types. Already-confirmed
+	 * Case-insensitive substring match, restricted to [types]. Already-confirmed
 	 * entries are excluded; dismissed entries are included with [AddSuggestion.isDismissed]
 	 * flagged so the UI can hint that picking will un-dismiss.
 	 *
-	 * Returns up to [maxResults] entries sorted by name.
+	 * Returns up to [maxResults] entries sorted by name. [types] is applied before
+	 * the cap, so a caller showing one group at a time gets a full page of that group.
 	 */
-	fun searchEntriesForAdd(query: String, maxResults: Int = 20): List<AddSuggestion>
+	fun searchEntriesForAdd(
+		query: String,
+		types: Set<EntryType> = EntryType.entries.toSet(),
+		maxResults: Int = 20,
+	): List<AddSuggestion>
 
 	/**
 	 * Adds one or more tags from a free-form space-separated string. Input is normalized by

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/storyeditor/sceneeditor/scenemetadata/SceneMetadataPanelComponent.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/storyeditor/sceneeditor/scenemetadata/SceneMetadataPanelComponent.kt
@@ -11,6 +11,7 @@ import com.darkrockstudios.apps.hammer.common.data.SceneSummary
 import com.darkrockstudios.apps.hammer.common.data.drafts.SceneDraftsDatasource
 import com.darkrockstudios.apps.hammer.common.data.encyclopediarepository.EncyclopediaService
 import com.darkrockstudios.apps.hammer.common.data.encyclopediarepository.entry.EntryDef
+import com.darkrockstudios.apps.hammer.common.data.encyclopediarepository.entry.EntryType
 import com.darkrockstudios.apps.hammer.common.data.projectGet
 import com.darkrockstudios.apps.hammer.common.data.projectInject
 import com.darkrockstudios.apps.hammer.common.data.projectstatistics.countWords
@@ -279,7 +280,11 @@ class SceneMetadataPanelComponent(
 		}
 	}
 
-	override fun searchEntriesForAdd(query: String, maxResults: Int): List<SceneMetadataPanel.AddSuggestion> {
+	override fun searchEntriesForAdd(
+		query: String,
+		types: Set<EntryType>,
+		maxResults: Int,
+	): List<SceneMetadataPanel.AddSuggestion> {
 		val metadata = state.value.metadata
 		return filterEntriesForAdd(
 			query = query,
@@ -287,6 +292,7 @@ class SceneMetadataPanelComponent(
 			confirmedIds = metadata.confirmedReferences,
 			dismissedIds = metadata.dismissedReferences,
 			maxResults = maxResults,
+			types = types,
 		)
 	}
 

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/projectstatistics/StatisticsService.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/projectstatistics/StatisticsService.kt
@@ -4,6 +4,7 @@ import com.darkrockstudios.apps.hammer.common.data.ProjectDef
 import com.darkrockstudios.apps.hammer.common.data.ProjectScoped
 import com.darkrockstudios.apps.hammer.common.data.SceneItem
 import com.darkrockstudios.apps.hammer.common.data.encyclopediarepository.EncyclopediaRepository
+import com.darkrockstudios.apps.hammer.common.data.encyclopediarepository.entry.EntryType
 import com.darkrockstudios.apps.hammer.common.data.notesrepository.NotesRepository
 import com.darkrockstudios.apps.hammer.common.data.projectdata.ProjectDataRepository
 import com.darkrockstudios.apps.hammer.common.data.references.ReferenceIndexService
@@ -196,8 +197,10 @@ class StatisticsService(
 					sceneCount = sceneCount,
 				)
 			}
+			// People only: this drives the "Characters by Appearances" chart. The
+			// totalEntryConnections count above stays across all entry types.
 			val topAppearances = appearances
-				.filter { it.sceneCount > 0 }
+				.filter { it.type == EntryType.PERSON && it.sceneCount > 0 }
 				.sortedByDescending { it.sceneCount }
 				.take(TOP_APPEARANCES_LIMIT)
 

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/references/ReferenceIndexConfig.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/references/ReferenceIndexConfig.kt
@@ -12,7 +12,7 @@ data class ReferenceIndexConfig(
 ) {
 	companion object {
 		fun default() = ReferenceIndexConfig(
-			enabledEntryTypes = setOf(EntryType.PERSON, EntryType.PLACE),
+			enabledEntryTypes = EntryType.entries.toSet(),
 			enabledSourceTypes = setOf(ReferenceSourceType.Scene),
 		)
 	}

--- a/common/src/desktopTest/kotlin/components/sceneeditor/scenemetadata/EntryAddSearchTest.kt
+++ b/common/src/desktopTest/kotlin/components/sceneeditor/scenemetadata/EntryAddSearchTest.kt
@@ -115,6 +115,40 @@ class EntryAddSearchTest {
 	}
 
 	@Test
+	fun `types restricts the result to the requested entry types`() {
+		val result = filterEntriesForAdd(
+			query = "a",
+			entries = entries,
+			confirmedIds = emptySet(),
+			dismissedIds = emptySet(),
+			maxResults = 20,
+			types = setOf(EntryType.PLACE),
+		)
+		assertEquals(listOf("Atlantis"), result.map { it.entryDef.name })
+	}
+
+	@Test
+	fun `types narrows before maxResults truncates`() {
+		// The alphabetically-early people would fill the cap on their own; the
+		// requested type must still come back rather than being starved out.
+		val crowded = listOf(
+			entry(1, "Aaron"),
+			entry(2, "Abel"),
+			entry(3, "Abigail"),
+			entry(4, "Aventine", type = EntryType.PLACE),
+		)
+		val result = filterEntriesForAdd(
+			query = "a",
+			entries = crowded,
+			confirmedIds = emptySet(),
+			dismissedIds = emptySet(),
+			maxResults = 2,
+			types = setOf(EntryType.PLACE),
+		)
+		assertEquals(listOf("Aventine"), result.map { it.entryDef.name })
+	}
+
+	@Test
 	fun `maxResults caps the returned list`() {
 		// 'b' matches Bob, Bobby, and Robert; the cap must keep the first two in sorted order.
 		val result = filterEntriesForAdd(

--- a/common/src/desktopTest/kotlin/repositories/references/BackfillEntryReferencesUseCaseTest.kt
+++ b/common/src/desktopTest/kotlin/repositories/references/BackfillEntryReferencesUseCaseTest.kt
@@ -82,6 +82,30 @@ class BackfillEntryReferencesUseCaseTest : BaseTest() {
 	}
 
 	@Test
+	fun `Backfills entries of every type under the default config`() = runTest(mainTestDispatcher) {
+		for ((index, type) in EntryType.entries.withIndex()) {
+			val id = 100 + index
+			val name = "Entry$id"
+			val entry = EntryContent(
+				id = id,
+				name = name,
+				type = type,
+				text = "",
+				tags = emptySet(),
+				aliases = emptyList(),
+			)
+			coEvery { referenceIndexService.findScenesMatchingEntry(id, listOf(name)) } returns listOf(10)
+			coEvery { sceneEditor.loadSceneMetadata(10) } returns SceneMetadata()
+			val metaSlot = slot<SceneMetadata>()
+			coEvery { sceneEditor.storeMetadata(capture(metaSlot), 10) } just Runs
+
+			useCase(entry)
+
+			assertEquals(setOf(id), metaSlot.captured.confirmedReferences, "type $type was not backfilled")
+		}
+	}
+
+	@Test
 	fun `Skips entry types that are not enabled in config`() = runTest(mainTestDispatcher) {
 		// Config gates which entry types participate in matching. A type that is
 		// not enabled never produces a scan or a write, regardless of name matches.

--- a/common/src/desktopTest/kotlin/repositories/references/ReferenceIndexServiceTest.kt
+++ b/common/src/desktopTest/kotlin/repositories/references/ReferenceIndexServiceTest.kt
@@ -136,6 +136,9 @@ class ReferenceIndexServiceTest : BaseTest() {
 	private fun place(id: Int, name: String) =
 		EntryContent(id = id, name = name, type = EntryType.PLACE, text = "", tags = emptySet())
 
+	private fun entryOfType(id: Int, name: String, type: EntryType) =
+		EntryContent(id = id, name = name, type = type, text = "", tags = emptySet())
+
 	@Test
 	fun `recalculate builds inverted forward map from confirmed references`() = runTest(mainTestDispatcher) {
 		stubSceneTree(
@@ -267,6 +270,24 @@ class ReferenceIndexServiceTest : BaseTest() {
 		assertEquals(1, suggestions.size)
 		assertEquals(1, suggestions[0].entryId)
 	}
+
+	@Test
+	fun `computeAutoReferencesForScene matches every entry type under the default config`() =
+		runTest(mainTestDispatcher) {
+			val entries = EntryType.entries.mapIndexed { index, type ->
+				entryOfType(index + 1, "Entry${type.name}", type)
+			}
+			stubEntries(entries)
+			val service = makeService()
+
+			val suggestions = service.computeAutoReferencesForScene(
+				sceneId = 10,
+				sceneText = entries.joinToString(" ") { it.name },
+				metadata = SceneMetadata(),
+			)
+
+			assertEquals(entries.map { it.id }.toSet(), suggestions.map { it.entryId }.toSet())
+		}
 
 	@Test
 	fun `computeAutoReferencesForScene dedupes per entry on multiple hits`() = runTest(mainTestDispatcher) {

--- a/common/src/desktopTest/kotlin/repositories/statistics/StatisticsServiceTest.kt
+++ b/common/src/desktopTest/kotlin/repositories/statistics/StatisticsServiceTest.kt
@@ -3,6 +3,8 @@ package repositories.statistics
 import com.darkrockstudios.apps.hammer.common.data.ProjectDef
 import com.darkrockstudios.apps.hammer.common.data.SceneItem
 import com.darkrockstudios.apps.hammer.common.data.encyclopediarepository.EncyclopediaRepository
+import com.darkrockstudios.apps.hammer.common.data.encyclopediarepository.entry.EntryDef
+import com.darkrockstudios.apps.hammer.common.data.encyclopediarepository.entry.EntryType
 import com.darkrockstudios.apps.hammer.common.data.notesrepository.NotesRepository
 import com.darkrockstudios.apps.hammer.common.data.projectdata.ProjectDataRepository
 import com.darkrockstudios.apps.hammer.common.data.projectdata.StoredProjectData
@@ -206,6 +208,29 @@ class StatisticsServiceTest : BaseTest() {
 			assertEquals(stats, saved.captured)
 			// Calculation flag is reset once finished.
 			assertFalse(service.isCalculating.value)
+		}
+
+	@Test
+	fun `recalculateStatistics limits top appearances to people but counts connections for all types`() =
+		runTest(mainTestDispatcher) {
+			// Scenes reference entries of every type. The "Characters by Appearances"
+			// chart is people-only; the connections total spans the whole encyclopedia.
+			val entries = EntryType.entries.mapIndexed { index, type ->
+				EntryDef(projectDef, index + 1, type, "Entry${type.name}")
+			}
+			every { encyclopediaRepository.entryListFlow } returns MutableStateFlow(entries)
+			coEvery { referenceIndexService.loadIndex() } returns ReferenceIndex(
+				entryToScenes = entries.associate { it.id to setOf(100, 200) },
+			)
+			coEvery { statisticsRepository.loadStatistics() } returns null
+
+			val stats = makeService().recalculateStatistics()
+
+			assertEquals(
+				listOf(EntryType.PERSON),
+				stats.topAppearances.map { it.type }.distinct(),
+			)
+			assertEquals(entries.size * 2, stats.totalEntryConnections)
 		}
 
 	@Test

--- a/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/storyeditor/sceneeditor/SceneMetadataPanelUi.kt
+++ b/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/storyeditor/sceneeditor/SceneMetadataPanelUi.kt
@@ -43,6 +43,9 @@ private fun EntryType.bucket(): RefBucket = when (this) {
 	else -> RefBucket.Other
 }
 
+private fun RefBucket.types(): Set<EntryType> =
+	EntryType.entries.filterTo(mutableSetOf()) { it.bucket() == this }
+
 @Composable
 private fun RefBucket.label(): String = when (this) {
 	RefBucket.Characters -> Res.string.scene_editor_metadata_references_characters_label.get()
@@ -455,8 +458,7 @@ private fun AddReferenceDialog(
 	var tab by rememberSaveable { mutableStateOf(RefBucket.Characters) }
 
 	val suggestions = remember(query, tab) {
-		component.searchEntriesForAdd(query)
-			.filter { it.entryDef.type.bucket() == tab }
+		component.searchEntriesForAdd(query, types = tab.types())
 	}
 
 	AnimatedDialog(

--- a/composeUi/src/desktopMain/kotlin/com/darkrockstudios/apps/hammer/common/preview/sceneeditor/SceneEditorUi.Preview.kt
+++ b/composeUi/src/desktopMain/kotlin/com/darkrockstudios/apps/hammer/common/preview/sceneeditor/SceneEditorUi.Preview.kt
@@ -15,6 +15,7 @@ import com.darkrockstudios.apps.hammer.common.data.SceneBuffer
 import com.darkrockstudios.apps.hammer.common.data.SceneContent
 import com.darkrockstudios.apps.hammer.common.data.UpdateSource
 import com.darkrockstudios.apps.hammer.common.data.encyclopediarepository.entry.EntryDef
+import com.darkrockstudios.apps.hammer.common.data.encyclopediarepository.entry.EntryType
 import com.darkrockstudios.apps.hammer.common.fileio.HPath
 import com.darkrockstudios.apps.hammer.common.preview.KoinApplicationPreview
 import com.darkrockstudios.apps.hammer.common.preview.TABLET_HEIGHT_DP
@@ -84,7 +85,8 @@ private fun fakeComponent() = object : SceneEditor {
 		override fun dismissReference(entryId: Int) {}
 		override fun restoreDismissedReference(entryId: Int) {}
 		override fun addConfirmedReference(entryId: Int) {}
-		override fun searchEntriesForAdd(query: String, maxResults: Int) = emptyList<SceneMetadataPanel.AddSuggestion>()
+		override fun searchEntriesForAdd(query: String, types: Set<EntryType>, maxResults: Int) =
+			emptyList<SceneMetadataPanel.AddSuggestion>()
 		override fun navigateToEntry(entryDef: EntryDef) {}
 		override fun addTags(input: String) {}
 		override fun removeTag(tag: String) {}

--- a/composeUi/src/desktopMain/kotlin/com/darkrockstudios/apps/hammer/common/preview/sceneeditor/SceneMetadataPanelUi.Preview.kt
+++ b/composeUi/src/desktopMain/kotlin/com/darkrockstudios/apps/hammer/common/preview/sceneeditor/SceneMetadataPanelUi.Preview.kt
@@ -4,41 +4,95 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.tooling.preview.Preview
 import com.arkivanov.decompose.value.MutableValue
 import com.darkrockstudios.apps.hammer.common.components.storyeditor.sceneeditor.scenemetadata.SceneMetadataPanel
+import com.darkrockstudios.apps.hammer.common.compose.theme.AppTheme
+import com.darkrockstudios.apps.hammer.common.data.encyclopediarepository.entry.EntryDef
+import com.darkrockstudios.apps.hammer.common.data.encyclopediarepository.entry.EntryType
 import com.darkrockstudios.apps.hammer.common.data.sceneeditorrepository.scenemetadata.SceneMetadata
+import com.darkrockstudios.apps.hammer.common.preview.KoinApplicationPreview
+import com.darkrockstudios.apps.hammer.common.preview.fakeProjectDef
 import com.darkrockstudios.apps.hammer.common.preview.fakeSceneItem
+import com.darkrockstudios.apps.hammer.common.preview.globalSettingsPreview
 import com.darkrockstudios.apps.hammer.common.storyeditor.sceneeditor.SceneMetadataPanelUi
+
+private fun previewEntryDef(id: Int, name: String, type: EntryType) = EntryDef(
+	projectDef = fakeProjectDef(),
+	id = id,
+	name = name,
+	type = type,
+)
+
+private val previewConfirmedRefs = listOf(
+	previewEntryDef(1, "Alandra Vey", EntryType.PERSON),
+	previewEntryDef(2, "Bastion Roke", EntryType.PERSON),
+	previewEntryDef(3, "The Sunken Quarter", EntryType.PLACE),
+	previewEntryDef(4, "Cinderhall", EntryType.PLACE),
+	previewEntryDef(5, "The Ashen Key", EntryType.THING),
+	previewEntryDef(6, "The Long Silence", EntryType.EVENT),
+	previewEntryDef(7, "Debt As Inheritance", EntryType.IDEA),
+).sortedBy { it.name.lowercase() }
+
+private val previewDismissedRefs = listOf(
+	previewEntryDef(8, "Marek", EntryType.PERSON),
+	previewEntryDef(9, "Tidewatch Lantern", EntryType.THING),
+)
+
+private fun previewComponent(
+	confirmedRefs: List<EntryDef>,
+	dismissedRefs: List<EntryDef>,
+) = object : SceneMetadataPanel {
+	override val state = MutableValue(
+		SceneMetadataPanel.State(
+			sceneItem = fakeSceneItem(),
+			wordCount = 1337,
+			metadata = SceneMetadata(
+				outline = "Alandra bargains for passage through the Sunken Quarter.",
+				notes = "",
+				tags = setOf("act-one", "pov/alandra"),
+			),
+			confirmedRefs = confirmedRefs,
+			dismissedRefs = dismissedRefs,
+		)
+	)
+
+	override fun updateOutline(text: String) {}
+	override fun updateNotes(text: String) {}
+	override fun updateDraftName(text: String) {}
+	override fun validateDraftName(text: String) = true
+	override fun dismissReference(entryId: Int) {}
+	override fun restoreDismissedReference(entryId: Int) {}
+	override fun addConfirmedReference(entryId: Int) {}
+	override fun searchEntriesForAdd(query: String, maxResults: Int) =
+		emptyList<SceneMetadataPanel.AddSuggestion>()
+
+	override fun navigateToEntry(entryDef: EntryDef) {}
+	override fun addTags(input: String) {}
+	override fun removeTag(tag: String) {}
+	override fun showGlobalSearchForTag(tag: String) {}
+	override fun suggestTags(prefix: String, limit: Int) = emptyList<String>()
+}
 
 @Preview
 @Composable
 fun SceneMetadataPanelUiPreview() {
-	SceneMetadataPanelUi(
-		component = object : SceneMetadataPanel {
-			override val state = MutableValue(
-				SceneMetadataPanel.State(
-					sceneItem = fakeSceneItem(),
-					wordCount = 1337,
-					metadata = SceneMetadata(
-						outline = "",
-						notes = ""
-					)
-				)
+	KoinApplicationPreview {
+		AppTheme(globalSettingsPreview) {
+			SceneMetadataPanelUi(
+				component = previewComponent(previewConfirmedRefs, previewDismissedRefs),
+				closeMetadata = {},
 			)
+		}
+	}
+}
 
-			override fun updateOutline(text: String) {}
-			override fun updateNotes(text: String) {}
-			override fun updateDraftName(text: String) {}
-			override fun validateDraftName(text: String) = true
-			override fun dismissReference(entryId: Int) {}
-			override fun restoreDismissedReference(entryId: Int) {}
-			override fun addConfirmedReference(entryId: Int) {}
-			override fun searchEntriesForAdd(query: String, maxResults: Int) =
-				emptyList<SceneMetadataPanel.AddSuggestion>()
-			override fun navigateToEntry(entryDef: com.darkrockstudios.apps.hammer.common.data.encyclopediarepository.entry.EntryDef) {}
-			override fun addTags(input: String) {}
-			override fun removeTag(tag: String) {}
-			override fun showGlobalSearchForTag(tag: String) {}
-			override fun suggestTags(prefix: String, limit: Int) = emptyList<String>()
-		},
-		closeMetadata = {}
-	)
+@Preview
+@Composable
+fun SceneMetadataPanelUiEmptyPreview() {
+	KoinApplicationPreview {
+		AppTheme(globalSettingsPreview) {
+			SceneMetadataPanelUi(
+				component = previewComponent(emptyList(), emptyList()),
+				closeMetadata = {},
+			)
+		}
+	}
 }

--- a/composeUi/src/desktopMain/kotlin/com/darkrockstudios/apps/hammer/common/preview/sceneeditor/SceneMetadataPanelUi.Preview.kt
+++ b/composeUi/src/desktopMain/kotlin/com/darkrockstudios/apps/hammer/common/preview/sceneeditor/SceneMetadataPanelUi.Preview.kt
@@ -61,7 +61,7 @@ private fun previewComponent(
 	override fun dismissReference(entryId: Int) {}
 	override fun restoreDismissedReference(entryId: Int) {}
 	override fun addConfirmedReference(entryId: Int) {}
-	override fun searchEntriesForAdd(query: String, maxResults: Int) =
+	override fun searchEntriesForAdd(query: String, types: Set<EntryType>, maxResults: Int) =
 		emptyList<SceneMetadataPanel.AddSuggestion>()
 
 	override fun navigateToEntry(entryDef: EntryDef) {}


### PR DESCRIPTION
Scene reference auto-detection was limited to `PERSON` and `PLACE` entries. This opens it up to all five encyclopedia types, so `THING`, `EVENT`, and `IDEA` entries also get linked to the scenes that mention them.

## The change

`ReferenceIndexConfig.default()` now enables every `EntryType`. That single value is the gate for both consumers:

- `ReferenceIndexService.matchableEntries()`, the name/alias cache behind auto-confirm on scene save.
- `BackfillEntryReferencesUseCase`, the scan that runs when an entry is created, renamed, or gains an alias.

Everything downstream was already type-agnostic, so the rest comes for free:

- The metadata panel already bucketed references into **Characters / Locations / Other**. The three new types land in Other, each keeping its own glyph and colour from the design system.
- The "Add reference" dialog's Other tab was already there and already searched all types.
- "Appears in" on the encyclopedia entry page reads the same inverted index, so Thing/Event/Idea entries now get it too.

Verified by rendering the `SceneMetadataPanelUi` preview: Characters and Locations group as before, and Other shows the Idea / Thing / Event chips with their distinct glyphs and colours.

## Follow-ups in this PR

**Add-reference search now filters by type before capping.** `filterEntriesForAdd` took its `maxResults` slice first and the caller filtered to the selected tab afterwards, so a run of alphabetically-early entries from one group could fill the cap and leave another tab reading empty. Latent before, but far easier to hit once three more types share the list. The type set is now a parameter applied ahead of the sort and take, and `RefBucket.types()` is derived from `bucket()` so the tab and its filter cannot drift apart.

**The appearances chart is people-only again.** `topAppearances` drives the "Characters by Appearances" chart, and with every type indexed an Idea or Event could out-rank an actual character in it. It now filters to `EntryType.PERSON`. The separate `totalEntryConnections` count next to the encyclopedia donut still spans all types, since that one is about connections in general. Worth noting the chart already counted Places before this branch; this tightens it to what the label claims.

## Tests

- `ReferenceIndexServiceTest`: auto-detection matches every entry type under the default config.
- `BackfillEntryReferencesUseCaseTest`: backfill runs for every entry type under the default config.
- `EntryAddSearchTest`: the type set restricts results, and it narrows before `maxResults` truncates.
- `StatisticsServiceTest`: top appearances stay people-only while connections count every type.
- The two existing tests that assert the type gate still works build their own explicit configs, so they keep covering the mechanism.
- Extended the `SceneMetadataPanelUi` preview with refs across all five types (plus an empty-state preview).

## Note on existing projects

References accrue as you write: a scene picks up its links when it's saved, and an entry picks up its scenes when it's created or renamed. That's unchanged, but it means Thing/Event/Idea entries in an existing project won't show connections until the relevant scene is next saved. A project-wide rescan would be a separate piece of work.
