### PR TITLE
Cache dictionary tokens per entry

### DIFF
--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/encyclopediarepository/EncyclopediaRepository.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/encyclopediarepository/EncyclopediaRepository.kt
@@ -56,6 +56,11 @@ class EncyclopediaRepository(
 	)
 	val entryContentChangedFlow: SharedFlow<Unit> = _entryContentChangedFlow
 
+	// SUSPEND overflow (the default): consumers keep a cache from these, so events
+	// must never be dropped. With no subscribers, emits complete immediately.
+	private val _entryChangeFlow = MutableSharedFlow<EntryChange>(extraBufferCapacity = 64)
+	val entryChangeFlow: SharedFlow<EntryChange> = _entryChangeFlow
+
 	private suspend fun updateEntries(entries: List<EntryDef>) {
 		_entryListFlow.emit(entries)
 	}
@@ -98,6 +103,7 @@ class EncyclopediaRepository(
 			excludeFromDictionary = excludeFromDictionary,
 		)
 
+		_entryChangeFlow.emit(EntryChange.Saved(container.entry))
 		_entryContentChangedFlow.emit(Unit)
 		return EntryResult(container, EntryError.NONE)
 	}
@@ -184,6 +190,7 @@ class EncyclopediaRepository(
 
 		if (forceId == null) markForSynchronization(newDef)
 
+		_entryChangeFlow.emit(EntryChange.Saved(container.entry))
 		_entryContentChangedFlow.emit(Unit)
 		return EntryResult(container, EntryError.NONE)
 	}
