### PR TITLE
Encyclopedia names feed the spell check dictionary

### DIFF
--- a/base/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/base/http/ApiProjectEntity.kt
+++ b/base/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/base/http/ApiProjectEntity.kt
@@ -99,6 +99,7 @@ sealed interface ApiProjectEntity {
 		val tags: Set<String>,
 		val image: Image?,
 		val aliases: List<String> = emptyList(),
+		val excludeFromDictionary: Boolean = false,
 	) : ApiProjectEntity {
 		@Serializable
 		data class Image(
@@ -114,6 +115,7 @@ sealed interface ApiProjectEntity {
 			tags = tags,
 			image = image,
 			aliases = aliases,
+			excludeFromDictionary = excludeFromDictionary,
 		)
 	}
 

--- a/base/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/base/http/projectdata/ProjectData.kt
+++ b/base/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/base/http/projectdata/ProjectData.kt
@@ -11,6 +11,8 @@ data class ProjectData(
 	val tags: Set<String> = emptySet(),
 	/** BCP-47 tag of the language the project is written in (e.g. "en", "pt-BR"); null when unset. */
 	val language: String? = null,
+	/** Whether Encyclopedia entry names feed the spell-check session dictionary for this project. */
+	val encyclopediaDictionary: Boolean = true,
 )
 
 /** Picked as a unit during conflict resolution — one device's primary paired with another's secondary is undesigned. */

--- a/base/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/base/http/synchronizer/EntityHasher.kt
+++ b/base/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/base/http/synchronizer/EntityHasher.kt
@@ -99,6 +99,7 @@ object EntityHasher {
 		tags: Set<String>,
 		image: ApiProjectEntity.EncyclopediaEntryEntity.Image?,
 		aliases: List<String>,
+		excludeFromDictionary: Boolean = false,
 	): String {
 		val buf = buff()
 		val d = Algorithm.MurmurHash3_X64_128().createDigest()
@@ -119,6 +120,11 @@ object EntityHasher {
 		if (image != null) {
 			d.update(Base64.decode(image.base64, url = true))
 			d.update(image.fileExtension, buf)
+		}
+
+		// Zero bytes at the default (false): pre-existing hashes must stay identical.
+		if (excludeFromDictionary) {
+			d.update(1, buf)
 		}
 
 		return d.digest().base64Url

--- a/base/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/base/http/synchronizer/ProjectDataHasher.kt
+++ b/base/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/base/http/synchronizer/ProjectDataHasher.kt
@@ -56,6 +56,12 @@ object ProjectDataHasher {
 			d.update(data.language, buf)
 		}
 
+		// Zero bytes at the default (true): pre-existing hashes must stay identical.
+		// -2 marker: -1 is taken by the language block.
+		if (!data.encyclopediaDictionary) {
+			d.update(-2, buf)
+		}
+
 		return d.digest().base64Url
 	}
 }

--- a/base/src/commonTest/kotlin/com/darkrockstudios/apps/hammer/base/http/synchronizer/EntityHasherTest.kt
+++ b/base/src/commonTest/kotlin/com/darkrockstudios/apps/hammer/base/http/synchronizer/EntityHasherTest.kt
@@ -137,6 +137,23 @@ class EntityHasherTest {
 	}
 
 	@Test
+	fun `hashEncyclopediaEntry differs when excludeFromDictionary differs`() {
+		val included = EntityHasher.hashEncyclopediaEntry(
+			id = 2, name = "Robert", entryType = "person",
+			text = "text", tags = emptySet(), image = null,
+			aliases = emptyList(),
+			excludeFromDictionary = false,
+		)
+		val excluded = EntityHasher.hashEncyclopediaEntry(
+			id = 2, name = "Robert", entryType = "person",
+			text = "text", tags = emptySet(), image = null,
+			aliases = emptyList(),
+			excludeFromDictionary = true,
+		)
+		assertNotEquals(included, excluded, "hashEncyclopediaEntry must include excludeFromDictionary in the digest")
+	}
+
+	@Test
 	fun `hashEncyclopediaEntry alias order is significant`() {
 		// aliases is a List, not a Set - reordering is a meaningful change that should
 		// propagate through sync so two clients with reordered aliases don't silently diverge.

--- a/base/src/commonTest/kotlin/com/darkrockstudios/apps/hammer/base/http/synchronizer/ProjectDataHasherTest.kt
+++ b/base/src/commonTest/kotlin/com/darkrockstudios/apps/hammer/base/http/synchronizer/ProjectDataHasherTest.kt
@@ -82,6 +82,13 @@ class ProjectDataHasherTest {
 	}
 
 	@Test
+	fun `encyclopedia dictionary affects hash`() {
+		val on = ProjectData(authorName = "Pat")
+		val off = on.copy(encyclopediaDictionary = false)
+		assertNotEquals(ProjectDataHasher.hash(on), ProjectDataHasher.hash(off))
+	}
+
+	@Test
 	fun `null vs empty language distinguishable`() {
 		val nullLanguage = ProjectData(language = null)
 		val emptyLanguage = ProjectData(language = "")

--- a/common/src/commonMain/composeResources/values/strings_account_settings.xml
+++ b/common/src/commonMain/composeResources/values/strings_account_settings.xml
@@ -81,6 +81,8 @@
 	<string name="settings_spellcheck_notice">If it is causing problems just turn it off.</string>
 	<string name="settings_spellcheck_enable">Enable spell checking</string>
 	<string name="settings_spellcheck_in_focus_enable">Enable in focus mode</string>
+	<string name="settings_spellcheck_encyclopedia_enable">Learn encyclopedia names</string>
+	<string name="settings_spellcheck_encyclopedia_enable_hint">Entry names and aliases won&#8217;t be marked as misspelled while their project is open</string>
 	<string name="settings_spellcheck_dictionary">Dictionary</string>
 	<string name="settings_spellcheck_dictionary_android_info_title">Spell check language</string>
 	<string name="settings_spellcheck_dictionary_android_info_message">On Android, the spell check language is chosen by your device, not the app. To change it, update your system and keyboard languages in Android Settings.</string>

--- a/common/src/commonMain/composeResources/values/strings_encyclopedia.xml
+++ b/common/src/commonMain/composeResources/values/strings_encyclopedia.xml
@@ -37,6 +37,8 @@
 	<string name="encyclopedia_create_entry_toast_tag_too_long">Tag is too long. Max %1$d</string>
 	<string name="encyclopedia_create_entry_toast_alias_too_long">Alias is too long. Max %1$d</string>
 	<string name="encyclopedia_entry_aliases_label">Aliases</string>
+	<string name="encyclopedia_entry_dictionary_toggle_label">Learn in spell check</string>
+	<string name="encyclopedia_entry_dictionary_toggle_hint">This entry&#8217;s name and aliases won&#8217;t be marked as misspelled</string>
 	<string name="encyclopedia_entry_add_alias_dialog_title">Add Alias</string>
 	<string name="encyclopedia_entry_add_alias_button">Add</string>
 	<string name="encyclopedia_entry_alias_hint">Nickname or other name</string>

--- a/common/src/commonMain/composeResources/values/strings_sync.xml
+++ b/common/src/commonMain/composeResources/values/strings_sync.xml
@@ -63,6 +63,8 @@
 	<string name="project_settings_hero_no_author">by (no author set)</string>
 	<string name="project_settings_spellcheck_section_title">Spell checking</string>
 	<string name="project_settings_spellcheck_mismatch_caption">Spell check is off: the project language (%1$s) doesn’t match your dictionary (%2$s). Change either to re-enable it.</string>
+	<string name="project_settings_spellcheck_encyclopedia_enable">Learn encyclopedia names in this project</string>
+	<string name="project_settings_spellcheck_encyclopedia_enable_hint">Turn off to keep this project&#8217;s entry names out of the spell check dictionary</string>
 	<string name="project_settings_folio_caption">Project Settings · %1$s</string>
 	<string name="project_settings_folio_section_count">§§ %1$d</string>
 
@@ -73,7 +75,10 @@
 	<string name="sync_conflict_project_data_field_word_goal">Word Count Goal</string>
 	<string name="sync_conflict_project_data_field_tags">Tags</string>
 	<string name="sync_conflict_project_data_field_language">Language</string>
+	<string name="sync_conflict_project_data_field_dictionary">Learn Encyclopedia Names</string>
 	<string name="sync_conflict_project_data_value_unset">(not set)</string>
+	<string name="sync_conflict_project_data_value_on">On</string>
+	<string name="sync_conflict_project_data_value_off">Off</string>
 	<string name="sync_conflict_project_data_cadence_day">day</string>
 	<string name="sync_conflict_project_data_cadence_week">week</string>
 	<string name="sync_conflict_project_data_resolve_button">Resolve</string>

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/ProjectComponentBase.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/ProjectComponentBase.kt
@@ -33,6 +33,17 @@ abstract class ProjectComponentBase(
 			}
 		}
 	}
+
+	/** Collects whether encyclopedia names feed the spell-check dictionary (global AND project toggles); call from onCreate. [onChange] runs on the main dispatcher. */
+	protected fun watchEncyclopediaDictionaryEnabled(onChange: (Boolean) -> Unit) {
+		scope.launch {
+			projectSpellCheck.encyclopediaDictionaryEnabled.collect { enabled ->
+				withContext(dispatcherMain) {
+					onChange(enabled)
+				}
+			}
+		}
+	}
 }
 
 abstract class SavableProjectComponentBase<S : Any>(

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/encyclopedia/CreateEntry.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/encyclopedia/CreateEntry.kt
@@ -21,7 +21,8 @@ interface CreateEntry : TagSuggesting {
 		type: EntryType,
 		text: String,
 		tags: Set<String>,
-		imagePath: String?
+		imagePath: String?,
+		excludeFromDictionary: Boolean = false,
 	): EntryResult
 
 	fun confirmClose()

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/encyclopedia/CreateEntry.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/encyclopedia/CreateEntry.kt
@@ -14,6 +14,7 @@ interface CreateEntry : TagSuggesting {
 		val projectDef: ProjectDef,
 		val showConfirmClose: Boolean = false,
 		val spellCheckAllowed: Boolean = true,
+		val dictionaryFeatureEnabled: Boolean = true,
 	)
 
 	suspend fun createEntry(

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/encyclopedia/CreateEntryComponent.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/encyclopedia/CreateEntryComponent.kt
@@ -34,6 +34,10 @@ class CreateEntryComponent(
 		watchSpellCheckAllowed { allowed ->
 			_state.getAndUpdate { it.copy(spellCheckAllowed = allowed) }
 		}
+
+		watchEncyclopediaDictionaryEnabled { enabled ->
+			_state.getAndUpdate { it.copy(dictionaryFeatureEnabled = enabled) }
+		}
 	}
 
 	override fun confirmClose() {

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/encyclopedia/CreateEntryComponent.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/encyclopedia/CreateEntryComponent.kt
@@ -53,9 +53,17 @@ class CreateEntryComponent(
 		type: EntryType,
 		text: String,
 		tags: Set<String>,
-		imagePath: String?
+		imagePath: String?,
+		excludeFromDictionary: Boolean,
 	): EntryResult = withContext(dispatcherDefault) {
-		val result = encyclopediaService.createEntry(name, type, text, tags, imagePath)
+		val result = encyclopediaService.createEntry(
+			name = name,
+			type = type,
+			text = text,
+			tags = tags,
+			imagePath = imagePath,
+			excludeFromDictionary = excludeFromDictionary,
+		)
 		if (result.error == EntryError.NONE) {
 			encyclopediaService.loadEntries()
 			result.instance?.entry?.let { newEntry ->

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/encyclopedia/ViewEntry.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/encyclopedia/ViewEntry.kt
@@ -28,6 +28,7 @@ interface ViewEntry : TagSuggesting {
 		val menuItems: Set<MenuItemDescriptor> = emptySet(),
 		val appearsIn: List<Appearance> = emptyList(),
 		val spellCheckAllowed: Boolean = true,
+		val dictionaryFeatureEnabled: Boolean = true,
 	)
 
 	data class Appearance(

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/encyclopedia/ViewEntry.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/encyclopedia/ViewEntry.kt
@@ -69,5 +69,6 @@ interface ViewEntry : TagSuggesting {
 	fun endAliasAdd()
 	suspend fun addAlias(alias: String): EntryResult
 	fun removeAlias(alias: String)
+	suspend fun setExcludeFromDictionary(exclude: Boolean): EntryResult
 	fun navigateToAppearance(appearance: Appearance)
 }

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/encyclopedia/ViewEntryComponent.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/encyclopedia/ViewEntryComponent.kt
@@ -66,6 +66,10 @@ class ViewEntryComponent(
 			_state.getAndUpdate { it.copy(spellCheckAllowed = allowed) }
 		}
 
+		watchEncyclopediaDictionaryEnabled { enabled ->
+			_state.getAndUpdate { it.copy(dictionaryFeatureEnabled = enabled) }
+		}
+
 		// Trigger an initial recompute so the index reflects current data
 		scope.launch { referenceIndexService.loadIndex() }
 

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/encyclopedia/ViewEntryComponent.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/encyclopedia/ViewEntryComponent.kt
@@ -212,6 +212,7 @@ class ViewEntryComponent(
 			text = text,
 			tags = tags,
 			aliases = currentAliases,
+			excludeFromDictionary = state.value.content?.excludeFromDictionary ?: false,
 		)
 		if (result.instance != null && result.error == EntryError.NONE) {
 			_state.getAndUpdate {
@@ -258,6 +259,7 @@ class ViewEntryComponent(
 					text = text,
 					tags = newTags,
 					aliases = aliases,
+					excludeFromDictionary = excludeFromDictionary,
 				)
 
 				reload()
@@ -295,6 +297,7 @@ class ViewEntryComponent(
 				text = text,
 				tags = tags + newTags,
 				aliases = aliases,
+				excludeFromDictionary = excludeFromDictionary,
 			)
 		}
 
@@ -324,6 +327,7 @@ class ViewEntryComponent(
 			text = current.text,
 			tags = current.tags,
 			aliases = current.aliases + trimmed,
+			excludeFromDictionary = current.excludeFromDictionary,
 		)
 		if (result.error == EntryError.NONE) {
 			endAliasAdd()
@@ -342,12 +346,31 @@ class ViewEntryComponent(
 					text = text,
 					tags = tags,
 					aliases = aliases.filterNot { it == alias },
+					excludeFromDictionary = excludeFromDictionary,
 				)
 
 				reload()
 			}
 		}
 	}
+
+	override suspend fun setExcludeFromDictionary(exclude: Boolean): EntryResult =
+		withContext(dispatcherDefault) {
+			val current = state.value.content
+				?: return@withContext EntryResult(EntryError.NONE)
+			val result = encyclopediaService.updateEntry(
+				oldEntryDef = state.value.entryDef,
+				name = current.name,
+				text = current.text,
+				tags = current.tags,
+				aliases = current.aliases,
+				excludeFromDictionary = exclude,
+			)
+			if (result.error == EntryError.NONE) {
+				reload()
+			}
+			result
+		}
 
 	override fun navigateToAppearance(appearance: ViewEntry.Appearance) {
 		showScene(appearance.sceneItem)

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/projecthome/ProjectSettings.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/projecthome/ProjectSettings.kt
@@ -24,6 +24,8 @@ interface ProjectSettings : HammerComponent {
 	/** [tag] is a BCP-47 tag; null or blank clears the project language. */
 	fun setProjectLanguage(tag: String?)
 
+	fun setEncyclopediaDictionaryEnabled(enabled: Boolean)
+
 	data class LanguageOption(
 		val tag: String,
 		val displayName: String,

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/projecthome/ProjectSettingsComponent.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/projecthome/ProjectSettingsComponent.kt
@@ -95,6 +95,12 @@ class ProjectSettingsComponent(
 		}
 	}
 
+	override fun setEncyclopediaDictionaryEnabled(enabled: Boolean) {
+		scope.launch {
+			projectDataRepository.updateData { it.copy(encyclopediaDictionary = enabled) }
+		}
+	}
+
 	override fun suggestProjectTags(prefix: String): List<String> {
 		// Exclude this project's own tags so it suggests from the *other* projects' / ideas'
 		// vocabulary, rather than offering back tags already applied here.

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/spellchecksettings/SpellCheckSettings.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/spellchecksettings/SpellCheckSettings.kt
@@ -11,12 +11,14 @@ interface SpellCheckSettings {
 
 	suspend fun setSpellcheckEnable(enable: Boolean)
 	suspend fun setSpellCheckingInFocusEnabled(enable: Boolean)
+	suspend fun setSpellCheckEncyclopediaEnabled(enable: Boolean)
 	suspend fun setSpellCheckLanguage(language: Locale)
 
 	@Serializable
 	data class State(
 		val spellCheckingEnabled: Boolean,
 		val spellCheckingInFocusEnabled: Boolean,
+		val spellCheckingEncyclopediaEnabled: Boolean = true,
 		@Serializable(with = LocaleSerializer::class)
 		val spellCheckingLanguage: Locale,
 		@Serializable(with = LocaleListSerializer::class)

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/spellchecksettings/SpellCheckSettingsComponent.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/spellchecksettings/SpellCheckSettingsComponent.kt
@@ -27,6 +27,7 @@ class SpellCheckSettingsComponent(
 		SpellCheckSettings.State(
 			spellCheckingEnabled = globalSettingsStore.globalSettings.spellCheckSettings.enabled,
 			spellCheckingInFocusEnabled = globalSettingsStore.globalSettings.spellCheckSettings.enabledInFocusMode,
+			spellCheckingEncyclopediaEnabled = globalSettingsStore.globalSettings.spellCheckSettings.includeEncyclopediaNames,
 			spellCheckingLanguage = globalSettingsStore.globalSettings.spellCheckSettings.locale,
 			spellCheckLanguages = platformSpellCheckerFactory.availableLocales().map { it.toLocale() },
 		)
@@ -47,6 +48,7 @@ class SpellCheckSettingsComponent(
 						it.copy(
 							spellCheckingEnabled = settings.spellCheckSettings.enabled,
 							spellCheckingInFocusEnabled = settings.spellCheckSettings.enabledInFocusMode,
+							spellCheckingEncyclopediaEnabled = settings.spellCheckSettings.includeEncyclopediaNames,
 							spellCheckingLanguage = settings.spellCheckSettings.locale
 						)
 					}
@@ -70,6 +72,16 @@ class SpellCheckSettingsComponent(
 			it.copy(
 				spellCheckSettings = it.spellCheckSettings.copy(
 					enabledInFocusMode = enable
+				)
+			)
+		}
+	}
+
+	override suspend fun setSpellCheckEncyclopediaEnabled(enable: Boolean) {
+		globalSettingsStore.updateSettings {
+			it.copy(
+				spellCheckSettings = it.spellCheckSettings.copy(
+					includeEncyclopediaNames = enable
 				)
 			)
 		}

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/ProjectEditorScopeUtils.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/ProjectEditorScopeUtils.kt
@@ -3,6 +3,7 @@ package com.darkrockstudios.apps.hammer.common.data
 import com.darkrockstudios.apps.hammer.common.data.sceneeditorrepository.SceneEditorService
 import com.darkrockstudios.apps.hammer.common.data.timelinerepository.TimeLineRepository
 import com.darkrockstudios.apps.hammer.common.dependencyinjection.ProjectDefScope
+import com.darkrockstudios.apps.hammer.common.spellcheck.ProjectDictionaryService
 import io.github.aakira.napier.Napier
 import org.koin.core.Koin
 import org.koin.core.component.KoinComponent
@@ -57,6 +58,9 @@ suspend fun initializeProjectScope(projectDef: ProjectDef) {
 
 		val timeLineRepository: TimeLineRepository = projScope.get { parametersOf(projectDef) }
 		timeLineRepository.initialize()
+
+		// Eagerly created so encyclopedia session words load from project open, not first use.
+		projScope.get<ProjectDictionaryService>()
 	} ?: throw IllegalStateException("No scope found for $projectDef")
 }
 

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/encyclopediarepository/EncyclopediaDatasource.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/encyclopediarepository/EncyclopediaDatasource.kt
@@ -283,7 +283,8 @@ class EncyclopediaDatasource(
 		name: String,
 		text: String,
 		tags: Set<String>,
-		aliases: List<String> = emptyList(),
+		aliases: List<String>,
+		excludeFromDictionary: Boolean,
 	): EntryContainer {
 		val oldPath = getEntryPath(oldEntryDef.id).toOkioPath()
 		fileSystem.delete(oldPath)
@@ -295,6 +296,7 @@ class EncyclopediaDatasource(
 			text = text.trim(),
 			tags = tags,
 			aliases = aliases,
+			excludeFromDictionary = excludeFromDictionary,
 		)
 		val container = EntryContainer(entry)
 		val entryToml = toml.encodeToString(container)

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/encyclopediarepository/EncyclopediaRepository.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/encyclopediarepository/EncyclopediaRepository.kt
@@ -80,6 +80,7 @@ class EncyclopediaRepository(
 		text: String,
 		tags: Set<String>,
 		aliases: List<String> = emptyList(),
+		excludeFromDictionary: Boolean,
 	): EntryResult {
 		val result = validateEntry(name, oldEntryDef.type, text, tags, aliases)
 		if (result != EntryError.NONE) return EntryResult(result)
@@ -94,6 +95,7 @@ class EncyclopediaRepository(
 			text = text,
 			tags = cleanedTags,
 			aliases = cleanedAliases,
+			excludeFromDictionary = excludeFromDictionary,
 		)
 
 		_entryContentChangedFlow.emit(Unit)
@@ -153,6 +155,7 @@ class EncyclopediaRepository(
 		imagePath: String?,
 		forceId: Int? = null,
 		aliases: List<String> = emptyList(),
+		excludeFromDictionary: Boolean = false,
 	): EntryResult {
 		val result = validateEntry(name, type, text, tags, aliases)
 		if (result != EntryError.NONE) return EntryResult(result)
@@ -168,6 +171,7 @@ class EncyclopediaRepository(
 			text = text.trim(),
 			tags = cleanedTags,
 			aliases = cleanedAliases,
+			excludeFromDictionary = excludeFromDictionary,
 		)
 		val container = EntryContainer(entry)
 

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/encyclopediarepository/EncyclopediaService.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/encyclopediarepository/EncyclopediaService.kt
@@ -31,8 +31,10 @@ class EncyclopediaService(
 		imagePath: String?,
 		forceId: Int? = null,
 		aliases: List<String> = emptyList(),
+		excludeFromDictionary: Boolean = false,
 	): EntryResult {
-		val result = repository.createEntry(name, type, text, tags, imagePath, forceId, aliases)
+		val result =
+			repository.createEntry(name, type, text, tags, imagePath, forceId, aliases, excludeFromDictionary)
 		if (result.error == EntryError.NONE) statisticsRepository.markDirty()
 		return result
 	}
@@ -43,8 +45,9 @@ class EncyclopediaService(
 		text: String,
 		tags: Set<String>,
 		aliases: List<String> = emptyList(),
+		excludeFromDictionary: Boolean,
 	): EntryResult {
-		val result = repository.updateEntry(oldEntryDef, name, text, tags, aliases)
+		val result = repository.updateEntry(oldEntryDef, name, text, tags, aliases, excludeFromDictionary)
 		if (result.error == EntryError.NONE) statisticsRepository.markDirty()
 		return result
 	}

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/encyclopediarepository/entry/EntryContent.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/encyclopediarepository/entry/EntryContent.kt
@@ -13,6 +13,8 @@ data class EntryContent(
 	val text: String,
 	val tags: Set<String>,
 	val aliases: List<String> = emptyList(),
+	/** Keeps this entry's name and aliases out of the spell-check session dictionary. */
+	val excludeFromDictionary: Boolean = false,
 ) {
 	fun toDef(projectDef: ProjectDef): EntryDef = EntryDef(
 		projectDef = projectDef,

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/globalsettings/GlobalSettings.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/globalsettings/GlobalSettings.kt
@@ -77,6 +77,11 @@ data class NewUserExperience(
 data class SpellCheckerSettings(
 	val enabled: Boolean = true,
 	val enabledInFocusMode: Boolean = false,
+	/**
+	 * Add Encyclopedia entry names and aliases to the dictionary as session
+	 * words while a project is open. Never persisted to any OS dictionary.
+	 */
+	val includeEncyclopediaNames: Boolean = true,
 	@Serializable(with = LocaleSerializer::class)
 	val locale: Locale
 ) {

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/sync/projectsync/synchronizers/ClientEncyclopediaSynchronizer.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/sync/projectsync/synchronizers/ClientEncyclopediaSynchronizer.kt
@@ -69,6 +69,7 @@ class ClientEncyclopediaSynchronizer(
 			tags = entity.tags,
 			image = entity.image,
 			aliases = entity.aliases,
+			excludeFromDictionary = entity.excludeFromDictionary,
 		)
 	}
 
@@ -97,6 +98,7 @@ class ClientEncyclopediaSynchronizer(
 			tags = entry.tags,
 			image = image,
 			aliases = entry.aliases,
+			excludeFromDictionary = entry.excludeFromDictionary,
 		)
 	}
 
@@ -150,6 +152,7 @@ class ClientEncyclopediaSynchronizer(
 				text = serverEntity.text,
 				tags = serverEntity.tags,
 				aliases = serverEntity.aliases,
+				excludeFromDictionary = serverEntity.excludeFromDictionary,
 			)
 		} else {
 			encyclopediaService.createEntry(
@@ -160,6 +163,7 @@ class ClientEncyclopediaSynchronizer(
 				imagePath = null, // Always pass null here, we wrote the image our selves
 				forceId = serverEntity.id,
 				aliases = serverEntity.aliases,
+				excludeFromDictionary = serverEntity.excludeFromDictionary,
 			)
 		}
 

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/dependencyinjection/mainModule.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/dependencyinjection/mainModule.kt
@@ -117,6 +117,7 @@ import com.darkrockstudios.apps.hammer.common.server.ServerProjectApi
 import com.darkrockstudios.apps.hammer.common.server.ServerIdeasApi
 import com.darkrockstudios.apps.hammer.common.server.ServerProjectsApi
 import com.darkrockstudios.apps.hammer.common.server.WritingActivityApi
+import com.darkrockstudios.apps.hammer.common.spellcheck.ProjectDictionaryService
 import com.darkrockstudios.apps.hammer.common.spellcheck.ProjectSpellCheckRepository
 import com.darkrockstudios.apps.hammer.common.spellcheck.SpellCheckRepository
 import com.russhwolf.settings.Settings
@@ -289,6 +290,7 @@ val mainModule = module {
 		scoped<ProjectDataRepository>()
 		scoped<ProjectDataConflictBroker>()
 		scoped<ProjectSpellCheckRepository>()
+		scoped<ProjectDictionaryService>()
 
 		scoped<ReferenceIndexDatasource>()
 		scoped<ReferenceIndexRepository>()

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/spellcheck/DictionaryTokenizer.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/spellcheck/DictionaryTokenizer.kt
@@ -1,0 +1,19 @@
+package com.darkrockstudios.apps.hammer.common.spellcheck
+
+private val WHITESPACE = Regex("""\s+""")
+
+/**
+ * Splits entry names and aliases into single dictionary candidate words.
+ * The spell checker matches trimmed, lowercased single tokens only, so
+ * multi-word phrases must be split or they would silently never match.
+ * Surrounding punctuation is stripped ("Mr." -> "mr") while inner
+ * apostrophes and hyphens are kept ("d'Artagnan", "Jean-Luc").
+ * Blank and single-character tokens are dropped.
+ */
+fun tokenizeDictionaryWords(phrases: Iterable<String>): Set<String> =
+	phrases.asSequence()
+		.flatMap { phrase -> phrase.splitToSequence(WHITESPACE) }
+		.map { token -> token.trim { c -> !c.isLetterOrDigit() } }
+		.filter { token -> token.length > 1 }
+		.map { token -> token.lowercase() }
+		.toSet()

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/spellcheck/ProjectDictionaryService.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/spellcheck/ProjectDictionaryService.kt
@@ -3,8 +3,6 @@ package com.darkrockstudios.apps.hammer.common.spellcheck
 import com.darkrockstudios.apps.hammer.common.data.ProjectDef
 import com.darkrockstudios.apps.hammer.common.data.ProjectScoped
 import com.darkrockstudios.apps.hammer.common.data.encyclopediarepository.EncyclopediaRepository
-import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettingsStore
-import com.darkrockstudios.apps.hammer.common.data.projectdata.ProjectDataRepository
 import com.darkrockstudios.apps.hammer.common.dependencyinjection.DISPATCHER_DEFAULT
 import com.darkrockstudios.apps.hammer.common.dependencyinjection.ProjectDefScope
 import io.github.aakira.napier.Napier
@@ -16,8 +14,6 @@ import kotlinx.coroutines.cancel
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.debounce
-import kotlinx.coroutines.flow.distinctUntilChanged
-import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.launch
 import org.koin.core.component.KoinComponent
@@ -37,8 +33,7 @@ import kotlin.time.Duration.Companion.milliseconds
 class ProjectDictionaryService(
 	private val projectDef: ProjectDef,
 	private val encyclopediaRepository: EncyclopediaRepository,
-	private val projectDataRepository: ProjectDataRepository,
-	private val globalSettingsStore: GlobalSettingsStore,
+	private val projectSpellCheckRepository: ProjectSpellCheckRepository,
 	private val spellCheckRepository: SpellCheckRepository,
 ) : ScopeCallback, ProjectScoped, KoinComponent {
 
@@ -51,15 +46,9 @@ class ProjectDictionaryService(
 		projectScope.scope.registerCallback(this)
 		serviceScope.launch {
 			combine(
-				globalSettingsStore.globalSettingsUpdates
-					.map { it.spellCheckSettings.includeEncyclopediaNames }
-					.distinctUntilChanged(),
-				projectDataRepository.state
-					.onStart { projectDataRepository.load() }
-					.map { it?.data?.encyclopediaDictionary ?: true }
-					.distinctUntilChanged(),
+				projectSpellCheckRepository.encyclopediaDictionaryEnabled,
 				encyclopediaRepository.entryContentChangedFlow.onStart { emit(Unit) },
-			) { globalOn, projectOn, _ -> globalOn && projectOn }
+			) { enabled, _ -> enabled }
 				.debounce(REBUILD_DEBOUNCE)
 				.collect { enabled ->
 					if (enabled) {

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/spellcheck/ProjectDictionaryService.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/spellcheck/ProjectDictionaryService.kt
@@ -1,0 +1,104 @@
+package com.darkrockstudios.apps.hammer.common.spellcheck
+
+import com.darkrockstudios.apps.hammer.common.data.ProjectDef
+import com.darkrockstudios.apps.hammer.common.data.ProjectScoped
+import com.darkrockstudios.apps.hammer.common.data.encyclopediarepository.EncyclopediaRepository
+import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettingsStore
+import com.darkrockstudios.apps.hammer.common.data.projectdata.ProjectDataRepository
+import com.darkrockstudios.apps.hammer.common.dependencyinjection.DISPATCHER_DEFAULT
+import com.darkrockstudios.apps.hammer.common.dependencyinjection.ProjectDefScope
+import io.github.aakira.napier.Napier
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.FlowPreview
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.debounce
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.onStart
+import kotlinx.coroutines.launch
+import org.koin.core.component.KoinComponent
+import org.koin.core.component.inject
+import org.koin.core.qualifier.named
+import org.koin.core.scope.Scope
+import org.koin.core.scope.ScopeCallback
+import kotlin.coroutines.CoroutineContext
+import kotlin.time.Duration.Companion.milliseconds
+
+/**
+ * Feeds the project's Encyclopedia entry names and aliases to the spell checker as
+ * session words for the lifetime of the project scope. Gated on the global
+ * spell-check setting and the project's own toggle, both live-reactive.
+ */
+@OptIn(FlowPreview::class)
+class ProjectDictionaryService(
+	private val projectDef: ProjectDef,
+	private val encyclopediaRepository: EncyclopediaRepository,
+	private val projectDataRepository: ProjectDataRepository,
+	private val globalSettingsStore: GlobalSettingsStore,
+	private val spellCheckRepository: SpellCheckRepository,
+) : ScopeCallback, ProjectScoped, KoinComponent {
+
+	override val projectScope = ProjectDefScope(projectDef)
+
+	private val dispatcherDefault: CoroutineContext by inject(named(DISPATCHER_DEFAULT))
+	private val serviceScope = CoroutineScope(dispatcherDefault)
+
+	init {
+		projectScope.scope.registerCallback(this)
+		serviceScope.launch {
+			combine(
+				globalSettingsStore.globalSettingsUpdates
+					.map { it.spellCheckSettings.includeEncyclopediaNames }
+					.distinctUntilChanged(),
+				projectDataRepository.state
+					.onStart { projectDataRepository.load() }
+					.map { it?.data?.encyclopediaDictionary ?: true }
+					.distinctUntilChanged(),
+				encyclopediaRepository.entryContentChangedFlow.onStart { emit(Unit) },
+			) { globalOn, projectOn, _ -> globalOn && projectOn }
+				.debounce(REBUILD_DEBOUNCE)
+				.collect { enabled ->
+					if (enabled) {
+						rebuild()
+					} else {
+						spellCheckRepository.clearSessionWords(projectDef)
+					}
+				}
+		}
+	}
+
+	@Suppress("TooGenericExceptionCaught") // Background rebuild must not crash on any failure
+	private suspend fun rebuild() {
+		try {
+			// entryListFlow's replay cache is not refreshed by entry writes, so force a
+			// reload before reading defs - renames change EntryDef.name.
+			encyclopediaRepository.loadEntriesImperative()
+			val defs = encyclopediaRepository.ensureEntriesLoaded()
+			val words = coroutineScope {
+				defs.map { def ->
+					async {
+						val entry = encyclopediaRepository.loadEntry(def).entry
+						if (entry.excludeFromDictionary) emptySet()
+						else tokenizeDictionaryWords(listOf(entry.name) + entry.aliases)
+					}
+				}.awaitAll()
+			}.flatten().toSet()
+			spellCheckRepository.setSessionWords(projectDef, words)
+		} catch (t: Throwable) {
+			Napier.e("ProjectDictionaryService rebuild failed", t)
+		}
+	}
+
+	override fun onScopeClose(scope: Scope) {
+		spellCheckRepository.clearSessionWords(projectDef)
+		serviceScope.cancel("ProjectDictionaryService closed")
+	}
+
+	private companion object {
+		val REBUILD_DEBOUNCE = 150.milliseconds
+	}
+}

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/spellcheck/ProjectSpellCheckRepository.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/spellcheck/ProjectSpellCheckRepository.kt
@@ -42,4 +42,19 @@ class ProjectSpellCheckRepository(
 	) { checker, allowed ->
 		if (allowed) checker else null
 	}.distinctUntilChanged()
+
+	/**
+	 * True while encyclopedia names feed the spell-check session dictionary:
+	 * the global setting AND this project's own toggle. Gates the feature's
+	 * per-entry UI as well as the word loading itself.
+	 */
+	val encyclopediaDictionaryEnabled: Flow<Boolean> = combine(
+		globalSettingsStore.globalSettingsUpdates,
+		projectDataRepository.state,
+	) { settings, stored ->
+		settings.spellCheckSettings.includeEncyclopediaNames &&
+			(stored?.data?.encyclopediaDictionary ?: true)
+	}
+		.onStart { projectDataRepository.load() }
+		.distinctUntilChanged()
 }

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/spellcheck/SpellCheckRepository.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/spellcheck/SpellCheckRepository.kt
@@ -1,5 +1,6 @@
 package com.darkrockstudios.apps.hammer.common.spellcheck
 
+import com.darkrockstudios.apps.hammer.common.data.ProjectDef
 import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettingsStore
 import com.darkrockstudios.apps.hammer.common.dependencyinjection.injectDefaultDispatcher
 import com.darkrockstudios.apps.hammer.common.util.Locale
@@ -12,6 +13,8 @@ import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import org.koin.core.component.KoinComponent
 
 class SpellCheckRepository(
@@ -31,18 +34,75 @@ class SpellCheckRepository(
 	private var currentLanguage: Locale? = null
 	private var currentEnabled: Boolean? = null
 
-	private suspend fun applySpellCheckSettings(enabled: Boolean, language: Locale) {
+	private val mutex = Mutex()
+	private var sessionWords: Map<ProjectDef, Set<String>> = emptyMap()
+	private var appliedCandidates: Set<String> = emptySet()
+
+	/**
+	 * Replaces [owner]'s session words. Held in-memory only (DictionaryScope.AppLocal),
+	 * unioned across owners, and re-applied whenever a new checker is created.
+	 * Non-suspend so it is callable from ScopeCallback.onScopeClose.
+	 */
+	fun setSessionWords(owner: ProjectDef, words: Set<String>) {
+		scope.launch {
+			mutex.withLock {
+				if (sessionWords[owner] == words) return@withLock
+				sessionWords = sessionWords + (owner to words)
+				recreateCheckerWithSessionWords()
+			}
+		}
+	}
+
+	fun clearSessionWords(owner: ProjectDef) {
+		scope.launch {
+			mutex.withLock {
+				if (owner !in sessionWords) return@withLock
+				sessionWords = sessionWords - owner
+				recreateCheckerWithSessionWords()
+			}
+		}
+	}
+
+	/**
+	 * Downstream editors only re-run a full scan when the checker identity changes,
+	 * so word-set changes emit a fresh instance rather than mutating the current one.
+	 */
+	private suspend fun recreateCheckerWithSessionWords() {
+		val language = currentLanguage ?: return
+		if (sessionWordUnion() == appliedCandidates) return
+
+		val checker = spellCheckFactory.createSpellChecker(language.toSpLocale())
+		applySessionWords(checker)
+		_dictionaryFlow.tryEmit(checker)
+	}
+
+	private fun sessionWordUnion(): Set<String> =
+		sessionWords.values.flatMapTo(mutableSetOf()) { it }
+
+	// Words the base dictionary already accepts are filtered, so only unknown spellings are added.
+	private suspend fun applySessionWords(checker: PlatformSpellChecker) {
+		val union = sessionWordUnion()
+		appliedCandidates = union
+		val toAdd = union.filterNot { checker.isWordCorrect(it) }
+		if (toAdd.isNotEmpty()) {
+			checker.setUserDictionary(toAdd)
+			Napier.i("Spell Check: applied ${toAdd.size} session words")
+		}
+	}
+
+	private suspend fun applySpellCheckSettings(enabled: Boolean, language: Locale) = mutex.withLock {
 		if (!enabled) {
 			if (currentEnabled != false) {
 				currentEnabled = false
 				currentLanguage = null
+				appliedCandidates = emptySet()
 				_dictionaryFlow.tryEmit(null)
 				Napier.i("Spell Check disabled: dictionary cleared")
 			}
-			return
+			return@withLock
 		}
 
-		if (currentEnabled == true && currentLanguage == language) return
+		if (currentEnabled == true && currentLanguage == language) return@withLock
 
 		val spLocale = language.toSpLocale()
 		if (spellCheckFactory.hasLanguage(spLocale).not()) {
@@ -51,6 +111,7 @@ class SpellCheckRepository(
 			val checker = spellCheckFactory.createSpellChecker(spLocale)
 			currentLanguage = language
 			currentEnabled = true
+			applySessionWords(checker)
 			_dictionaryFlow.tryEmit(checker)
 
 			Napier.i("Spell Checker loaded for: ${language.toLanguageTag()}")

--- a/common/src/commonTest/kotlin/com/darkrockstudios/apps/hammer/common/spellcheck/DictionaryTokenizerTest.kt
+++ b/common/src/commonTest/kotlin/com/darkrockstudios/apps/hammer/common/spellcheck/DictionaryTokenizerTest.kt
@@ -1,0 +1,60 @@
+package com.darkrockstudios.apps.hammer.common.spellcheck
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class DictionaryTokenizerTest {
+
+	@Test
+	fun `multi-word names are split into single tokens`() {
+		assertEquals(
+			setOf("bob", "roberts"),
+			tokenizeDictionaryWords(listOf("Bob Roberts")),
+		)
+	}
+
+	@Test
+	fun `tokens are lowercased`() {
+		assertEquals(
+			setOf("zaltharion"),
+			tokenizeDictionaryWords(listOf("ZALTHARION")),
+		)
+	}
+
+	@Test
+	fun `surrounding punctuation is stripped`() {
+		assertEquals(
+			setOf("mr", "smith"),
+			tokenizeDictionaryWords(listOf("Mr. Smith")),
+		)
+	}
+
+	@Test
+	fun `inner apostrophes and hyphens are kept`() {
+		assertEquals(
+			setOf("d'artagnan", "jean-luc"),
+			tokenizeDictionaryWords(listOf("d'Artagnan", "Jean-Luc")),
+		)
+	}
+
+	@Test
+	fun `blank and single-character tokens are dropped`() {
+		assertEquals(
+			setOf("initial"),
+			tokenizeDictionaryWords(listOf("A Initial", "  ", "-", "x")),
+		)
+	}
+
+	@Test
+	fun `duplicate tokens across phrases are deduped case-insensitively`() {
+		assertEquals(
+			setOf("kastle", "rock"),
+			tokenizeDictionaryWords(listOf("Kastle Rock", "kastle", "KASTLE")),
+		)
+	}
+
+	@Test
+	fun `empty input produces empty output`() {
+		assertEquals(emptySet(), tokenizeDictionaryWords(emptyList()))
+	}
+}

--- a/common/src/desktopTest/kotlin/components/encyclopedia/ViewEntryComponentTest.kt
+++ b/common/src/desktopTest/kotlin/components/encyclopedia/ViewEntryComponentTest.kt
@@ -90,7 +90,8 @@ class ViewEntryComponentTest : BaseTest() {
 				oldEntryDef = origDef,
 				name = newName,
 				text = oldEntry.text,
-				tags = oldEntry.tags
+				tags = oldEntry.tags,
+				excludeFromDictionary = false,
 			)
 		} returns EntryResult(newContainer, EntryError.NONE)
 
@@ -136,7 +137,8 @@ class ViewEntryComponentTest : BaseTest() {
 				oldEntryDef = origDef,
 				name = newName,
 				text = oldEntry.text,
-				tags = oldEntry.tags
+				tags = oldEntry.tags,
+				excludeFromDictionary = false,
 			)
 		} returns EntryResult(newContainer, EntryError.NAME_INVALID_CHARACTERS)
 

--- a/common/src/desktopTest/kotlin/repositories/encyclopedia/EncyclopediaRepositoryTest.kt
+++ b/common/src/desktopTest/kotlin/repositories/encyclopedia/EncyclopediaRepositoryTest.kt
@@ -96,7 +96,8 @@ class EncyclopediaRepositoryTest : BaseTest() {
 			oldEntryDef = origDef,
 			name = newValidName,
 			text = entry.text,
-			tags = entry.tags
+			tags = entry.tags,
+			excludeFromDictionary = false,
 		)
 
 
@@ -127,7 +128,8 @@ class EncyclopediaRepositoryTest : BaseTest() {
 			oldEntryDef = origDef,
 			name = newName,
 			text = oldEntry.text,
-			tags = oldEntry.tags
+			tags = oldEntry.tags,
+			excludeFromDictionary = false,
 		)
 
 		assertInvalid(EntryError.NAME_INVALID_CHARACTERS, result, repo, oldEntry, newEntry)
@@ -142,7 +144,8 @@ class EncyclopediaRepositoryTest : BaseTest() {
 			oldEntryDef = origDef,
 			name = newName,
 			text = oldEntry.text,
-			tags = oldEntry.tags
+			tags = oldEntry.tags,
+			excludeFromDictionary = false,
 		)
 
 		assertInvalid(EntryError.NAME_TOO_SHORT, result, repo, oldEntry, newEntry)
@@ -157,7 +160,8 @@ class EncyclopediaRepositoryTest : BaseTest() {
 			oldEntryDef = origDef,
 			name = newName,
 			text = oldEntry.text,
-			tags = oldEntry.tags
+			tags = oldEntry.tags,
+			excludeFromDictionary = false,
 		)
 
 		assertInvalid(EntryError.NAME_TOO_LONG, result, repo, oldEntry, newEntry)
@@ -368,6 +372,7 @@ class EncyclopediaRepositoryTest : BaseTest() {
 				name = entry1().name,
 				text = "updated text",
 				tags = entry1().tags,
+				excludeFromDictionary = false,
 			)
 			awaitItem()
 

--- a/common/src/desktopTest/kotlin/repositories/encyclopedia/EncyclopediaServiceTest.kt
+++ b/common/src/desktopTest/kotlin/repositories/encyclopedia/EncyclopediaServiceTest.kt
@@ -131,6 +131,7 @@ class EncyclopediaServiceTest : BaseTest() {
 			name = "A new name",
 			text = entry1().text,
 			tags = entry1().tags,
+			excludeFromDictionary = false,
 		)
 
 		assertEquals(EntryError.NONE, result.error)
@@ -145,6 +146,7 @@ class EncyclopediaServiceTest : BaseTest() {
 			name = "",
 			text = entry1().text,
 			tags = entry1().tags,
+			excludeFromDictionary = false,
 		)
 
 		assertEquals(EntryError.NAME_TOO_SHORT, result.error)

--- a/common/src/desktopTest/kotlin/repositories/spellcheck/ProjectDictionaryServiceTest.kt
+++ b/common/src/desktopTest/kotlin/repositories/spellcheck/ProjectDictionaryServiceTest.kt
@@ -1,0 +1,290 @@
+package repositories.spellcheck
+
+import PROJECT_EMPTY_NAME
+import com.darkrockstudios.apps.hammer.common.data.encyclopediarepository.EncyclopediaDatasource
+import com.darkrockstudios.apps.hammer.common.data.encyclopediarepository.EncyclopediaRepository
+import com.darkrockstudios.apps.hammer.common.data.encyclopediarepository.entry.EntryType
+import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettings
+import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettingsStore
+import com.darkrockstudios.apps.hammer.common.data.globalsettings.SpellCheckerSettings
+import com.darkrockstudios.apps.hammer.common.data.globalsettings.datasource.GlobalSettingsDatasource
+import com.darkrockstudios.apps.hammer.common.data.globalsettings.datasource.ServerSettingsDatasource
+import com.darkrockstudios.apps.hammer.common.data.id.IdAllocator
+import com.darkrockstudios.apps.hammer.common.data.projectdata.ProjectDataDatasource
+import com.darkrockstudios.apps.hammer.common.data.projectdata.ProjectDataRepository
+import com.darkrockstudios.apps.hammer.common.data.sync.projectsync.SyncDataDatasource
+import com.darkrockstudios.apps.hammer.common.data.sync.projectsync.SyncJournal
+import com.darkrockstudios.apps.hammer.common.dependencyinjection.ProjectDefScope
+import com.darkrockstudios.apps.hammer.common.dependencyinjection.createTomlSerializer
+import com.darkrockstudios.apps.hammer.common.fileio.ExternalFileIo
+import com.darkrockstudios.apps.hammer.common.spellcheck.ProjectDictionaryService
+import com.darkrockstudios.apps.hammer.common.spellcheck.SpellCheckRepository
+import com.darkrockstudios.apps.hammer.common.util.Locale
+import com.darkrockstudios.libs.platformspellchecker.PlatformSpellChecker
+import com.darkrockstudios.libs.platformspellchecker.PlatformSpellCheckerFactory
+import createProject
+import getProjectDef
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.Runs
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import okio.fakefilesystem.FakeFileSystem
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.koin.dsl.module
+import utils.BaseTest
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Classical-style: a real [ProjectDictionaryService] over a real [EncyclopediaRepository],
+ * [ProjectDataRepository], [GlobalSettingsStore] and [SpellCheckRepository] (FakeFileSystem-backed).
+ * Only the platform spell checker factory and settings/sync persistence are mocked.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class ProjectDictionaryServiceTest : BaseTest() {
+
+	private val projectDef = getProjectDef(PROJECT_EMPTY_NAME)
+
+	private lateinit var globalSettingsDatasource: GlobalSettingsDatasource
+	private lateinit var serverSettingsDatasource: ServerSettingsDatasource
+	private lateinit var factory: PlatformSpellCheckerFactory
+	private lateinit var fileSystem: FakeFileSystem
+	private lateinit var idAllocator: IdAllocator
+	private lateinit var syncJournal: SyncJournal
+	private lateinit var encyclopediaRepository: EncyclopediaRepository
+	private lateinit var projectDataRepository: ProjectDataRepository
+	private lateinit var globalSettingsStore: GlobalSettingsStore
+	private lateinit var spellCheckRepository: SpellCheckRepository
+
+	/** Words applied per created checker, in creation order. Empty set = checker created with no session words. */
+	private val appliedPerChecker = mutableListOf<Set<String>>()
+
+	private var nextId = 1
+
+	@BeforeEach
+	override fun setup() {
+		super.setup()
+		globalSettingsDatasource = mockk()
+		serverSettingsDatasource = mockk()
+		factory = mockk()
+		idAllocator = mockk()
+		syncJournal = mockk()
+		appliedPerChecker.clear()
+		nextId = 1
+
+		every { factory.hasLanguage(any()) } returns true
+		coEvery { factory.createSpellChecker(any()) } answers {
+			val index = appliedPerChecker.size
+			appliedPerChecker.add(emptySet())
+			val checker = mockk<PlatformSpellChecker>()
+			coEvery { checker.isWordCorrect(any()) } returns false
+			coEvery { checker.setUserDictionary(any()) } answers {
+				appliedPerChecker[index] = firstArg<Collection<String>>().toSet()
+			}
+			checker
+		}
+		coEvery { globalSettingsDatasource.loadSettings() } returns GlobalSettings(
+			projectsDirectory = "/projects",
+			spellCheckSettings = SpellCheckerSettings(
+				enabled = true,
+				locale = Locale.forLanguageTag("en"),
+			),
+		)
+		coEvery { globalSettingsDatasource.storeSettings(any()) } just Runs
+		coEvery { serverSettingsDatasource.loadServerSettings(any()) } returns null
+		every { syncJournal.isServerSynchronized() } returns false
+		coEvery { idAllocator.claimNextId() } answers { nextId++ }
+
+		val syncDataDatasource = mockk<SyncDataDatasource>(relaxed = true)
+		setupKoin(module {
+			scope<ProjectDefScope> {
+				scoped { projectDef }
+				scoped { syncDataDatasource }
+			}
+		})
+
+		fileSystem = FakeFileSystem()
+		createProject(fileSystem, PROJECT_EMPTY_NAME)
+
+		val toml = createTomlSerializer()
+		encyclopediaRepository = EncyclopediaRepository(
+			projectDef = projectDef,
+			idAllocator = idAllocator,
+			datasource = EncyclopediaDatasource(
+				projectDef = projectDef,
+				toml = toml,
+				fileSystem = fileSystem,
+				externalFileIo = mockk<ExternalFileIo>(),
+			),
+			syncJournal = syncJournal,
+		)
+		projectDataRepository = ProjectDataRepository(
+			ProjectDataDatasource(fileSystem, toml, projectDef),
+			projectDef,
+		)
+		globalSettingsStore = GlobalSettingsStore(globalSettingsDatasource, serverSettingsDatasource)
+		spellCheckRepository = SpellCheckRepository(globalSettingsStore, factory)
+	}
+
+	private fun createService() = ProjectDictionaryService(
+		projectDef = projectDef,
+		encyclopediaRepository = encyclopediaRepository,
+		projectDataRepository = projectDataRepository,
+		globalSettingsStore = globalSettingsStore,
+		spellCheckRepository = spellCheckRepository,
+	)
+
+	private suspend fun createEntry(
+		name: String,
+		type: EntryType = EntryType.PERSON,
+		aliases: List<String> = emptyList(),
+		excludeFromDictionary: Boolean = false,
+	) {
+		encyclopediaRepository.createEntry(
+			name = name,
+			type = type,
+			text = "text",
+			tags = emptySet(),
+			imagePath = null,
+			aliases = aliases,
+			excludeFromDictionary = excludeFromDictionary,
+		)
+	}
+
+	@Test
+	fun `entry names and aliases of all types are tokenized and pushed on start`() = scope.runTest {
+		createEntry("Zaltharion", type = EntryType.PERSON, aliases = listOf("Mr. Zal"))
+		createEntry("Kastle Rock", type = EntryType.PLACE)
+		createEntry("Vorpal Sword", type = EntryType.THING)
+		createEntry("The Sundering", type = EntryType.EVENT)
+		createEntry("Weirding", type = EntryType.IDEA)
+
+		createService()
+		advanceUntilIdle()
+
+		assertEquals(
+			setOf(
+				"zaltharion", "mr", "zal",
+				"kastle", "rock",
+				"vorpal", "sword",
+				"the", "sundering",
+				"weirding",
+			),
+			appliedPerChecker.last(),
+		)
+	}
+
+	@Test
+	fun `entry changes after start push an updated word set`() = scope.runTest {
+		createEntry("Zaltharion")
+		createService()
+		advanceUntilIdle()
+
+		createEntry("Kastle")
+		advanceUntilIdle()
+
+		assertEquals(setOf("zaltharion", "kastle"), appliedPerChecker.last())
+	}
+
+	@Test
+	fun `text-only entry edits do not recreate the checker`() = scope.runTest {
+		createEntry("Zaltharion")
+		createService()
+		advanceUntilIdle()
+		val checkersAfterStart = appliedPerChecker.size
+
+		val def = encyclopediaRepository.ensureEntriesLoaded().single()
+		encyclopediaRepository.updateEntry(
+			oldEntryDef = def,
+			name = def.name,
+			text = "new text",
+			tags = emptySet(),
+			excludeFromDictionary = false,
+		)
+		advanceUntilIdle()
+
+		assertEquals(checkersAfterStart, appliedPerChecker.size)
+	}
+
+	@Test
+	fun `disabling the global setting clears the words and re-enabling restores them`() = scope.runTest {
+		createEntry("Zaltharion")
+		createService()
+		advanceUntilIdle()
+		assertEquals(setOf("zaltharion"), appliedPerChecker.last())
+
+		globalSettingsStore.updateSettings {
+			it.copy(spellCheckSettings = it.spellCheckSettings.copy(includeEncyclopediaNames = false))
+		}
+		advanceUntilIdle()
+		assertEquals(emptySet(), appliedPerChecker.last())
+
+		globalSettingsStore.updateSettings {
+			it.copy(spellCheckSettings = it.spellCheckSettings.copy(includeEncyclopediaNames = true))
+		}
+		advanceUntilIdle()
+		assertEquals(setOf("zaltharion"), appliedPerChecker.last())
+	}
+
+	@Test
+	fun `disabling the per-project setting clears the words`() = scope.runTest {
+		createEntry("Zaltharion")
+		createService()
+		advanceUntilIdle()
+		assertEquals(setOf("zaltharion"), appliedPerChecker.last())
+
+		projectDataRepository.updateData { it.copy(encyclopediaDictionary = false) }
+		advanceUntilIdle()
+
+		assertEquals(emptySet(), appliedPerChecker.last())
+	}
+
+	@Test
+	fun `an excluded entry contributes no words`() = scope.runTest {
+		createEntry("Zaltharion")
+		createEntry("Secretname", excludeFromDictionary = true, aliases = listOf("Hiddenalias"))
+
+		createService()
+		advanceUntilIdle()
+
+		assertEquals(setOf("zaltharion"), appliedPerChecker.last())
+	}
+
+	@Test
+	fun `closing the project scope clears the words`() = scope.runTest {
+		createEntry("Zaltharion")
+		val service = createService()
+		advanceUntilIdle()
+		assertEquals(setOf("zaltharion"), appliedPerChecker.last())
+
+		service.projectScope.scope.close()
+		advanceUntilIdle()
+
+		assertEquals(emptySet(), appliedPerChecker.last())
+	}
+
+	@Test
+	fun `renaming an entry replaces its old tokens`() = scope.runTest {
+		createEntry("Zaltharion")
+		createService()
+		advanceUntilIdle()
+
+		val def = encyclopediaRepository.ensureEntriesLoaded().single()
+		encyclopediaRepository.updateEntry(
+			oldEntryDef = def,
+			name = "Velcaryn",
+			text = "text",
+			tags = emptySet(),
+			excludeFromDictionary = false,
+		)
+		advanceUntilIdle()
+
+		assertEquals(setOf("velcaryn"), appliedPerChecker.last())
+		assertTrue(appliedPerChecker.none { "zaltharion" in it && "velcaryn" in it })
+	}
+}

--- a/common/src/desktopTest/kotlin/repositories/spellcheck/ProjectDictionaryServiceTest.kt
+++ b/common/src/desktopTest/kotlin/repositories/spellcheck/ProjectDictionaryServiceTest.kt
@@ -18,6 +18,7 @@ import com.darkrockstudios.apps.hammer.common.dependencyinjection.ProjectDefScop
 import com.darkrockstudios.apps.hammer.common.dependencyinjection.createTomlSerializer
 import com.darkrockstudios.apps.hammer.common.fileio.ExternalFileIo
 import com.darkrockstudios.apps.hammer.common.spellcheck.ProjectDictionaryService
+import com.darkrockstudios.apps.hammer.common.spellcheck.ProjectSpellCheckRepository
 import com.darkrockstudios.apps.hammer.common.spellcheck.SpellCheckRepository
 import com.darkrockstudios.apps.hammer.common.util.Locale
 import com.darkrockstudios.libs.platformspellchecker.PlatformSpellChecker
@@ -134,8 +135,12 @@ class ProjectDictionaryServiceTest : BaseTest() {
 	private fun createService() = ProjectDictionaryService(
 		projectDef = projectDef,
 		encyclopediaRepository = encyclopediaRepository,
-		projectDataRepository = projectDataRepository,
-		globalSettingsStore = globalSettingsStore,
+		projectSpellCheckRepository = ProjectSpellCheckRepository(
+			spellCheckRepository = spellCheckRepository,
+			globalSettingsStore = globalSettingsStore,
+			projectDataRepository = projectDataRepository,
+			projectDef = projectDef,
+		),
 		spellCheckRepository = spellCheckRepository,
 	)
 

--- a/common/src/desktopTest/kotlin/repositories/spellcheck/SpellCheckRepositoryTest.kt
+++ b/common/src/desktopTest/kotlin/repositories/spellcheck/SpellCheckRepositoryTest.kt
@@ -12,6 +12,8 @@ import com.darkrockstudios.apps.hammer.common.util.Locale
 import com.darkrockstudios.libs.platformspellchecker.PlatformSpellChecker
 import com.darkrockstudios.libs.platformspellchecker.PlatformSpellCheckerFactory
 import com.darkrockstudios.libs.platformspellchecker.SpLocale
+import getProject1Def
+import getProjectDef
 import io.mockk.Runs
 import io.mockk.coEvery
 import io.mockk.coVerify
@@ -187,6 +189,209 @@ class SpellCheckRepositoryTest : BaseTest() {
 			assertSame(checker, awaitItem())
 			cancelAndConsumeRemainingEvents()
 		}
+	}
+
+	private fun sessionCapableChecker(correctWords: Set<String> = emptySet()): Pair<PlatformSpellChecker, MutableList<Collection<String>>> {
+		val applied = mutableListOf<Collection<String>>()
+		val checker = mockk<PlatformSpellChecker>()
+		coEvery { checker.isWordCorrect(any()) } answers { firstArg<String>() in correctWords }
+		coEvery { checker.setUserDictionary(any()) } answers { applied.add(firstArg()); Unit }
+		return checker to applied
+	}
+
+	@Test
+	fun `setSessionWords emits a new checker carrying the words`() = scope.runTest {
+		val (first, _) = sessionCapableChecker()
+		val (second, secondApplied) = sessionCapableChecker()
+		every { factory.hasLanguage(any()) } returns true
+		coEvery { factory.createSpellChecker(any()) } returnsMany listOf(first, second)
+
+		val repo = SpellCheckRepository(settingsStore(Locale.forLanguageTag("en")), factory)
+
+		repo.dictionaryFlow.test {
+			assertSame(first, awaitItem())
+
+			repo.setSessionWords(getProject1Def(), setOf("zaltharion", "kastle"))
+
+			assertSame(second, awaitItem())
+			assertEquals(setOf("zaltharion", "kastle"), secondApplied.single().toSet())
+			cancelAndConsumeRemainingEvents()
+		}
+	}
+
+	@Test
+	fun `words the base dictionary already accepts are not added`() = scope.runTest {
+		val (first, _) = sessionCapableChecker()
+		val (second, secondApplied) = sessionCapableChecker(correctWords = setOf("paris"))
+		every { factory.hasLanguage(any()) } returns true
+		coEvery { factory.createSpellChecker(any()) } returnsMany listOf(first, second)
+
+		val repo = SpellCheckRepository(settingsStore(Locale.forLanguageTag("en")), factory)
+
+		repo.dictionaryFlow.test {
+			assertSame(first, awaitItem())
+
+			repo.setSessionWords(getProject1Def(), setOf("paris", "zaltharion"))
+
+			assertSame(second, awaitItem())
+			assertEquals(setOf("zaltharion"), secondApplied.single().toSet())
+			cancelAndConsumeRemainingEvents()
+		}
+	}
+
+	@Test
+	fun `locale change re-applies session words to the new checker`() = scope.runTest {
+		val (en, _) = sessionCapableChecker()
+		val (enWithWords, _) = sessionCapableChecker()
+		val (fr, frApplied) = sessionCapableChecker()
+		every { factory.hasLanguage(any()) } returns true
+		coEvery { factory.createSpellChecker(SpLocale("en")) } returnsMany listOf(en, enWithWords)
+		coEvery { factory.createSpellChecker(SpLocale("fr")) } returns fr
+		coEvery { globalSettingsDatasource.storeSettings(any()) } just Runs
+
+		val store = settingsStore(Locale.forLanguageTag("en"))
+		val repo = SpellCheckRepository(store, factory)
+
+		repo.dictionaryFlow.test {
+			assertSame(en, awaitItem())
+
+			repo.setSessionWords(getProject1Def(), setOf("zaltharion"))
+			assertSame(enWithWords, awaitItem())
+
+			store.updateSettings { settings ->
+				settings.copy(
+					spellCheckSettings = settings.spellCheckSettings.copy(
+						locale = Locale.forLanguageTag("fr")
+					)
+				)
+			}
+
+			assertSame(fr, awaitItem())
+			assertEquals(setOf("zaltharion"), frApplied.single().toSet())
+			cancelAndConsumeRemainingEvents()
+		}
+	}
+
+	@Test
+	fun `session words set while disabled are applied on re-enable`() = scope.runTest {
+		val (checker, applied) = sessionCapableChecker()
+		every { factory.hasLanguage(any()) } returns true
+		coEvery { factory.createSpellChecker(SpLocale("en")) } returns checker
+		coEvery { globalSettingsDatasource.storeSettings(any()) } just Runs
+
+		val store = settingsStore(Locale.forLanguageTag("en"), enabled = false)
+		val repo = SpellCheckRepository(store, factory)
+		advanceUntilIdle()
+
+		repo.setSessionWords(getProject1Def(), setOf("zaltharion"))
+		advanceUntilIdle()
+		coVerify(exactly = 0) { factory.createSpellChecker(any()) }
+
+		repo.dictionaryFlow.test {
+			assertEquals(null, awaitItem())
+
+			store.updateSettings { settings ->
+				settings.copy(
+					spellCheckSettings = settings.spellCheckSettings.copy(enabled = true)
+				)
+			}
+
+			assertSame(checker, awaitItem())
+			assertEquals(setOf("zaltharion"), applied.single().toSet())
+			cancelAndConsumeRemainingEvents()
+		}
+	}
+
+	@Test
+	fun `clearSessionWords emits a fresh checker without the words`() = scope.runTest {
+		val (first, _) = sessionCapableChecker()
+		val (second, secondApplied) = sessionCapableChecker()
+		val (third, thirdApplied) = sessionCapableChecker()
+		every { factory.hasLanguage(any()) } returns true
+		coEvery { factory.createSpellChecker(any()) } returnsMany listOf(first, second, third)
+
+		val repo = SpellCheckRepository(settingsStore(Locale.forLanguageTag("en")), factory)
+
+		repo.dictionaryFlow.test {
+			assertSame(first, awaitItem())
+
+			repo.setSessionWords(getProject1Def(), setOf("zaltharion"))
+			assertSame(second, awaitItem())
+			assertEquals(setOf("zaltharion"), secondApplied.single().toSet())
+
+			repo.clearSessionWords(getProject1Def())
+			assertSame(third, awaitItem())
+			assertTrue(thirdApplied.isEmpty())
+			cancelAndConsumeRemainingEvents()
+		}
+	}
+
+	@Test
+	fun `clearing an owner that contributed nothing does not recreate the checker`() = scope.runTest {
+		val (checker, _) = sessionCapableChecker()
+		var loadCount = 0
+		every { factory.hasLanguage(any()) } returns true
+		coEvery { factory.createSpellChecker(any()) } answers { loadCount++; checker }
+
+		val repo = SpellCheckRepository(settingsStore(Locale.forLanguageTag("en")), factory)
+		advanceUntilIdle()
+		val loadsAfterInit = loadCount
+
+		repo.clearSessionWords(getProject1Def())
+		advanceUntilIdle()
+
+		assertEquals(loadsAfterInit, loadCount)
+	}
+
+	@Test
+	fun `session words are unioned across owners and cleared per-owner`() = scope.runTest {
+		val (first, _) = sessionCapableChecker()
+		val (second, secondApplied) = sessionCapableChecker()
+		val (third, thirdApplied) = sessionCapableChecker()
+		val (fourth, fourthApplied) = sessionCapableChecker()
+		every { factory.hasLanguage(any()) } returns true
+		coEvery { factory.createSpellChecker(any()) } returnsMany listOf(first, second, third, fourth)
+
+		val projectA = getProject1Def()
+		val projectB = getProjectDef("Project B")
+		val repo = SpellCheckRepository(settingsStore(Locale.forLanguageTag("en")), factory)
+
+		repo.dictionaryFlow.test {
+			assertSame(first, awaitItem())
+
+			repo.setSessionWords(projectA, setOf("zaltharion"))
+			assertSame(second, awaitItem())
+			assertEquals(setOf("zaltharion"), secondApplied.single().toSet())
+
+			repo.setSessionWords(projectB, setOf("kastle"))
+			assertSame(third, awaitItem())
+			assertEquals(setOf("zaltharion", "kastle"), thirdApplied.single().toSet())
+
+			repo.clearSessionWords(projectA)
+			assertSame(fourth, awaitItem())
+			assertEquals(setOf("kastle"), fourthApplied.single().toSet())
+			cancelAndConsumeRemainingEvents()
+		}
+	}
+
+	@Test
+	fun `pushing an identical word set does not recreate the checker`() = scope.runTest {
+		val (checker, _) = sessionCapableChecker()
+		var loadCount = 0
+		every { factory.hasLanguage(any()) } returns true
+		coEvery { factory.createSpellChecker(any()) } answers { loadCount++; checker }
+
+		val repo = SpellCheckRepository(settingsStore(Locale.forLanguageTag("en")), factory)
+		advanceUntilIdle()
+
+		repo.setSessionWords(getProject1Def(), setOf("zaltharion"))
+		advanceUntilIdle()
+		val loadsAfterFirstPush = loadCount
+
+		repo.setSessionWords(getProject1Def(), setOf("zaltharion"))
+		advanceUntilIdle()
+
+		assertEquals(loadsAfterFirstPush, loadCount)
 	}
 
 	@Test

--- a/common/src/desktopTest/kotlin/utils/ComponentTest.kt
+++ b/common/src/desktopTest/kotlin/utils/ComponentTest.kt
@@ -108,6 +108,7 @@ open class ComponentTest : BaseTest() {
 					mockk(relaxed = true) {
 						every { spellCheckAllowed } returns emptyFlow()
 						every { dictionaryFlow } returns emptyFlow()
+						every { encyclopediaDictionaryEnabled } returns emptyFlow()
 					}
 				}
 			},

--- a/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/encyclopedia/CreateEntryUi.kt
+++ b/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/encyclopedia/CreateEntryUi.kt
@@ -45,6 +45,7 @@ import com.darkrockstudios.apps.hammer.common.compose.designsystem.HdHairlineBut
 import com.darkrockstudios.apps.hammer.common.compose.designsystem.HdHairlineField
 import com.darkrockstudios.apps.hammer.common.compose.designsystem.HdHairlineImageDrop
 import com.darkrockstudios.apps.hammer.common.compose.designsystem.HdHairlineTagField
+import com.darkrockstudios.apps.hammer.common.compose.designsystem.HdHairlineToggleRow
 import com.darkrockstudios.apps.hammer.common.compose.designsystem.HdHairlineTypePicker
 import com.darkrockstudios.apps.hammer.common.compose.designsystem.HdMonoLabel
 import com.darkrockstudios.apps.hammer.common.compose.designsystem.glyph
@@ -75,6 +76,8 @@ import com.darkrockstudios.apps.hammer.encyclopedia_create_entry_image_too_large
 import com.darkrockstudios.apps.hammer.encyclopedia_create_entry_name_label
 import com.darkrockstudios.apps.hammer.encyclopedia_create_entry_name_placeholder
 import com.darkrockstudios.apps.hammer.encyclopedia_create_entry_section_marker
+import com.darkrockstudios.apps.hammer.encyclopedia_entry_dictionary_toggle_hint
+import com.darkrockstudios.apps.hammer.encyclopedia_entry_dictionary_toggle_label
 import com.darkrockstudios.apps.hammer.encyclopedia_create_entry_tags_hint
 import com.darkrockstudios.apps.hammer.encyclopedia_create_entry_tags_label
 import com.darkrockstudios.apps.hammer.encyclopedia_create_entry_tags_placeholder
@@ -117,6 +120,7 @@ internal fun CreateEntryUi(
 	var description by rememberSaveable { mutableStateOf("") }
 	val tags = rememberSaveableStringList()
 	var selectedType by rememberSaveable { mutableStateOf(EntryType.PERSON) }
+	var excludeFromDictionary by rememberSaveable { mutableStateOf(false) }
 
 	var imagePath by remember { mutableStateOf<PlatformFile?>(null) }
 
@@ -254,6 +258,13 @@ internal fun CreateEntryUi(
 						{ imagePath = null }
 					} else null,
 				)
+
+				HdHairlineToggleRow(
+					checked = !excludeFromDictionary,
+					label = Res.string.encyclopedia_entry_dictionary_toggle_label.get(),
+					hint = Res.string.encyclopedia_entry_dictionary_toggle_hint.get(),
+					onCheckedChange = { include -> excludeFromDictionary = !include },
+				)
 			}
 
 			HairlineModalFooter(
@@ -267,6 +278,7 @@ internal fun CreateEntryUi(
 							text = description,
 							tags = tags.toSet(),
 							imagePath = imagePath?.path,
+							excludeFromDictionary = excludeFromDictionary,
 						)
 						val message = when (result.error) {
 							EntryError.NAME_TOO_LONG -> strRes.get(

--- a/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/encyclopedia/CreateEntryUi.kt
+++ b/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/encyclopedia/CreateEntryUi.kt
@@ -259,12 +259,14 @@ internal fun CreateEntryUi(
 					} else null,
 				)
 
-				HdHairlineToggleRow(
-					checked = !excludeFromDictionary,
-					label = Res.string.encyclopedia_entry_dictionary_toggle_label.get(),
-					hint = Res.string.encyclopedia_entry_dictionary_toggle_hint.get(),
-					onCheckedChange = { include -> excludeFromDictionary = !include },
-				)
+				if (state.dictionaryFeatureEnabled) {
+					HdHairlineToggleRow(
+						checked = !excludeFromDictionary,
+						label = Res.string.encyclopedia_entry_dictionary_toggle_label.get(),
+						hint = Res.string.encyclopedia_entry_dictionary_toggle_hint.get(),
+						onCheckedChange = { include -> excludeFromDictionary = !include },
+					)
+				}
 			}
 
 			HairlineModalFooter(

--- a/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/encyclopedia/ViewEntryUi.kt
+++ b/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/encyclopedia/ViewEntryUi.kt
@@ -377,12 +377,17 @@ internal fun ViewEntryUi(
 							state = state,
 							component = component,
 							compact = isCompact,
-							scope = scope,
 						)
 
 						AppearsInZone(
 							state = state,
 							component = component,
+						)
+
+						DictionaryToggleZone(
+							state = state,
+							component = component,
+							scope = scope,
 						)
 
 						FooterColophon(
@@ -1017,7 +1022,6 @@ private fun TagsAndAliasesZone(
 	state: ViewEntry.State,
 	component: ViewEntry,
 	compact: Boolean,
-	scope: CoroutineScope,
 ) {
 	val content = state.content ?: return
 	val padding = Modifier.padding(horizontal = Ui.Padding.XXL).padding(top = 28.dp)
@@ -1038,7 +1042,16 @@ private fun TagsAndAliasesZone(
 			AliasesSection(content.aliases, component, modifier = Modifier.weight(1f))
 		}
 	}
+}
 
+@Composable
+private fun DictionaryToggleZone(
+	state: ViewEntry.State,
+	component: ViewEntry,
+	scope: CoroutineScope,
+) {
+	if (!state.dictionaryFeatureEnabled) return
+	val content = state.content ?: return
 	HdHairlineToggleRow(
 		checked = !content.excludeFromDictionary,
 		label = Res.string.encyclopedia_entry_dictionary_toggle_label.get(),

--- a/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/encyclopedia/ViewEntryUi.kt
+++ b/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/encyclopedia/ViewEntryUi.kt
@@ -83,6 +83,7 @@ import com.darkrockstudios.apps.hammer.common.compose.designsystem.HdEngravingPl
 import com.darkrockstudios.apps.hammer.common.compose.designsystem.HdHairlineButton
 import com.darkrockstudios.apps.hammer.common.compose.designsystem.HdHairlineField
 import com.darkrockstudios.apps.hammer.common.compose.designsystem.HdHairlineGrid
+import com.darkrockstudios.apps.hammer.common.compose.designsystem.HdHairlineToggleRow
 import com.darkrockstudios.apps.hammer.common.compose.designsystem.HdMetadataItem
 import com.darkrockstudios.apps.hammer.common.compose.designsystem.HdMonoLabel
 import com.darkrockstudios.apps.hammer.common.compose.designsystem.HdSectionHeader
@@ -127,6 +128,8 @@ import com.darkrockstudios.apps.hammer.encyclopedia_entry_alias_hint
 import com.darkrockstudios.apps.hammer.encyclopedia_entry_aliases_label
 import com.darkrockstudios.apps.hammer.encyclopedia_entry_appears_in_empty
 import com.darkrockstudios.apps.hammer.encyclopedia_entry_appears_in_label
+import com.darkrockstudios.apps.hammer.encyclopedia_entry_dictionary_toggle_hint
+import com.darkrockstudios.apps.hammer.encyclopedia_entry_dictionary_toggle_label
 import com.darkrockstudios.apps.hammer.encyclopedia_entry_body_empty_label
 import com.darkrockstudios.apps.hammer.encyclopedia_entry_close_button
 import com.darkrockstudios.apps.hammer.encyclopedia_entry_colophon_end
@@ -374,6 +377,7 @@ internal fun ViewEntryUi(
 							state = state,
 							component = component,
 							compact = isCompact,
+							scope = scope,
 						)
 
 						AppearsInZone(
@@ -1013,6 +1017,7 @@ private fun TagsAndAliasesZone(
 	state: ViewEntry.State,
 	component: ViewEntry,
 	compact: Boolean,
+	scope: CoroutineScope,
 ) {
 	val content = state.content ?: return
 	val padding = Modifier.padding(horizontal = Ui.Padding.XXL).padding(top = 28.dp)
@@ -1033,6 +1038,19 @@ private fun TagsAndAliasesZone(
 			AliasesSection(content.aliases, component, modifier = Modifier.weight(1f))
 		}
 	}
+
+	HdHairlineToggleRow(
+		checked = !content.excludeFromDictionary,
+		label = Res.string.encyclopedia_entry_dictionary_toggle_label.get(),
+		hint = Res.string.encyclopedia_entry_dictionary_toggle_hint.get(),
+		onCheckedChange = { include ->
+			scope.launch { component.setExcludeFromDictionary(!include) }
+		},
+		modifier = Modifier
+			.padding(horizontal = Ui.Padding.XXL)
+			.padding(top = 28.dp)
+			.fillMaxWidth(),
+	)
 }
 
 @OptIn(ExperimentalLayoutApi::class)

--- a/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/projecthome/ProjectSettingsUi.kt
+++ b/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/projecthome/ProjectSettingsUi.kt
@@ -22,6 +22,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.Dp
@@ -36,6 +37,7 @@ import com.darkrockstudios.apps.hammer.common.compose.Ui
 import com.darkrockstudios.apps.hammer.common.compose.designsystem.HdCrumbBackLink
 import com.darkrockstudios.apps.hammer.common.compose.designsystem.HdFolioDivider
 import com.darkrockstudios.apps.hammer.common.compose.designsystem.HdHairlineSection
+import com.darkrockstudios.apps.hammer.common.compose.designsystem.HdHairlineToggleRow
 import com.darkrockstudios.apps.hammer.common.compose.designsystem.HdMonoLabel
 import com.darkrockstudios.apps.hammer.common.compose.resources.get
 import com.darkrockstudios.apps.hammer.common.compose.scrollBarOverlay
@@ -52,6 +54,8 @@ import com.darkrockstudios.apps.hammer.project_settings_folio_section_count
 import com.darkrockstudios.apps.hammer.project_settings_hero_by
 import com.darkrockstudios.apps.hammer.project_settings_hero_marker
 import com.darkrockstudios.apps.hammer.project_settings_hero_no_author
+import com.darkrockstudios.apps.hammer.project_settings_spellcheck_encyclopedia_enable
+import com.darkrockstudios.apps.hammer.project_settings_spellcheck_encyclopedia_enable_hint
 import com.darkrockstudios.apps.hammer.project_settings_spellcheck_mismatch_caption
 import com.darkrockstudios.apps.hammer.project_settings_spellcheck_section_title
 
@@ -116,6 +120,10 @@ fun ProjectSettingsUi(
 								contentSpacing = 18.dp,
 							) {
 								SpellCheckSettingsContent(component.spellCheckSettings)
+								ProjectDictionaryToggle(
+									enabled = state.data.encyclopediaDictionary,
+									component = component,
+								)
 								SpellCheckMismatchCaption(
 									projectLanguageTag = state.data.language,
 									spellCheckSettings = component.spellCheckSettings,
@@ -138,6 +146,31 @@ fun ProjectSettingsUi(
 			projectName = component.projectName,
 			sectionCount = 4,
 			horizontalPadding = outerHorizontal,
+		)
+	}
+}
+
+/** Per-project override for the global "learn encyclopedia names" feature. */
+@Composable
+private fun ProjectDictionaryToggle(
+	enabled: Boolean,
+	component: ProjectSettings,
+) {
+	val spellCheckState by component.spellCheckSettings.state.subscribeAsState()
+	val featureOn = spellCheckState.spellCheckingEnabled && spellCheckState.spellCheckingEncyclopediaEnabled
+
+	Box(
+		modifier = Modifier.alpha(if (featureOn) 1f else 0.45f),
+	) {
+		HdHairlineToggleRow(
+			checked = enabled,
+			label = Res.string.project_settings_spellcheck_encyclopedia_enable.get(),
+			hint = Res.string.project_settings_spellcheck_encyclopedia_enable_hint.get(),
+			onCheckedChange = {
+				if (featureOn) {
+					component.setEncyclopediaDictionaryEnabled(it)
+				}
+			},
 		)
 	}
 }

--- a/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/projecthome/ProjectSettingsUi.kt
+++ b/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/projecthome/ProjectSettingsUi.kt
@@ -119,7 +119,10 @@ fun ProjectSettingsUi(
 								title = Res.string.project_settings_spellcheck_section_title.get(),
 								contentSpacing = 18.dp,
 							) {
-								SpellCheckSettingsContent(component.spellCheckSettings)
+								SpellCheckSettingsContent(
+									component.spellCheckSettings,
+									showEncyclopediaToggle = false,
+								)
 								ProjectDictionaryToggle(
 									enabled = state.data.encyclopediaDictionary,
 									component = component,
@@ -157,7 +160,8 @@ private fun ProjectDictionaryToggle(
 	component: ProjectSettings,
 ) {
 	val spellCheckState by component.spellCheckSettings.state.subscribeAsState()
-	val featureOn = spellCheckState.spellCheckingEnabled && spellCheckState.spellCheckingEncyclopediaEnabled
+	if (!spellCheckState.spellCheckingEncyclopediaEnabled) return
+	val featureOn = spellCheckState.spellCheckingEnabled
 
 	Box(
 		modifier = Modifier.alpha(if (featureOn) 1f else 0.45f),

--- a/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/projectselection/settings/SpellCheckSettingsUi.kt
+++ b/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/projectselection/settings/SpellCheckSettingsUi.kt
@@ -31,6 +31,8 @@ import com.darkrockstudios.apps.hammer.common.compose.resources.get
 import com.darkrockstudios.apps.hammer.common.compose.theme.LocalHammerColors
 import com.darkrockstudios.apps.hammer.notice_experimental_label
 import com.darkrockstudios.apps.hammer.settings_spellcheck_enable
+import com.darkrockstudios.apps.hammer.settings_spellcheck_encyclopedia_enable
+import com.darkrockstudios.apps.hammer.settings_spellcheck_encyclopedia_enable_hint
 import com.darkrockstudios.apps.hammer.settings_spellcheck_in_focus_enable
 import com.darkrockstudios.apps.hammer.settings_spellcheck_notice
 import kotlinx.coroutines.launch
@@ -58,6 +60,20 @@ internal fun SpellCheckSettingsContent(
 				onCheckedChange = {
 					if (state.spellCheckingEnabled) {
 						scope.launch { component.setSpellCheckingInFocusEnabled(it) }
+					}
+				},
+			)
+		}
+		Box(
+			modifier = Modifier.alpha(if (state.spellCheckingEnabled) 1f else 0.45f),
+		) {
+			HdHairlineToggleRow(
+				checked = state.spellCheckingEncyclopediaEnabled,
+				label = Res.string.settings_spellcheck_encyclopedia_enable.get(),
+				hint = Res.string.settings_spellcheck_encyclopedia_enable_hint.get(),
+				onCheckedChange = {
+					if (state.spellCheckingEnabled) {
+						scope.launch { component.setSpellCheckEncyclopediaEnabled(it) }
 					}
 				},
 			)

--- a/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/projectselection/settings/SpellCheckSettingsUi.kt
+++ b/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/projectselection/settings/SpellCheckSettingsUi.kt
@@ -40,6 +40,7 @@ import kotlinx.coroutines.launch
 @Composable
 internal fun SpellCheckSettingsContent(
 	component: SpellCheckSettings,
+	showEncyclopediaToggle: Boolean = true,
 ) {
 	val state by component.state.subscribeAsState()
 	val scope = rememberCoroutineScope()
@@ -64,19 +65,21 @@ internal fun SpellCheckSettingsContent(
 				},
 			)
 		}
-		Box(
-			modifier = Modifier.alpha(if (state.spellCheckingEnabled) 1f else 0.45f),
-		) {
-			HdHairlineToggleRow(
-				checked = state.spellCheckingEncyclopediaEnabled,
-				label = Res.string.settings_spellcheck_encyclopedia_enable.get(),
-				hint = Res.string.settings_spellcheck_encyclopedia_enable_hint.get(),
-				onCheckedChange = {
-					if (state.spellCheckingEnabled) {
-						scope.launch { component.setSpellCheckEncyclopediaEnabled(it) }
-					}
-				},
-			)
+		if (showEncyclopediaToggle) {
+			Box(
+				modifier = Modifier.alpha(if (state.spellCheckingEnabled) 1f else 0.45f),
+			) {
+				HdHairlineToggleRow(
+					checked = state.spellCheckingEncyclopediaEnabled,
+					label = Res.string.settings_spellcheck_encyclopedia_enable.get(),
+					hint = Res.string.settings_spellcheck_encyclopedia_enable_hint.get(),
+					onCheckedChange = {
+						if (state.spellCheckingEnabled) {
+							scope.launch { component.setSpellCheckEncyclopediaEnabled(it) }
+						}
+					},
+				)
+			}
 		}
 		SpellCheckDictionaryControl(
 			selected = state.spellCheckingLanguage,

--- a/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/projectsync/ProjectDataConflict.kt
+++ b/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/projectsync/ProjectDataConflict.kt
@@ -42,11 +42,14 @@ import com.darkrockstudios.apps.hammer.sync_conflict_project_data_explanation
 import com.darkrockstudios.apps.hammer.common.spellcheck.displayName
 import com.darkrockstudios.apps.hammer.common.util.Locale
 import com.darkrockstudios.apps.hammer.sync_conflict_project_data_field_author
+import com.darkrockstudios.apps.hammer.sync_conflict_project_data_field_dictionary
 import com.darkrockstudios.apps.hammer.sync_conflict_project_data_field_language
 import com.darkrockstudios.apps.hammer.sync_conflict_project_data_field_tags
 import com.darkrockstudios.apps.hammer.sync_conflict_project_data_field_theme
 import com.darkrockstudios.apps.hammer.sync_conflict_project_data_field_word_goal
 import com.darkrockstudios.apps.hammer.sync_conflict_project_data_resolve_button
+import com.darkrockstudios.apps.hammer.sync_conflict_project_data_value_off
+import com.darkrockstudios.apps.hammer.sync_conflict_project_data_value_on
 import com.darkrockstudios.apps.hammer.sync_conflict_project_data_value_unset
 import com.darkrockstudios.apps.hammer.sync_conflict_tab_local
 import com.darkrockstudios.apps.hammer.sync_conflict_tab_remote
@@ -64,14 +67,19 @@ internal fun ProjectDataConflict(
 	var goalChoice by remember { mutableStateOf(DataChoice.LOCAL) }
 	var tagsChoice by remember { mutableStateOf(DataChoice.LOCAL) }
 	var languageChoice by remember { mutableStateOf(DataChoice.LOCAL) }
+	var dictionaryChoice by remember { mutableStateOf(DataChoice.LOCAL) }
 
 	val authorConflict = conflictState.local.authorName != conflictState.server.authorName
 	val themeConflict = conflictState.local.theme != conflictState.server.theme
 	val goalConflict = conflictState.local.wordCountGoal != conflictState.server.wordCountGoal
 	val tagsConflict = conflictState.local.tags != conflictState.server.tags
 	val languageConflict = conflictState.local.language != conflictState.server.language
+	val dictionaryConflict =
+		conflictState.local.encyclopediaDictionary != conflictState.server.encyclopediaDictionary
 
 	val unsetLabel = Res.string.sync_conflict_project_data_value_unset.get()
+	val onLabel = Res.string.sync_conflict_project_data_value_on.get()
+	val offLabel = Res.string.sync_conflict_project_data_value_off.get()
 	val localLabel = Res.string.sync_conflict_tab_local.get()
 	val remoteLabel = Res.string.sync_conflict_tab_remote.get()
 	val dayLabel = Res.string.sync_conflict_project_data_cadence_day.get()
@@ -151,6 +159,18 @@ internal fun ProjectDataConflict(
 			stackVertical = stackVertical,
 		)
 
+		PerFieldChoice(
+			label = Res.string.sync_conflict_project_data_field_dictionary.get(),
+			conflict = dictionaryConflict,
+			localValue = if (conflictState.local.encyclopediaDictionary) onLabel else offLabel,
+			serverValue = if (conflictState.server.encyclopediaDictionary) onLabel else offLabel,
+			selected = dictionaryChoice,
+			onSelect = { dictionaryChoice = it },
+			localLabel = localLabel,
+			remoteLabel = remoteLabel,
+			stackVertical = stackVertical,
+		)
+
 		Row(
 			modifier = Modifier.fillMaxWidth(),
 			horizontalArrangement = Arrangement.End,
@@ -167,6 +187,7 @@ internal fun ProjectDataConflict(
 							goalChoice = goalChoice,
 							tagsChoice = tagsChoice,
 							languageChoice = languageChoice,
+							dictionaryChoice = dictionaryChoice,
 						)
 					)
 				},
@@ -270,12 +291,14 @@ private fun buildResolved(
 	goalChoice: DataChoice,
 	tagsChoice: DataChoice,
 	languageChoice: DataChoice,
+	dictionaryChoice: DataChoice,
 ): ProjectData = ProjectData(
 	authorName = if (authorChoice == DataChoice.LOCAL) local.authorName else server.authorName,
 	theme = if (themeChoice == DataChoice.LOCAL) local.theme else server.theme,
 	wordCountGoal = if (goalChoice == DataChoice.LOCAL) local.wordCountGoal else server.wordCountGoal,
 	tags = if (tagsChoice == DataChoice.LOCAL) local.tags else server.tags,
 	language = if (languageChoice == DataChoice.LOCAL) local.language else server.language,
+	encyclopediaDictionary = if (dictionaryChoice == DataChoice.LOCAL) local.encyclopediaDictionary else server.encyclopediaDictionary,
 )
 
 private fun displayString(value: String?, unsetLabel: String): String =

--- a/composeUi/src/desktopMain/kotlin/com/darkrockstudios/apps/hammer/common/preview/EncyclopediaUi.Preview.kt
+++ b/composeUi/src/desktopMain/kotlin/com/darkrockstudios/apps/hammer/common/preview/EncyclopediaUi.Preview.kt
@@ -174,7 +174,8 @@ private val fakeCreateEntryComponent: CreateEntry = object : CreateEntry {
 		type: EntryType,
 		text: String,
 		tags: Set<String>,
-		imagePath: String?
+		imagePath: String?,
+		excludeFromDictionary: Boolean,
 	): EntryResult = EntryResult(EntryContainer(fakeEntryContent()), EntryError.NONE)
 
 	override fun confirmClose() {}
@@ -328,6 +329,8 @@ val fakeViewEntryComponent: ViewEntry = object : ViewEntry {
 	override suspend fun addAlias(alias: String) =
 		EntryResult(EntryContainer(fakeEntryContent()), EntryError.NONE)
 	override fun removeAlias(alias: String) {}
+	override suspend fun setExcludeFromDictionary(exclude: Boolean) =
+		EntryResult(EntryContainer(fakeEntryContent()), EntryError.NONE)
 	override fun navigateToAppearance(appearance: ViewEntry.Appearance) {}
 	override fun suggestTags(prefix: String, limit: Int): List<String> = emptyList()
 }

--- a/composeUi/src/desktopMain/kotlin/com/darkrockstudios/apps/hammer/common/preview/projecthome/ProjectSettingsUi.Preview.kt
+++ b/composeUi/src/desktopMain/kotlin/com/darkrockstudios/apps/hammer/common/preview/projecthome/ProjectSettingsUi.Preview.kt
@@ -69,6 +69,7 @@ private val fakeSpellCheckSettings = object : SpellCheckSettings {
 
 	override suspend fun setSpellcheckEnable(enable: Boolean) {}
 	override suspend fun setSpellCheckingInFocusEnabled(enable: Boolean) {}
+	override suspend fun setSpellCheckEncyclopediaEnabled(enable: Boolean) {}
 	override suspend fun setSpellCheckLanguage(language: Locale) {}
 }
 
@@ -96,6 +97,7 @@ private fun fakeComponent(language: String?) = object : ProjectSettings {
 	override fun setWordCountGoal(goal: WordCountGoal?) {}
 	override fun setTags(tags: Set<String>) {}
 	override fun setProjectLanguage(tag: String?) {}
+	override fun setEncyclopediaDictionaryEnabled(enabled: Boolean) {}
 	override fun suggestProjectTags(prefix: String): List<String> =
 		listOf("fantasy", "sci-fi", "nanowrimo").filter { it.startsWith(prefix, ignoreCase = true) }
 }

--- a/composeUi/src/desktopMain/kotlin/com/darkrockstudios/apps/hammer/common/projectselection/AccountSettingsUtils.kt
+++ b/composeUi/src/desktopMain/kotlin/com/darkrockstudios/apps/hammer/common/projectselection/AccountSettingsUtils.kt
@@ -87,12 +87,13 @@ internal fun accountSettingsComponent(state: AccountSettings.State = defaultAcco
 				override val state: Value<SpellCheckSettings.State>
 					get() = MutableValue(
 						SpellCheckSettings.State(
-							true, true, Locale.root, emptyList()
+							true, true, true, Locale.root, emptyList()
 						)
 					)
 
 				override suspend fun setSpellcheckEnable(enable: Boolean) {}
 				override suspend fun setSpellCheckingInFocusEnabled(enable: Boolean) {}
+				override suspend fun setSpellCheckEncyclopediaEnabled(enable: Boolean) {}
 				override suspend fun setSpellCheckLanguage(language: Locale) {}
 			}
 

--- a/integrationTests/src/jvmTest/kotlin/com/darkrockstudios/apps/hammer/integration/scenarios/EntityTypeResyncMatrixTest.kt
+++ b/integrationTests/src/jvmTest/kotlin/com/darkrockstudios/apps/hammer/integration/scenarios/EntityTypeResyncMatrixTest.kt
@@ -86,6 +86,7 @@ class EntityTypeResyncMatrixTest : RoundTripTestBase() {
 			name = "Hero",
 			text = "a very brave hero",
 			tags = setOf("hero", "legend"),
+			excludeFromDictionary = false,
 		)
 		assertTrue(client.syncNoConflict(), "resync should succeed")
 		assertNotEquals(before, serverEntityHash(project, container.entry.id), "edit must reach the server")

--- a/integrationTests/src/jvmTest/kotlin/com/darkrockstudios/apps/hammer/integration/scenarios/MixedSyncFuzzTest.kt
+++ b/integrationTests/src/jvmTest/kotlin/com/darkrockstudios/apps/hammer/integration/scenarios/MixedSyncFuzzTest.kt
@@ -95,7 +95,13 @@ class MixedSyncFuzzTest : RoundTripTestBase() {
 					eventState[id] = updated
 				}
 				9 -> entries.randomOrNull(rng)?.let { id ->
-					encyclopedia.updateEntry(encyclopedia.getEntryDef(id), "Entry $i", "about edit $i", randomTags(rng))
+					encyclopedia.updateEntry(
+						encyclopedia.getEntryDef(id),
+						"Entry $i",
+						"about edit $i",
+						randomTags(rng),
+						excludeFromDictionary = false,
+					)
 				}
 
 				10 -> scenes.randomOrNull(rng)?.let { id ->

--- a/server/src/test/kotlin/com/darkrockstudios/apps/hammer/utilities/EntityHashSensitivityTest.kt
+++ b/server/src/test/kotlin/com/darkrockstudios/apps/hammer/utilities/EntityHashSensitivityTest.kt
@@ -237,6 +237,7 @@ class EntityHashSensitivityTest {
 				"image.base64" to base.copy(image = base.image!!.copy(base64 = "abcd")),
 				"image.fileExtension" to base.copy(image = base.image!!.copy(fileExtension = "jpg")),
 				"aliases" to base.copy(aliases = listOf("Bobby")),
+				"excludeFromDictionary" to base.copy(excludeFromDictionary = true),
 			),
 		)
 	}
@@ -291,6 +292,7 @@ class EntityHashSensitivityTest {
 				"wordCountGoal.count" to base.copy(wordCountGoal = base.wordCountGoal!!.copy(count = 999)),
 				"tags" to base.copy(tags = setOf("different")),
 				"language" to base.copy(language = "fr"),
+				"encyclopediaDictionary" to base.copy(encyclopediaDictionary = false),
 			),
 		)
 	}


### PR DESCRIPTION
Encyclopedia entry names and aliases feed the spell checker as session-only words while their project is open, so invented names ("Zaltharion", "Kastle Rock") stop being red-squiggled. Words live in the checker's in-memory AppLocal dictionary: they never touch the OS user dictionary, and they are cleared when the project closes, so nothing leaks between projects.

## How it works

- Names/aliases are tokenized into single words (the platform checkers only match single lowercase tokens), and each token is filtered through `isWordCorrect` so only genuinely unknown spellings get added. A sentence-like entry name ("The guy from the alley we met once") therefore contributes nothing.
- `SpellCheckRepository` holds session words keyed by `ProjectDef` (unioned across owners, which keeps `temporaryProjectTask` background scopes correct). When the effective word set changes it emits a fresh checker instance, which is what makes open editors re-run a full scan; the same path re-applies and re-filters words on locale change and re-enable.
- `ProjectDictionaryService` (project-scoped, eagerly started in `initializeProjectScope`) rebuilds the word set from the encyclopedia on entry changes (debounced 150 ms) and clears it on scope close. It reloads the entry list imperatively first, because entry writes never refresh `entryListFlow`'s replay cache.

## Controls (all live-reactive, each level hides the ones below it when off)

1. **Global**: "Learn encyclopedia names" in Spell Check settings (`SpellCheckerSettings.includeEncyclopediaNames`, default on)
2. **Per-project**: toggle in Project Settings (`ProjectData.encyclopediaDictionary`, synced; hashed only when false so all existing ProjectData hashes are unchanged; has a conflict-resolution row)
3. **Per-entry**: "Learn in spell check" on view/create entry (`EntryContent.excludeFromDictionary`, synced entity field following the aliases precedent; hashed only when true so all existing entity hashes are unchanged)

The shared gate is `ProjectSpellCheckRepository.encyclopediaDictionaryEnabled` (global AND project), consumed by both the UI visibility and the word loading itself.

## Notes for review

- `updateEntry` now **requires** `excludeFromDictionary` at every layer (no default), so no call site can silently reset the synced flag.
- Known version skew, same accepted class as `aliases`: an old server or client that re-encodes an entry drops `excludeFromDictionary`.
- No PlatformSpellCheck library changes needed; the AppLocal dictionary API shipped in 1.2.0 and we are on 1.3.2.

## Testing

- New: `DictionaryTokenizerTest`, `ProjectDictionaryServiceTest` (real encyclopedia/project-data/settings/spell-check repositories over FakeFileSystem, mocked platform factory), session-word coverage in `SpellCheckRepositoryTest`, hasher tests for both new fields (golden pins prove hash back-compat).
- `desktopTest`, `server:test` (EntityHashSensitivityTest gates), Android + iOS compiles all green; previews rendered and eyeballed; manual desktop smoke test done (learn, secondary editors, all three toggles, no cross-project leak).