@@ -191,6 +198,7 @@ class EncyclopediaRepository(
 	suspend fun deleteEntry(entryDef: EntryDef): Boolean {
 		datasource.deleteEntry(entryDef)
 		syncJournal.recordIdDeletion(entryDef.id)
+		_entryChangeFlow.emit(EntryChange.Deleted(entryDef.id))
 		_entryContentChangedFlow.emit(Unit)
 		return true
 	}
@@ -200,7 +208,10 @@ class EncyclopediaRepository(
 		datasource.setEntryImage(entryDef, imagePath)
 	}
 
-	suspend fun reIdEntry(oldId: Int, newId: Int) = datasource.reIdEntry(oldId, newId)
+	suspend fun reIdEntry(oldId: Int, newId: Int) {
+		datasource.reIdEntry(oldId, newId)
+		_entryChangeFlow.emit(EntryChange.ReId(oldId, newId))
+	}
 
 	fun hasEntryImage(entryDef: EntryDef, fileExension: String): Boolean =
 		datasource.hasEntryImage(entryDef, fileExension)

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/encyclopediarepository/EntryChange.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/encyclopediarepository/EntryChange.kt
@@ -1,0 +1,18 @@
+package com.darkrockstudios.apps.hammer.common.data.encyclopediarepository
+
+import com.darkrockstudios.apps.hammer.common.data.encyclopediarepository.entry.EntryContent
+
+/**
+ * A single entry mutation, carrying the written content so consumers can react
+ * without re-reading the entry from disk. Complements [EncyclopediaRepository.entryContentChangedFlow],
+ * which only signals that "something changed".
+ */
+sealed interface EntryChange {
+	/** An entry was created or updated; [entry] is exactly what was persisted. */
+	data class Saved(val entry: EntryContent) : EntryChange
+
+	data class Deleted(val id: Int) : EntryChange
+
+	/** Sync re-numbered an entry; its content is unchanged. */
+	data class ReId(val oldId: Int, val newId: Int) : EntryChange
+}

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/spellcheck/ProjectDictionaryService.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/spellcheck/ProjectDictionaryService.kt
@@ -3,6 +3,8 @@ package com.darkrockstudios.apps.hammer.common.spellcheck
 import com.darkrockstudios.apps.hammer.common.data.ProjectDef
 import com.darkrockstudios.apps.hammer.common.data.ProjectScoped
 import com.darkrockstudios.apps.hammer.common.data.encyclopediarepository.EncyclopediaRepository
+import com.darkrockstudios.apps.hammer.common.data.encyclopediarepository.EntryChange
+import com.darkrockstudios.apps.hammer.common.data.encyclopediarepository.entry.EntryContent
 import com.darkrockstudios.apps.hammer.common.dependencyinjection.ProjectDefScope
 import com.darkrockstudios.apps.hammer.common.dependencyinjection.injectDefaultDispatcher
 import io.github.aakira.napier.Napier
@@ -14,9 +16,9 @@ import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.debounce
-import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import org.koin.core.component.KoinComponent
@@ -28,6 +30,10 @@ import kotlin.time.Duration.Companion.milliseconds
  * Feeds the project's Encyclopedia entry names and aliases to the spell checker as
  * session words for the lifetime of the project scope. Gated on spell check being
  * enabled, the global feature setting and the project's own toggle, all live-reactive.
+ *
+ * Entries are read from disk once, at [initialize]; after that a per-entry token
+ * cache is kept fresh purely from [EncyclopediaRepository.entryChangeFlow] events,
+ * which carry the written content.
  */
 @OptIn(FlowPreview::class)
 class ProjectDictionaryService(
@@ -42,6 +48,12 @@ class ProjectDictionaryService(
 	private val dispatcherDefault by injectDefaultDispatcher()
 	private val serviceScope = CoroutineScope(dispatcherDefault)
 
+	// Confined to the event-collector coroutine; other coroutines only see [words].
+	private val tokensByEntry = mutableMapOf<Int, Set<String>>()
+
+	/** Union of all entries' tokens; null until the initial load has seeded the cache. */
+	private val words = MutableStateFlow<Set<String>?>(null)
+
 	init {
 		projectScope.scope.registerCallback(this)
 	}
@@ -49,47 +61,70 @@ class ProjectDictionaryService(
 	/** Starts watching for words to load; called from initializeProjectScope on project open. */
 	fun initialize() {
 		serviceScope.launch {
-			combine(
+			seedCache()
+			encyclopediaRepository.entryChangeFlow.collect { change ->
+				applyChange(change)
+				words.value = tokensByEntry.values.flatMapTo(mutableSetOf()) { it }
+			}
+		}
+
+		serviceScope.launch {
+			val enabledFlow = combine(
 				projectSpellCheckRepository.spellCheckEnabled,
 				projectSpellCheckRepository.encyclopediaDictionaryEnabled,
-				encyclopediaRepository.entryContentChangedFlow.onStart { emit(Unit) },
-			) { spellCheckOn, featureOn, _ -> spellCheckOn && featureOn }
-				.debounce(REBUILD_DEBOUNCE)
-				.collect { enabled ->
-					if (enabled) {
-						rebuild()
-					} else {
-						spellCheckRepository.clearSessionWords(projectDef)
+			) { spellCheckOn, featureOn -> spellCheckOn && featureOn }
+
+			combine(words, enabledFlow) { currentWords, enabled -> currentWords to enabled }
+				.debounce(PUSH_DEBOUNCE)
+				.collect { (currentWords, enabled) ->
+					// Never push words after onScopeClose has cleared them: close cancels
+					// this scope first, so a collect that raced past its last suspension
+					// bails here.
+					if (!currentCoroutineContext().isActive) return@collect
+					when {
+						!enabled -> spellCheckRepository.clearSessionWords(projectDef)
+						currentWords != null -> spellCheckRepository.setSessionWords(projectDef, currentWords)
 					}
 				}
 		}
 	}
 
-	@Suppress("TooGenericExceptionCaught") // Background rebuild must not crash on any failure
-	private suspend fun rebuild() {
+	@Suppress("TooGenericExceptionCaught") // Background load must not crash on any failure
+	private suspend fun seedCache() {
 		try {
-			// entryListFlow's replay cache is not refreshed by entry writes, so force a
-			// reload before reading defs - renames change EntryDef.name.
+			// entryListFlow's replay cache is not refreshed by entry writes, so read the
+			// defs imperatively rather than trusting a stale cache.
 			val defs = encyclopediaRepository.loadEntriesImperative()
-			val words = coroutineScope {
+			val loaded = coroutineScope {
 				defs.map { def ->
 					async {
-						val entry = encyclopediaRepository.loadEntry(def).entry
-						if (entry.excludeFromDictionary) emptySet()
-						else tokenizeDictionaryWords(listOf(entry.name) + entry.aliases)
+						def.id to tokensFor(encyclopediaRepository.loadEntry(def).entry)
 					}
 				}.awaitAll()
-			}.flatten().toSet()
-			// Never push words after onScopeClose has cleared them: close cancels this
-			// scope first, so a rebuild that raced past its last suspension bails here.
-			if (!currentCoroutineContext().isActive) return
-			spellCheckRepository.setSessionWords(projectDef, words)
+			}
+			tokensByEntry.clear()
+			tokensByEntry.putAll(loaded)
+			words.value = tokensByEntry.values.flatMapTo(mutableSetOf()) { it }
 		} catch (e: CancellationException) {
 			throw e
 		} catch (t: Throwable) {
-			Napier.e("ProjectDictionaryService rebuild failed", t)
+			Napier.e("ProjectDictionaryService initial load failed", t)
 		}
 	}
+
+	private fun applyChange(change: EntryChange) {
+		when (change) {
+			is EntryChange.Saved -> tokensByEntry[change.entry.id] = tokensFor(change.entry)
+			is EntryChange.Deleted -> tokensByEntry.remove(change.id)
+			is EntryChange.ReId -> tokensByEntry.remove(change.oldId)?.let { tokens ->
+				tokensByEntry[change.newId] = tokens
+			}
+		}
+	}
+
+	private fun tokensFor(entry: EntryContent): Set<String> =
+		if (entry.excludeFromDictionary) emptySet()
+		else tokenizeDictionaryWords(listOf(entry.name) + entry.aliases)
 
 	override fun onScopeClose(scope: Scope) {
 		serviceScope.cancel("ProjectDictionaryService closed")
@@ -97,6 +132,6 @@ class ProjectDictionaryService(
 	}
 
 	private companion object {
-		val REBUILD_DEBOUNCE = 150.milliseconds
+		val PUSH_DEBOUNCE = 150.milliseconds
 	}
 }

--- a/common/src/desktopTest/kotlin/repositories/encyclopedia/EncyclopediaRepositoryTest.kt
+++ b/common/src/desktopTest/kotlin/repositories/encyclopedia/EncyclopediaRepositoryTest.kt
@@ -6,6 +6,7 @@ import com.darkrockstudios.apps.hammer.base.http.readToml
 import com.darkrockstudios.apps.hammer.common.data.encyclopediarepository.EncyclopediaDatasource
 import com.darkrockstudios.apps.hammer.common.data.encyclopediarepository.EncyclopediaRepository
 import com.darkrockstudios.apps.hammer.common.data.encyclopediarepository.EncyclopediaRepository.Companion.MAX_NAME_SIZE
+import com.darkrockstudios.apps.hammer.common.data.encyclopediarepository.EntryChange
 import com.darkrockstudios.apps.hammer.common.data.encyclopediarepository.EntryError
 import com.darkrockstudios.apps.hammer.common.data.encyclopediarepository.EntryLoadError
 import com.darkrockstudios.apps.hammer.common.data.encyclopediarepository.EntryResult
@@ -378,6 +379,41 @@ class EncyclopediaRepositoryTest : BaseTest() {
 
 			repo.deleteEntry(entry1().toDef(projDef))
 			awaitItem()
+		}
+	}
+
+	@Test
+	fun `entryChangeFlow carries the persisted mutation`() = runTest {
+		coEvery { idAllocator.claimNextId() } returns 3
+		coEvery { syncJournal.recordIdDeletion(any()) } just Runs
+		val repo = createRepository()
+
+		repo.entryChangeFlow.test {
+			repo.createEntry(
+				name = "NewEntry",
+				type = EntryType.PERSON,
+				text = "",
+				tags = emptySet(),
+				imagePath = null,
+				aliases = listOf("SomeAlias"),
+			)
+			val created = awaitItem() as EntryChange.Saved
+			assertEquals("NewEntry", created.entry.name)
+			assertEquals(listOf("SomeAlias"), created.entry.aliases)
+
+			repo.updateEntry(
+				oldEntryDef = created.entry.toDef(projDef),
+				name = "Renamed",
+				text = "",
+				tags = emptySet(),
+				excludeFromDictionary = true,
+			)
+			val updated = awaitItem() as EntryChange.Saved
+			assertEquals("Renamed", updated.entry.name)
+			assertTrue(updated.entry.excludeFromDictionary)
+
+			repo.deleteEntry(updated.entry.toDef(projDef))
+			assertEquals(EntryChange.Deleted(3), awaitItem())
 		}
 	}
 

--- a/common/src/desktopTest/kotlin/repositories/spellcheck/ProjectDictionaryServiceTest.kt
+++ b/common/src/desktopTest/kotlin/repositories/spellcheck/ProjectDictionaryServiceTest.kt
@@ -17,6 +17,7 @@ import com.darkrockstudios.apps.hammer.common.data.sync.projectsync.SyncJournal
 import com.darkrockstudios.apps.hammer.common.dependencyinjection.ProjectDefScope
 import com.darkrockstudios.apps.hammer.common.dependencyinjection.createTomlSerializer
 import com.darkrockstudios.apps.hammer.common.fileio.ExternalFileIo
+import com.darkrockstudios.apps.hammer.common.fileio.okio.toOkioPath
 import com.darkrockstudios.apps.hammer.common.spellcheck.ProjectDictionaryService
 import com.darkrockstudios.apps.hammer.common.spellcheck.ProjectSpellCheckRepository
 import com.darkrockstudios.apps.hammer.common.spellcheck.SpellCheckRepository
@@ -57,6 +58,7 @@ class ProjectDictionaryServiceTest : BaseTest() {
 	private lateinit var fileSystem: FakeFileSystem
 	private lateinit var idAllocator: IdAllocator
 	private lateinit var syncJournal: SyncJournal
+	private lateinit var datasource: EncyclopediaDatasource
 	private lateinit var encyclopediaRepository: EncyclopediaRepository
 	private lateinit var projectDataRepository: ProjectDataRepository
 	private lateinit var globalSettingsStore: GlobalSettingsStore
@@ -99,6 +101,7 @@ class ProjectDictionaryServiceTest : BaseTest() {
 		coEvery { globalSettingsDatasource.storeSettings(any()) } just Runs
 		coEvery { serverSettingsDatasource.loadServerSettings(any()) } returns null
 		every { syncJournal.isServerSynchronized() } returns false
+		coEvery { syncJournal.recordIdDeletion(any()) } just Runs
 		coEvery { idAllocator.claimNextId() } answers { nextId++ }
 
 		val syncDataDatasource = mockk<SyncDataDatasource>(relaxed = true)
@@ -113,15 +116,16 @@ class ProjectDictionaryServiceTest : BaseTest() {
 		createProject(fileSystem, PROJECT_EMPTY_NAME)
 
 		val toml = createTomlSerializer()
+		datasource = EncyclopediaDatasource(
+			projectDef = projectDef,
+			toml = toml,
+			fileSystem = fileSystem,
+			externalFileIo = mockk<ExternalFileIo>(),
+		)
 		encyclopediaRepository = EncyclopediaRepository(
 			projectDef = projectDef,
 			idAllocator = idAllocator,
-			datasource = EncyclopediaDatasource(
-				projectDef = projectDef,
-				toml = toml,
-				fileSystem = fileSystem,
-				externalFileIo = mockk<ExternalFileIo>(),
-			),
+			datasource = datasource,
 			syncJournal = syncJournal,
 		)
 		projectDataRepository = ProjectDataRepository(
@@ -290,6 +294,70 @@ class ProjectDictionaryServiceTest : BaseTest() {
 		advanceUntilIdle()
 
 		assertEquals(emptySet(), appliedPerChecker.last())
+	}
+
+	@Test
+	fun `deleting an entry removes its words`() = scope.runTest {
+		createEntry("Zaltharion")
+		createEntry("Kastle")
+		createService()
+		advanceUntilIdle()
+		assertEquals(setOf("zaltharion", "kastle"), appliedPerChecker.last())
+
+		val def = encyclopediaRepository.ensureEntriesLoaded().first { it.name == "Kastle" }
+		encyclopediaRepository.deleteEntry(def)
+		advanceUntilIdle()
+
+		assertEquals(setOf("zaltharion"), appliedPerChecker.last())
+	}
+
+	@Test
+	fun `changes made while the feature is off are reflected on re-enable`() = scope.runTest {
+		createEntry("Zaltharion")
+		createService()
+		advanceUntilIdle()
+		assertEquals(setOf("zaltharion"), appliedPerChecker.last())
+
+		globalSettingsStore.updateSettings {
+			it.copy(spellCheckSettings = it.spellCheckSettings.copy(includeEncyclopediaNames = false))
+		}
+		advanceUntilIdle()
+		createEntry("Kastle")
+		advanceUntilIdle()
+
+		globalSettingsStore.updateSettings {
+			it.copy(spellCheckSettings = it.spellCheckSettings.copy(includeEncyclopediaNames = true))
+		}
+		advanceUntilIdle()
+
+		assertEquals(setOf("zaltharion", "kastle"), appliedPerChecker.last())
+	}
+
+	@Test
+	fun `entry edits do not re-read other entries from disk`() = scope.runTest {
+		createEntry("Zaltharion")
+		createEntry("Kastle", aliases = listOf("Rock"))
+		createService()
+		advanceUntilIdle()
+		assertEquals(setOf("zaltharion", "kastle", "rock"), appliedPerChecker.last())
+
+		// Remove Kastle's file behind the datasource's back: a full re-scan would now
+		// lose its words, so their survival proves the edit was served from the cache.
+		val kastleDef = encyclopediaRepository.ensureEntriesLoaded().first { it.name == "Kastle" }
+		fileSystem.delete(datasource.getEntryPath(kastleDef).toOkioPath())
+
+		val zalDef = encyclopediaRepository.ensureEntriesLoaded().first { it.name == "Zaltharion" }
+		encyclopediaRepository.updateEntry(
+			oldEntryDef = zalDef,
+			name = zalDef.name,
+			text = "new text",
+			tags = emptySet(),
+			aliases = listOf("Velcaryn"),
+			excludeFromDictionary = false,
+		)
+		advanceUntilIdle()
+
+		assertEquals(setOf("zaltharion", "velcaryn", "kastle", "rock"), appliedPerChecker.last())
 	}
 
 	@Test


### PR DESCRIPTION
Follow-up to #918, closing out the deferred review finding: `ProjectDictionaryService.rebuild()` re-read and TOML-decoded every encyclopedia entry file on every entry save, even text-only edits that cannot change dictionary tokens.

## Approach

A def-keyed cache can't work here because alias and exclusion-flag edits don't change `EntryDef`, so the change signal itself now carries the content:

- **`EncyclopediaRepository.entryChangeFlow`** — a new typed event flow (`Saved(entry)` / `Deleted(id)` / `ReId(oldId, newId)`) emitted at the four mutation points alongside the existing Unit flow, carrying exactly what was persisted. The Unit flow is untouched, so TagIndexService and other consumers are unaffected. Suspending emit semantics guarantee cache-keeping consumers never miss an event; with no subscribers (temporary sync scopes skip the service) emits complete immediately, so sync paths pay nothing.
- **`ProjectDictionaryService`** reads the encyclopedia exactly once, at project open, to seed a per-entry token map. Every subsequent save/delete/re-id updates just that entry's tokens from the event payload: no directory walk, no file reads. The token union flows through a `StateFlow` into the existing debounced push/clear gate, which also means the cache stays warm while the feature is toggled off, making re-enable instant.

## Testing

- New service tests: delete removes an entry's words; changes made while the feature is off are reflected on re-enable; and a direct no-re-read proof: another entry's file is deleted behind the datasource's back, an unrelated entry is edited, and the deleted entry's words survive (a full re-scan would have lost them).
- New repository test: `entryChangeFlow` carries the persisted mutation for create/update/delete.
- All prior dictionary behavior tests pass unchanged; full `desktopTest` green.
