### PR TITLE
Support configuring the server time zone (#882)

### DIFF
--- a/docker/config.example.toml
+++ b/docker/config.example.toml
@@ -12,6 +12,10 @@ host = "hammer.example.com"
 # HEALTHCHECK both assume 8080; changing it means changing those too.
 port = 8080
 
+# Time zone for rendered timestamps and log lines, as an IANA zone ID. Defaults to
+# the container's zone (UTC unless TZ is set in docker-compose.yml).
+# timezone = "Europe/Paris"
+
 # Do NOT set bindHosts under Docker. The main server guide recommends
 # ["127.0.0.1", "::1"] behind a reverse proxy, but inside a container that binds
 # the container's own loopback, so the published port reaches nothing and the

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -26,6 +26,12 @@ services:
       # at a reverse proxy in front of it, or configure sslCert and publish 443.
       - "${HAMMER_HTTP_BIND:-127.0.0.1}:${HAMMER_HTTP_PORT:-8080}:8080"
 
+    environment:
+      # Time zone for web-UI timestamps and log lines, as an IANA zone ID. Defaults
+      # to UTC; set TZ in your shell or a .env file next to this compose file to
+      # change it. `timezone` in config.toml overrides this.
+      TZ: ${TZ:-UTC}
+
     # Uncomment alongside the postgres service below.
     # depends_on:
     #   postgres:

--- a/docs/HOW-TO-RUN-A-SERVER-DOCKER.md
+++ b/docs/HOW-TO-RUN-A-SERVER-DOCKER.md
@@ -127,6 +127,27 @@ Paths inside `config.toml` are resolved differently depending on the setting:
 > with a confusing `UnexpectedTokenException` on line 1. In PowerShell use
 > `[System.IO.File]::WriteAllText($path, $text)`.
 
+### Time zone
+
+The container runs in UTC unless told otherwise, so rendered timestamps and log lines are stamped
+in UTC. `docker-compose.yml` passes `TZ` through, so set it in your shell or in a `.env` file next
+to the compose file:
+
+```
+TZ=Europe/Paris
+```
+
+Or set it directly in `config.toml`, which takes precedence:
+
+```toml
+timezone = "Europe/Paris"
+```
+
+Either way the value is an IANA zone ID; see the [full list](SERVER-TIMEZONES.md). The effective
+zone is logged at startup as `Server time zone: ...`. Stored data is unaffected, since everything
+is persisted as an absolute instant. See [Time zone](HOW-TO-RUN-A-SERVER.md#time-zone) for the
+full rundown, including the one caveat when changing the zone on a server already in use.
+
 ## TLS in the container
 
 If you want Hammer itself to terminate TLS, mount the certificate directory and

--- a/docs/HOW-TO-RUN-A-SERVER.md
+++ b/docs/HOW-TO-RUN-A-SERVER.md
@@ -74,6 +74,53 @@ bindHosts = ["127.0.0.1", "::1"]
 public name shown to users. Each address gets its own listener (and its own HTTPS listener when an
 SSL cert is configured).
 
+## Time zone
+
+The server stamps timestamps in the host's time zone, which on most containers and fresh installs
+is UTC. To use your local zone instead, set `timezone` to an IANA zone ID
+([full list of accepted IDs](SERVER-TIMEZONES.md)):
+
+```toml
+timezone = "Europe/Paris"
+```
+
+Two environment variables do the same thing, for setups where the config file is inconvenient:
+`HAMMER_TIMEZONE`, and the standard `TZ`. `config.toml` wins over `HAMMER_TIMEZONE`, which wins
+over `TZ`.
+
+```sh
+HAMMER_TIMEZONE=Europe/Paris ./run.sh
+```
+
+The zone is applied at startup, and logged as `Server time zone: ...` so you can confirm it took.
+An unknown ID in `timezone` or `HAMMER_TIMEZONE` aborts startup rather than quietly leaving every
+timestamp in the wrong zone. `TZ` is treated more leniently, because the POSIX form some systems
+use (`CET-1CEST,M3.5.0`) is a legitimate value the operating system has already acted on: a `TZ`
+Hammer cannot read logs a warning and leaves the zone to the host.
+
+What it affects:
+
+- Dates and times on the web pages the server renders: the dashboard, admin screens, monitoring,
+  editorial reviews, and published story dates.
+- Log line timestamps, both in the console output and the admin log viewer.
+
+What it does not affect:
+
+- Stored data. Everything is persisted as an absolute instant (UTC in the database), so changing
+  the zone re-renders existing timestamps rather than shifting any data.
+- The desktop, Android, and iOS clients. Those render in each device's own zone.
+- Maintenance job scheduling. Jobs run on fixed intervals from server start, not at a wall-clock
+  time of day, so no schedule moves with the zone.
+
+One caveat when changing the zone on a server that has already been running: date-only admin
+fields are interpreted in whatever zone was in effect when they were saved. An Allowed Users
+expiry entered as "expires Sep 1" is stored as the end of Sep 1 in the old zone, so afterwards the
+edit form can show the neighboring date, and re-saving that row moves the expiry by a day. Nothing
+expires early or late on its own; only re-saving an existing row does it.
+
+Note that `TZ` alone already works on Linux, because the JVM reads it. Hammer reads it back
+explicitly so the same variable also works on Windows and macOS hosts, which ignore it.
+
 ## Rich link previews (optional)
 
 By default, sharing an author or story link on social media shows a branded static preview card.

--- a/docs/SERVER-TIMEZONES.md
+++ b/docs/SERVER-TIMEZONES.md
@@ -1,0 +1,728 @@
+# Server time zone IDs
+
+Every value the server's `timezone` setting, the `HAMMER_TIMEZONE` environment variable, and
+`TZ` accept. See [Time zone](HOW-TO-RUN-A-SERVER.md#time-zone) for what the setting does and
+which one wins when more than one is set.
+
+These are IANA (tz database) zone IDs, read from the JVM's own copy of the database, so the
+same IDs work on every host regardless of what the operating system has installed. They are
+case-sensitive: `Europe/Paris` is valid, `europe/paris` is not.
+
+The offset columns are sampled mid-January and mid-July. Where they differ, the zone observes
+daylight saving and the server follows the shift on its own.
+
+Generated from the tz database shipped with JDK 21.0.9 (604 IDs). A JDK update can add or retire
+entries; the authoritative list for a given install is always `ZoneId.getAvailableZoneIds()` on the
+JDK the server runs on.
+
+## Contents
+
+- [Africa](#africa)
+- [America](#america)
+- [Antarctica](#antarctica)
+- [Arctic](#arctic)
+- [Asia](#asia)
+- [Atlantic](#atlantic)
+- [Australia](#australia)
+- [Brazil](#brazil)
+- [Canada](#canada)
+- [Chile](#chile)
+- [Europe](#europe)
+- [Indian](#indian)
+- [Mexico](#mexico)
+- [Pacific](#pacific)
+- [US](#us)
+- [Legacy and fixed-offset IDs](#legacy-and-fixed-offset-ids)
+
+## Africa
+
+| Zone ID | Offset (January) | Offset (July) |
+| --- | --- | --- |
+| `Africa/Abidjan` | UTC | UTC |
+| `Africa/Accra` | UTC | UTC |
+| `Africa/Addis_Ababa` | UTC+03:00 | UTC+03:00 |
+| `Africa/Algiers` | UTC+01:00 | UTC+01:00 |
+| `Africa/Asmara` | UTC+03:00 | UTC+03:00 |
+| `Africa/Asmera` | UTC+03:00 | UTC+03:00 |
+| `Africa/Bamako` | UTC | UTC |
+| `Africa/Bangui` | UTC+01:00 | UTC+01:00 |
+| `Africa/Banjul` | UTC | UTC |
+| `Africa/Bissau` | UTC | UTC |
+| `Africa/Blantyre` | UTC+02:00 | UTC+02:00 |
+| `Africa/Brazzaville` | UTC+01:00 | UTC+01:00 |
+| `Africa/Bujumbura` | UTC+02:00 | UTC+02:00 |
+| `Africa/Cairo` | UTC+02:00 | UTC+03:00 |
+| `Africa/Casablanca` | UTC+01:00 | UTC+01:00 |
+| `Africa/Ceuta` | UTC+01:00 | UTC+02:00 |
+| `Africa/Conakry` | UTC | UTC |
+| `Africa/Dakar` | UTC | UTC |
+| `Africa/Dar_es_Salaam` | UTC+03:00 | UTC+03:00 |
+| `Africa/Djibouti` | UTC+03:00 | UTC+03:00 |
+| `Africa/Douala` | UTC+01:00 | UTC+01:00 |
+| `Africa/El_Aaiun` | UTC+01:00 | UTC+01:00 |
+| `Africa/Freetown` | UTC | UTC |
+| `Africa/Gaborone` | UTC+02:00 | UTC+02:00 |
+| `Africa/Harare` | UTC+02:00 | UTC+02:00 |
+| `Africa/Johannesburg` | UTC+02:00 | UTC+02:00 |
+| `Africa/Juba` | UTC+02:00 | UTC+02:00 |
+| `Africa/Kampala` | UTC+03:00 | UTC+03:00 |
+| `Africa/Khartoum` | UTC+02:00 | UTC+02:00 |
+| `Africa/Kigali` | UTC+02:00 | UTC+02:00 |
+| `Africa/Kinshasa` | UTC+01:00 | UTC+01:00 |
+| `Africa/Lagos` | UTC+01:00 | UTC+01:00 |
+| `Africa/Libreville` | UTC+01:00 | UTC+01:00 |
+| `Africa/Lome` | UTC | UTC |
+| `Africa/Luanda` | UTC+01:00 | UTC+01:00 |
+| `Africa/Lubumbashi` | UTC+02:00 | UTC+02:00 |
+| `Africa/Lusaka` | UTC+02:00 | UTC+02:00 |
+| `Africa/Malabo` | UTC+01:00 | UTC+01:00 |
+| `Africa/Maputo` | UTC+02:00 | UTC+02:00 |
+| `Africa/Maseru` | UTC+02:00 | UTC+02:00 |
+| `Africa/Mbabane` | UTC+02:00 | UTC+02:00 |
+| `Africa/Mogadishu` | UTC+03:00 | UTC+03:00 |
+| `Africa/Monrovia` | UTC | UTC |
+| `Africa/Nairobi` | UTC+03:00 | UTC+03:00 |
+| `Africa/Ndjamena` | UTC+01:00 | UTC+01:00 |
+| `Africa/Niamey` | UTC+01:00 | UTC+01:00 |
+| `Africa/Nouakchott` | UTC | UTC |
+| `Africa/Ouagadougou` | UTC | UTC |
+| `Africa/Porto-Novo` | UTC+01:00 | UTC+01:00 |
+| `Africa/Sao_Tome` | UTC | UTC |
+| `Africa/Timbuktu` | UTC | UTC |
+| `Africa/Tripoli` | UTC+02:00 | UTC+02:00 |
+| `Africa/Tunis` | UTC+01:00 | UTC+01:00 |
+| `Africa/Windhoek` | UTC+02:00 | UTC+02:00 |
+
+## America
+
+| Zone ID | Offset (January) | Offset (July) |
+| --- | --- | --- |
+| `America/Adak` | UTC-10:00 | UTC-09:00 |
+| `America/Anchorage` | UTC-09:00 | UTC-08:00 |
+| `America/Anguilla` | UTC-04:00 | UTC-04:00 |
+| `America/Antigua` | UTC-04:00 | UTC-04:00 |
+| `America/Araguaina` | UTC-03:00 | UTC-03:00 |
+| `America/Argentina/Buenos_Aires` | UTC-03:00 | UTC-03:00 |
+| `America/Argentina/Catamarca` | UTC-03:00 | UTC-03:00 |
+| `America/Argentina/ComodRivadavia` | UTC-03:00 | UTC-03:00 |
+| `America/Argentina/Cordoba` | UTC-03:00 | UTC-03:00 |
+| `America/Argentina/Jujuy` | UTC-03:00 | UTC-03:00 |
+| `America/Argentina/La_Rioja` | UTC-03:00 | UTC-03:00 |
+| `America/Argentina/Mendoza` | UTC-03:00 | UTC-03:00 |
+| `America/Argentina/Rio_Gallegos` | UTC-03:00 | UTC-03:00 |
+| `America/Argentina/Salta` | UTC-03:00 | UTC-03:00 |
+| `America/Argentina/San_Juan` | UTC-03:00 | UTC-03:00 |
+| `America/Argentina/San_Luis` | UTC-03:00 | UTC-03:00 |
+| `America/Argentina/Tucuman` | UTC-03:00 | UTC-03:00 |
+| `America/Argentina/Ushuaia` | UTC-03:00 | UTC-03:00 |
+| `America/Aruba` | UTC-04:00 | UTC-04:00 |
+| `America/Asuncion` | UTC-03:00 | UTC-03:00 |
+| `America/Atikokan` | UTC-05:00 | UTC-05:00 |
+| `America/Atka` | UTC-10:00 | UTC-09:00 |
+| `America/Bahia` | UTC-03:00 | UTC-03:00 |
+| `America/Bahia_Banderas` | UTC-06:00 | UTC-06:00 |
+| `America/Barbados` | UTC-04:00 | UTC-04:00 |
+| `America/Belem` | UTC-03:00 | UTC-03:00 |
+| `America/Belize` | UTC-06:00 | UTC-06:00 |
+| `America/Blanc-Sablon` | UTC-04:00 | UTC-04:00 |
+| `America/Boa_Vista` | UTC-04:00 | UTC-04:00 |
+| `America/Bogota` | UTC-05:00 | UTC-05:00 |
+| `America/Boise` | UTC-07:00 | UTC-06:00 |
+| `America/Buenos_Aires` | UTC-03:00 | UTC-03:00 |
+| `America/Cambridge_Bay` | UTC-07:00 | UTC-06:00 |
+| `America/Campo_Grande` | UTC-04:00 | UTC-04:00 |
+| `America/Cancun` | UTC-05:00 | UTC-05:00 |
+| `America/Caracas` | UTC-04:00 | UTC-04:00 |
+| `America/Catamarca` | UTC-03:00 | UTC-03:00 |
+| `America/Cayenne` | UTC-03:00 | UTC-03:00 |
+| `America/Cayman` | UTC-05:00 | UTC-05:00 |
+| `America/Chicago` | UTC-06:00 | UTC-05:00 |
+| `America/Chihuahua` | UTC-06:00 | UTC-06:00 |
+| `America/Ciudad_Juarez` | UTC-07:00 | UTC-06:00 |
+| `America/Coral_Harbour` | UTC-05:00 | UTC-05:00 |
+| `America/Cordoba` | UTC-03:00 | UTC-03:00 |
+| `America/Costa_Rica` | UTC-06:00 | UTC-06:00 |
+| `America/Coyhaique` | UTC-03:00 | UTC-03:00 |
+| `America/Creston` | UTC-07:00 | UTC-07:00 |
+| `America/Cuiaba` | UTC-04:00 | UTC-04:00 |
+| `America/Curacao` | UTC-04:00 | UTC-04:00 |
+| `America/Danmarkshavn` | UTC | UTC |
+| `America/Dawson` | UTC-07:00 | UTC-07:00 |
+| `America/Dawson_Creek` | UTC-07:00 | UTC-07:00 |
+| `America/Denver` | UTC-07:00 | UTC-06:00 |
+| `America/Detroit` | UTC-05:00 | UTC-04:00 |
+| `America/Dominica` | UTC-04:00 | UTC-04:00 |
+| `America/Edmonton` | UTC-07:00 | UTC-06:00 |
+| `America/Eirunepe` | UTC-05:00 | UTC-05:00 |
+| `America/El_Salvador` | UTC-06:00 | UTC-06:00 |
+| `America/Ensenada` | UTC-08:00 | UTC-07:00 |
+| `America/Fort_Nelson` | UTC-07:00 | UTC-07:00 |
+| `America/Fort_Wayne` | UTC-05:00 | UTC-04:00 |
+| `America/Fortaleza` | UTC-03:00 | UTC-03:00 |
+| `America/Glace_Bay` | UTC-04:00 | UTC-03:00 |
+| `America/Godthab` | UTC-02:00 | UTC-01:00 |
+| `America/Goose_Bay` | UTC-04:00 | UTC-03:00 |
+| `America/Grand_Turk` | UTC-05:00 | UTC-04:00 |
+| `America/Grenada` | UTC-04:00 | UTC-04:00 |
+| `America/Guadeloupe` | UTC-04:00 | UTC-04:00 |
+| `America/Guatemala` | UTC-06:00 | UTC-06:00 |
+| `America/Guayaquil` | UTC-05:00 | UTC-05:00 |
+| `America/Guyana` | UTC-04:00 | UTC-04:00 |
+| `America/Halifax` | UTC-04:00 | UTC-03:00 |
+| `America/Havana` | UTC-05:00 | UTC-04:00 |
+| `America/Hermosillo` | UTC-07:00 | UTC-07:00 |
+| `America/Indiana/Indianapolis` | UTC-05:00 | UTC-04:00 |
+| `America/Indiana/Knox` | UTC-06:00 | UTC-05:00 |
+| `America/Indiana/Marengo` | UTC-05:00 | UTC-04:00 |
+| `America/Indiana/Petersburg` | UTC-05:00 | UTC-04:00 |
+| `America/Indiana/Tell_City` | UTC-06:00 | UTC-05:00 |
+| `America/Indiana/Vevay` | UTC-05:00 | UTC-04:00 |
+| `America/Indiana/Vincennes` | UTC-05:00 | UTC-04:00 |
+| `America/Indiana/Winamac` | UTC-05:00 | UTC-04:00 |
+| `America/Indianapolis` | UTC-05:00 | UTC-04:00 |
+| `America/Inuvik` | UTC-07:00 | UTC-06:00 |
+| `America/Iqaluit` | UTC-05:00 | UTC-04:00 |
+| `America/Jamaica` | UTC-05:00 | UTC-05:00 |
+| `America/Jujuy` | UTC-03:00 | UTC-03:00 |
+| `America/Juneau` | UTC-09:00 | UTC-08:00 |
+| `America/Kentucky/Louisville` | UTC-05:00 | UTC-04:00 |
+| `America/Kentucky/Monticello` | UTC-05:00 | UTC-04:00 |
+| `America/Knox_IN` | UTC-06:00 | UTC-05:00 |
+| `America/Kralendijk` | UTC-04:00 | UTC-04:00 |
+| `America/La_Paz` | UTC-04:00 | UTC-04:00 |
+| `America/Lima` | UTC-05:00 | UTC-05:00 |
+| `America/Los_Angeles` | UTC-08:00 | UTC-07:00 |
+| `America/Louisville` | UTC-05:00 | UTC-04:00 |
+| `America/Lower_Princes` | UTC-04:00 | UTC-04:00 |
+| `America/Maceio` | UTC-03:00 | UTC-03:00 |
+| `America/Managua` | UTC-06:00 | UTC-06:00 |
+| `America/Manaus` | UTC-04:00 | UTC-04:00 |
+| `America/Marigot` | UTC-04:00 | UTC-04:00 |
+| `America/Martinique` | UTC-04:00 | UTC-04:00 |
+| `America/Matamoros` | UTC-06:00 | UTC-05:00 |
+| `America/Mazatlan` | UTC-07:00 | UTC-07:00 |
+| `America/Mendoza` | UTC-03:00 | UTC-03:00 |
+| `America/Menominee` | UTC-06:00 | UTC-05:00 |
+| `America/Merida` | UTC-06:00 | UTC-06:00 |
+| `America/Metlakatla` | UTC-09:00 | UTC-08:00 |
+| `America/Mexico_City` | UTC-06:00 | UTC-06:00 |
+| `America/Miquelon` | UTC-03:00 | UTC-02:00 |
+| `America/Moncton` | UTC-04:00 | UTC-03:00 |
+| `America/Monterrey` | UTC-06:00 | UTC-06:00 |
+| `America/Montevideo` | UTC-03:00 | UTC-03:00 |
+| `America/Montreal` | UTC-05:00 | UTC-04:00 |
+| `America/Montserrat` | UTC-04:00 | UTC-04:00 |
+| `America/Nassau` | UTC-05:00 | UTC-04:00 |
+| `America/New_York` | UTC-05:00 | UTC-04:00 |
+| `America/Nipigon` | UTC-05:00 | UTC-04:00 |
+| `America/Nome` | UTC-09:00 | UTC-08:00 |
+| `America/Noronha` | UTC-02:00 | UTC-02:00 |
+| `America/North_Dakota/Beulah` | UTC-06:00 | UTC-05:00 |
+| `America/North_Dakota/Center` | UTC-06:00 | UTC-05:00 |
+| `America/North_Dakota/New_Salem` | UTC-06:00 | UTC-05:00 |
+| `America/Nuuk` | UTC-02:00 | UTC-01:00 |
+| `America/Ojinaga` | UTC-06:00 | UTC-05:00 |
+| `America/Panama` | UTC-05:00 | UTC-05:00 |
+| `America/Pangnirtung` | UTC-05:00 | UTC-04:00 |
+| `America/Paramaribo` | UTC-03:00 | UTC-03:00 |
+| `America/Phoenix` | UTC-07:00 | UTC-07:00 |
+| `America/Port-au-Prince` | UTC-05:00 | UTC-04:00 |
+| `America/Port_of_Spain` | UTC-04:00 | UTC-04:00 |
+| `America/Porto_Acre` | UTC-05:00 | UTC-05:00 |
+| `America/Porto_Velho` | UTC-04:00 | UTC-04:00 |
+| `America/Puerto_Rico` | UTC-04:00 | UTC-04:00 |
+| `America/Punta_Arenas` | UTC-03:00 | UTC-03:00 |
+| `America/Rainy_River` | UTC-06:00 | UTC-05:00 |
+| `America/Rankin_Inlet` | UTC-06:00 | UTC-05:00 |
+| `America/Recife` | UTC-03:00 | UTC-03:00 |
+| `America/Regina` | UTC-06:00 | UTC-06:00 |
+| `America/Resolute` | UTC-06:00 | UTC-05:00 |
+| `America/Rio_Branco` | UTC-05:00 | UTC-05:00 |
+| `America/Rosario` | UTC-03:00 | UTC-03:00 |
+| `America/Santa_Isabel` | UTC-08:00 | UTC-07:00 |
+| `America/Santarem` | UTC-03:00 | UTC-03:00 |
+| `America/Santiago` | UTC-03:00 | UTC-04:00 |
+| `America/Santo_Domingo` | UTC-04:00 | UTC-04:00 |
+| `America/Sao_Paulo` | UTC-03:00 | UTC-03:00 |
+| `America/Scoresbysund` | UTC-02:00 | UTC-01:00 |
+| `America/Shiprock` | UTC-07:00 | UTC-06:00 |
+| `America/Sitka` | UTC-09:00 | UTC-08:00 |
+| `America/St_Barthelemy` | UTC-04:00 | UTC-04:00 |
+| `America/St_Johns` | UTC-03:30 | UTC-02:30 |
+| `America/St_Kitts` | UTC-04:00 | UTC-04:00 |
+| `America/St_Lucia` | UTC-04:00 | UTC-04:00 |
+| `America/St_Thomas` | UTC-04:00 | UTC-04:00 |
+| `America/St_Vincent` | UTC-04:00 | UTC-04:00 |
+| `America/Swift_Current` | UTC-06:00 | UTC-06:00 |
+| `America/Tegucigalpa` | UTC-06:00 | UTC-06:00 |
+| `America/Thule` | UTC-04:00 | UTC-03:00 |
+| `America/Thunder_Bay` | UTC-05:00 | UTC-04:00 |
+| `America/Tijuana` | UTC-08:00 | UTC-07:00 |
+| `America/Toronto` | UTC-05:00 | UTC-04:00 |
+| `America/Tortola` | UTC-04:00 | UTC-04:00 |
+| `America/Vancouver` | UTC-08:00 | UTC-07:00 |
+| `America/Virgin` | UTC-04:00 | UTC-04:00 |
+| `America/Whitehorse` | UTC-07:00 | UTC-07:00 |
+| `America/Winnipeg` | UTC-06:00 | UTC-05:00 |
+| `America/Yakutat` | UTC-09:00 | UTC-08:00 |
+| `America/Yellowknife` | UTC-07:00 | UTC-06:00 |
+
+## Antarctica
+
+| Zone ID | Offset (January) | Offset (July) |
+| --- | --- | --- |
+| `Antarctica/Casey` | UTC+08:00 | UTC+08:00 |
+| `Antarctica/Davis` | UTC+07:00 | UTC+07:00 |
+| `Antarctica/DumontDUrville` | UTC+10:00 | UTC+10:00 |
+| `Antarctica/Macquarie` | UTC+11:00 | UTC+10:00 |
+| `Antarctica/Mawson` | UTC+05:00 | UTC+05:00 |
+| `Antarctica/McMurdo` | UTC+13:00 | UTC+12:00 |
+| `Antarctica/Palmer` | UTC-03:00 | UTC-03:00 |
+| `Antarctica/Rothera` | UTC-03:00 | UTC-03:00 |
+| `Antarctica/South_Pole` | UTC+13:00 | UTC+12:00 |
+| `Antarctica/Syowa` | UTC+03:00 | UTC+03:00 |
+| `Antarctica/Troll` | UTC | UTC+02:00 |
+| `Antarctica/Vostok` | UTC+05:00 | UTC+05:00 |
+
+## Arctic
+
+| Zone ID | Offset (January) | Offset (July) |
+| --- | --- | --- |
+| `Arctic/Longyearbyen` | UTC+01:00 | UTC+02:00 |
+
+## Asia
+
+| Zone ID | Offset (January) | Offset (July) |
+| --- | --- | --- |
+| `Asia/Aden` | UTC+03:00 | UTC+03:00 |
+| `Asia/Almaty` | UTC+05:00 | UTC+05:00 |
+| `Asia/Amman` | UTC+03:00 | UTC+03:00 |
+| `Asia/Anadyr` | UTC+12:00 | UTC+12:00 |
+| `Asia/Aqtau` | UTC+05:00 | UTC+05:00 |
+| `Asia/Aqtobe` | UTC+05:00 | UTC+05:00 |
+| `Asia/Ashgabat` | UTC+05:00 | UTC+05:00 |
+| `Asia/Ashkhabad` | UTC+05:00 | UTC+05:00 |
+| `Asia/Atyrau` | UTC+05:00 | UTC+05:00 |
+| `Asia/Baghdad` | UTC+03:00 | UTC+03:00 |
+| `Asia/Bahrain` | UTC+03:00 | UTC+03:00 |
+| `Asia/Baku` | UTC+04:00 | UTC+04:00 |
+| `Asia/Bangkok` | UTC+07:00 | UTC+07:00 |
+| `Asia/Barnaul` | UTC+07:00 | UTC+07:00 |
+| `Asia/Beirut` | UTC+02:00 | UTC+03:00 |
+| `Asia/Bishkek` | UTC+06:00 | UTC+06:00 |
+| `Asia/Brunei` | UTC+08:00 | UTC+08:00 |
+| `Asia/Calcutta` | UTC+05:30 | UTC+05:30 |
+| `Asia/Chita` | UTC+09:00 | UTC+09:00 |
+| `Asia/Choibalsan` | UTC+08:00 | UTC+08:00 |
+| `Asia/Chongqing` | UTC+08:00 | UTC+08:00 |
+| `Asia/Chungking` | UTC+08:00 | UTC+08:00 |
+| `Asia/Colombo` | UTC+05:30 | UTC+05:30 |
+| `Asia/Dacca` | UTC+06:00 | UTC+06:00 |
+| `Asia/Damascus` | UTC+03:00 | UTC+03:00 |
+| `Asia/Dhaka` | UTC+06:00 | UTC+06:00 |
+| `Asia/Dili` | UTC+09:00 | UTC+09:00 |
+| `Asia/Dubai` | UTC+04:00 | UTC+04:00 |
+| `Asia/Dushanbe` | UTC+05:00 | UTC+05:00 |
+| `Asia/Famagusta` | UTC+02:00 | UTC+03:00 |
+| `Asia/Gaza` | UTC+02:00 | UTC+03:00 |
+| `Asia/Harbin` | UTC+08:00 | UTC+08:00 |
+| `Asia/Hebron` | UTC+02:00 | UTC+03:00 |
+| `Asia/Ho_Chi_Minh` | UTC+07:00 | UTC+07:00 |
+| `Asia/Hong_Kong` | UTC+08:00 | UTC+08:00 |
+| `Asia/Hovd` | UTC+07:00 | UTC+07:00 |
+| `Asia/Irkutsk` | UTC+08:00 | UTC+08:00 |
+| `Asia/Istanbul` | UTC+03:00 | UTC+03:00 |
+| `Asia/Jakarta` | UTC+07:00 | UTC+07:00 |
+| `Asia/Jayapura` | UTC+09:00 | UTC+09:00 |
+| `Asia/Jerusalem` | UTC+02:00 | UTC+03:00 |
+| `Asia/Kabul` | UTC+04:30 | UTC+04:30 |
+| `Asia/Kamchatka` | UTC+12:00 | UTC+12:00 |
+| `Asia/Karachi` | UTC+05:00 | UTC+05:00 |
+| `Asia/Kashgar` | UTC+06:00 | UTC+06:00 |
+| `Asia/Kathmandu` | UTC+05:45 | UTC+05:45 |
+| `Asia/Katmandu` | UTC+05:45 | UTC+05:45 |
+| `Asia/Khandyga` | UTC+09:00 | UTC+09:00 |
+| `Asia/Kolkata` | UTC+05:30 | UTC+05:30 |
+| `Asia/Krasnoyarsk` | UTC+07:00 | UTC+07:00 |
+| `Asia/Kuala_Lumpur` | UTC+08:00 | UTC+08:00 |
+| `Asia/Kuching` | UTC+08:00 | UTC+08:00 |
+| `Asia/Kuwait` | UTC+03:00 | UTC+03:00 |
+| `Asia/Macao` | UTC+08:00 | UTC+08:00 |
+| `Asia/Macau` | UTC+08:00 | UTC+08:00 |
+| `Asia/Magadan` | UTC+11:00 | UTC+11:00 |
+| `Asia/Makassar` | UTC+08:00 | UTC+08:00 |
+| `Asia/Manila` | UTC+08:00 | UTC+08:00 |
+| `Asia/Muscat` | UTC+04:00 | UTC+04:00 |
+| `Asia/Nicosia` | UTC+02:00 | UTC+03:00 |
+| `Asia/Novokuznetsk` | UTC+07:00 | UTC+07:00 |
+| `Asia/Novosibirsk` | UTC+07:00 | UTC+07:00 |
+| `Asia/Omsk` | UTC+06:00 | UTC+06:00 |
+| `Asia/Oral` | UTC+05:00 | UTC+05:00 |
+| `Asia/Phnom_Penh` | UTC+07:00 | UTC+07:00 |
+| `Asia/Pontianak` | UTC+07:00 | UTC+07:00 |
+| `Asia/Pyongyang` | UTC+09:00 | UTC+09:00 |
+| `Asia/Qatar` | UTC+03:00 | UTC+03:00 |
+| `Asia/Qostanay` | UTC+05:00 | UTC+05:00 |
+| `Asia/Qyzylorda` | UTC+05:00 | UTC+05:00 |
+| `Asia/Rangoon` | UTC+06:30 | UTC+06:30 |
+| `Asia/Riyadh` | UTC+03:00 | UTC+03:00 |
+| `Asia/Saigon` | UTC+07:00 | UTC+07:00 |
+| `Asia/Sakhalin` | UTC+11:00 | UTC+11:00 |
+| `Asia/Samarkand` | UTC+05:00 | UTC+05:00 |
+| `Asia/Seoul` | UTC+09:00 | UTC+09:00 |
+| `Asia/Shanghai` | UTC+08:00 | UTC+08:00 |
+| `Asia/Singapore` | UTC+08:00 | UTC+08:00 |
+| `Asia/Srednekolymsk` | UTC+11:00 | UTC+11:00 |
+| `Asia/Taipei` | UTC+08:00 | UTC+08:00 |
+| `Asia/Tashkent` | UTC+05:00 | UTC+05:00 |
+| `Asia/Tbilisi` | UTC+04:00 | UTC+04:00 |
+| `Asia/Tehran` | UTC+03:30 | UTC+03:30 |
+| `Asia/Tel_Aviv` | UTC+02:00 | UTC+03:00 |
+| `Asia/Thimbu` | UTC+06:00 | UTC+06:00 |
+| `Asia/Thimphu` | UTC+06:00 | UTC+06:00 |
+| `Asia/Tokyo` | UTC+09:00 | UTC+09:00 |
+| `Asia/Tomsk` | UTC+07:00 | UTC+07:00 |
+| `Asia/Ujung_Pandang` | UTC+08:00 | UTC+08:00 |
+| `Asia/Ulaanbaatar` | UTC+08:00 | UTC+08:00 |
+| `Asia/Ulan_Bator` | UTC+08:00 | UTC+08:00 |
+| `Asia/Urumqi` | UTC+06:00 | UTC+06:00 |
+| `Asia/Ust-Nera` | UTC+10:00 | UTC+10:00 |
+| `Asia/Vientiane` | UTC+07:00 | UTC+07:00 |
+| `Asia/Vladivostok` | UTC+10:00 | UTC+10:00 |
+| `Asia/Yakutsk` | UTC+09:00 | UTC+09:00 |
+| `Asia/Yangon` | UTC+06:30 | UTC+06:30 |
+| `Asia/Yekaterinburg` | UTC+05:00 | UTC+05:00 |
+| `Asia/Yerevan` | UTC+04:00 | UTC+04:00 |
+
+## Atlantic
+
+| Zone ID | Offset (January) | Offset (July) |
+| --- | --- | --- |
+| `Atlantic/Azores` | UTC-01:00 | UTC |
+| `Atlantic/Bermuda` | UTC-04:00 | UTC-03:00 |
+| `Atlantic/Canary` | UTC | UTC+01:00 |
+| `Atlantic/Cape_Verde` | UTC-01:00 | UTC-01:00 |
+| `Atlantic/Faeroe` | UTC | UTC+01:00 |
+| `Atlantic/Faroe` | UTC | UTC+01:00 |
+| `Atlantic/Jan_Mayen` | UTC+01:00 | UTC+02:00 |
+| `Atlantic/Madeira` | UTC | UTC+01:00 |
+| `Atlantic/Reykjavik` | UTC | UTC |
+| `Atlantic/South_Georgia` | UTC-02:00 | UTC-02:00 |
+| `Atlantic/St_Helena` | UTC | UTC |
+| `Atlantic/Stanley` | UTC-03:00 | UTC-03:00 |
+
+## Australia
+
+| Zone ID | Offset (January) | Offset (July) |
+| --- | --- | --- |
+| `Australia/ACT` | UTC+11:00 | UTC+10:00 |
+| `Australia/Adelaide` | UTC+10:30 | UTC+09:30 |
+| `Australia/Brisbane` | UTC+10:00 | UTC+10:00 |
+| `Australia/Broken_Hill` | UTC+10:30 | UTC+09:30 |
+| `Australia/Canberra` | UTC+11:00 | UTC+10:00 |
+| `Australia/Currie` | UTC+11:00 | UTC+10:00 |
+| `Australia/Darwin` | UTC+09:30 | UTC+09:30 |
+| `Australia/Eucla` | UTC+08:45 | UTC+08:45 |
+| `Australia/Hobart` | UTC+11:00 | UTC+10:00 |
+| `Australia/LHI` | UTC+11:00 | UTC+10:30 |
+| `Australia/Lindeman` | UTC+10:00 | UTC+10:00 |
+| `Australia/Lord_Howe` | UTC+11:00 | UTC+10:30 |
+| `Australia/Melbourne` | UTC+11:00 | UTC+10:00 |
+| `Australia/NSW` | UTC+11:00 | UTC+10:00 |
+| `Australia/North` | UTC+09:30 | UTC+09:30 |
+| `Australia/Perth` | UTC+08:00 | UTC+08:00 |
+| `Australia/Queensland` | UTC+10:00 | UTC+10:00 |
+| `Australia/South` | UTC+10:30 | UTC+09:30 |
+| `Australia/Sydney` | UTC+11:00 | UTC+10:00 |
+| `Australia/Tasmania` | UTC+11:00 | UTC+10:00 |
+| `Australia/Victoria` | UTC+11:00 | UTC+10:00 |
+| `Australia/West` | UTC+08:00 | UTC+08:00 |
+| `Australia/Yancowinna` | UTC+10:30 | UTC+09:30 |
+
+## Brazil
+
+| Zone ID | Offset (January) | Offset (July) |
+| --- | --- | --- |
+| `Brazil/Acre` | UTC-05:00 | UTC-05:00 |
+| `Brazil/DeNoronha` | UTC-02:00 | UTC-02:00 |
+| `Brazil/East` | UTC-03:00 | UTC-03:00 |
+| `Brazil/West` | UTC-04:00 | UTC-04:00 |
+
+## Canada
+
+| Zone ID | Offset (January) | Offset (July) |
+| --- | --- | --- |
+| `Canada/Atlantic` | UTC-04:00 | UTC-03:00 |
+| `Canada/Central` | UTC-06:00 | UTC-05:00 |
+| `Canada/Eastern` | UTC-05:00 | UTC-04:00 |
+| `Canada/Mountain` | UTC-07:00 | UTC-06:00 |
+| `Canada/Newfoundland` | UTC-03:30 | UTC-02:30 |
+| `Canada/Pacific` | UTC-08:00 | UTC-07:00 |
+| `Canada/Saskatchewan` | UTC-06:00 | UTC-06:00 |
+| `Canada/Yukon` | UTC-07:00 | UTC-07:00 |
+
+## Chile
+
+| Zone ID | Offset (January) | Offset (July) |
+| --- | --- | --- |
+| `Chile/Continental` | UTC-03:00 | UTC-04:00 |
+| `Chile/EasterIsland` | UTC-05:00 | UTC-06:00 |
+
+## Europe
+
+| Zone ID | Offset (January) | Offset (July) |
+| --- | --- | --- |
+| `Europe/Amsterdam` | UTC+01:00 | UTC+02:00 |
+| `Europe/Andorra` | UTC+01:00 | UTC+02:00 |
+| `Europe/Astrakhan` | UTC+04:00 | UTC+04:00 |
+| `Europe/Athens` | UTC+02:00 | UTC+03:00 |
+| `Europe/Belfast` | UTC | UTC+01:00 |
+| `Europe/Belgrade` | UTC+01:00 | UTC+02:00 |
+| `Europe/Berlin` | UTC+01:00 | UTC+02:00 |
+| `Europe/Bratislava` | UTC+01:00 | UTC+02:00 |
+| `Europe/Brussels` | UTC+01:00 | UTC+02:00 |
+| `Europe/Bucharest` | UTC+02:00 | UTC+03:00 |
+| `Europe/Budapest` | UTC+01:00 | UTC+02:00 |
+| `Europe/Busingen` | UTC+01:00 | UTC+02:00 |
+| `Europe/Chisinau` | UTC+02:00 | UTC+03:00 |
+| `Europe/Copenhagen` | UTC+01:00 | UTC+02:00 |
+| `Europe/Dublin` | UTC | UTC+01:00 |
+| `Europe/Gibraltar` | UTC+01:00 | UTC+02:00 |
+| `Europe/Guernsey` | UTC | UTC+01:00 |
+| `Europe/Helsinki` | UTC+02:00 | UTC+03:00 |
+| `Europe/Isle_of_Man` | UTC | UTC+01:00 |
+| `Europe/Istanbul` | UTC+03:00 | UTC+03:00 |
+| `Europe/Jersey` | UTC | UTC+01:00 |
+| `Europe/Kaliningrad` | UTC+02:00 | UTC+02:00 |
+| `Europe/Kiev` | UTC+02:00 | UTC+03:00 |
+| `Europe/Kirov` | UTC+03:00 | UTC+03:00 |
+| `Europe/Kyiv` | UTC+02:00 | UTC+03:00 |
+| `Europe/Lisbon` | UTC | UTC+01:00 |
+| `Europe/Ljubljana` | UTC+01:00 | UTC+02:00 |
+| `Europe/London` | UTC | UTC+01:00 |
+| `Europe/Luxembourg` | UTC+01:00 | UTC+02:00 |
+| `Europe/Madrid` | UTC+01:00 | UTC+02:00 |
+| `Europe/Malta` | UTC+01:00 | UTC+02:00 |
+| `Europe/Mariehamn` | UTC+02:00 | UTC+03:00 |
+| `Europe/Minsk` | UTC+03:00 | UTC+03:00 |
+| `Europe/Monaco` | UTC+01:00 | UTC+02:00 |
+| `Europe/Moscow` | UTC+03:00 | UTC+03:00 |
+| `Europe/Nicosia` | UTC+02:00 | UTC+03:00 |
+| `Europe/Oslo` | UTC+01:00 | UTC+02:00 |
+| `Europe/Paris` | UTC+01:00 | UTC+02:00 |
+| `Europe/Podgorica` | UTC+01:00 | UTC+02:00 |
+| `Europe/Prague` | UTC+01:00 | UTC+02:00 |
+| `Europe/Riga` | UTC+02:00 | UTC+03:00 |
+| `Europe/Rome` | UTC+01:00 | UTC+02:00 |
+| `Europe/Samara` | UTC+04:00 | UTC+04:00 |
+| `Europe/San_Marino` | UTC+01:00 | UTC+02:00 |
+| `Europe/Sarajevo` | UTC+01:00 | UTC+02:00 |
+| `Europe/Saratov` | UTC+04:00 | UTC+04:00 |
+| `Europe/Simferopol` | UTC+03:00 | UTC+03:00 |
+| `Europe/Skopje` | UTC+01:00 | UTC+02:00 |
+| `Europe/Sofia` | UTC+02:00 | UTC+03:00 |
+| `Europe/Stockholm` | UTC+01:00 | UTC+02:00 |
+| `Europe/Tallinn` | UTC+02:00 | UTC+03:00 |
+| `Europe/Tirane` | UTC+01:00 | UTC+02:00 |
+| `Europe/Tiraspol` | UTC+02:00 | UTC+03:00 |
+| `Europe/Ulyanovsk` | UTC+04:00 | UTC+04:00 |
+| `Europe/Uzhgorod` | UTC+02:00 | UTC+03:00 |
+| `Europe/Vaduz` | UTC+01:00 | UTC+02:00 |
+| `Europe/Vatican` | UTC+01:00 | UTC+02:00 |
+| `Europe/Vienna` | UTC+01:00 | UTC+02:00 |
+| `Europe/Vilnius` | UTC+02:00 | UTC+03:00 |
+| `Europe/Volgograd` | UTC+03:00 | UTC+03:00 |
+| `Europe/Warsaw` | UTC+01:00 | UTC+02:00 |
+| `Europe/Zagreb` | UTC+01:00 | UTC+02:00 |
+| `Europe/Zaporozhye` | UTC+02:00 | UTC+03:00 |
+| `Europe/Zurich` | UTC+01:00 | UTC+02:00 |
+
+## Indian
+
+| Zone ID | Offset (January) | Offset (July) |
+| --- | --- | --- |
+| `Indian/Antananarivo` | UTC+03:00 | UTC+03:00 |
+| `Indian/Chagos` | UTC+06:00 | UTC+06:00 |
+| `Indian/Christmas` | UTC+07:00 | UTC+07:00 |
+| `Indian/Cocos` | UTC+06:30 | UTC+06:30 |
+| `Indian/Comoro` | UTC+03:00 | UTC+03:00 |
+| `Indian/Kerguelen` | UTC+05:00 | UTC+05:00 |
+| `Indian/Mahe` | UTC+04:00 | UTC+04:00 |
+| `Indian/Maldives` | UTC+05:00 | UTC+05:00 |
+| `Indian/Mauritius` | UTC+04:00 | UTC+04:00 |
+| `Indian/Mayotte` | UTC+03:00 | UTC+03:00 |
+| `Indian/Reunion` | UTC+04:00 | UTC+04:00 |
+
+## Mexico
+
+| Zone ID | Offset (January) | Offset (July) |
+| --- | --- | --- |
+| `Mexico/BajaNorte` | UTC-08:00 | UTC-07:00 |
+| `Mexico/BajaSur` | UTC-07:00 | UTC-07:00 |
+| `Mexico/General` | UTC-06:00 | UTC-06:00 |
+
+## Pacific
+
+| Zone ID | Offset (January) | Offset (July) |
+| --- | --- | --- |
+| `Pacific/Apia` | UTC+13:00 | UTC+13:00 |
+| `Pacific/Auckland` | UTC+13:00 | UTC+12:00 |
+| `Pacific/Bougainville` | UTC+11:00 | UTC+11:00 |
+| `Pacific/Chatham` | UTC+13:45 | UTC+12:45 |
+| `Pacific/Chuuk` | UTC+10:00 | UTC+10:00 |
+| `Pacific/Easter` | UTC-05:00 | UTC-06:00 |
+| `Pacific/Efate` | UTC+11:00 | UTC+11:00 |
+| `Pacific/Enderbury` | UTC+13:00 | UTC+13:00 |
+| `Pacific/Fakaofo` | UTC+13:00 | UTC+13:00 |
+| `Pacific/Fiji` | UTC+12:00 | UTC+12:00 |
+| `Pacific/Funafuti` | UTC+12:00 | UTC+12:00 |
+| `Pacific/Galapagos` | UTC-06:00 | UTC-06:00 |
+| `Pacific/Gambier` | UTC-09:00 | UTC-09:00 |
+| `Pacific/Guadalcanal` | UTC+11:00 | UTC+11:00 |
+| `Pacific/Guam` | UTC+10:00 | UTC+10:00 |
+| `Pacific/Honolulu` | UTC-10:00 | UTC-10:00 |
+| `Pacific/Johnston` | UTC-10:00 | UTC-10:00 |
+| `Pacific/Kanton` | UTC+13:00 | UTC+13:00 |
+| `Pacific/Kiritimati` | UTC+14:00 | UTC+14:00 |
+| `Pacific/Kosrae` | UTC+11:00 | UTC+11:00 |
+| `Pacific/Kwajalein` | UTC+12:00 | UTC+12:00 |
+| `Pacific/Majuro` | UTC+12:00 | UTC+12:00 |
+| `Pacific/Marquesas` | UTC-09:30 | UTC-09:30 |
+| `Pacific/Midway` | UTC-11:00 | UTC-11:00 |
+| `Pacific/Nauru` | UTC+12:00 | UTC+12:00 |
+| `Pacific/Niue` | UTC-11:00 | UTC-11:00 |
+| `Pacific/Norfolk` | UTC+12:00 | UTC+11:00 |
+| `Pacific/Noumea` | UTC+11:00 | UTC+11:00 |
+| `Pacific/Pago_Pago` | UTC-11:00 | UTC-11:00 |
+| `Pacific/Palau` | UTC+09:00 | UTC+09:00 |
+| `Pacific/Pitcairn` | UTC-08:00 | UTC-08:00 |
+| `Pacific/Pohnpei` | UTC+11:00 | UTC+11:00 |
+| `Pacific/Ponape` | UTC+11:00 | UTC+11:00 |
+| `Pacific/Port_Moresby` | UTC+10:00 | UTC+10:00 |
+| `Pacific/Rarotonga` | UTC-10:00 | UTC-10:00 |
+| `Pacific/Saipan` | UTC+10:00 | UTC+10:00 |
+| `Pacific/Samoa` | UTC-11:00 | UTC-11:00 |
+| `Pacific/Tahiti` | UTC-10:00 | UTC-10:00 |
+| `Pacific/Tarawa` | UTC+12:00 | UTC+12:00 |
+| `Pacific/Tongatapu` | UTC+13:00 | UTC+13:00 |
+| `Pacific/Truk` | UTC+10:00 | UTC+10:00 |
+| `Pacific/Wake` | UTC+12:00 | UTC+12:00 |
+| `Pacific/Wallis` | UTC+12:00 | UTC+12:00 |
+| `Pacific/Yap` | UTC+10:00 | UTC+10:00 |
+
+## US
+
+| Zone ID | Offset (January) | Offset (July) |
+| --- | --- | --- |
+| `US/Alaska` | UTC-09:00 | UTC-08:00 |
+| `US/Aleutian` | UTC-10:00 | UTC-09:00 |
+| `US/Arizona` | UTC-07:00 | UTC-07:00 |
+| `US/Central` | UTC-06:00 | UTC-05:00 |
+| `US/East-Indiana` | UTC-05:00 | UTC-04:00 |
+| `US/Eastern` | UTC-05:00 | UTC-04:00 |
+| `US/Hawaii` | UTC-10:00 | UTC-10:00 |
+| `US/Indiana-Starke` | UTC-06:00 | UTC-05:00 |
+| `US/Michigan` | UTC-05:00 | UTC-04:00 |
+| `US/Mountain` | UTC-07:00 | UTC-06:00 |
+| `US/Pacific` | UTC-08:00 | UTC-07:00 |
+| `US/Samoa` | UTC-11:00 | UTC-11:00 |
+
+## Legacy and fixed-offset IDs
+
+The tz database keeps these for backwards compatibility. Each is either an alias for a
+`Region/City` zone or a fixed offset that never shifts, so prefer the `Region/City` form
+above. `UTC` is the one worth using directly: it is the default, and the right choice when
+you want timestamps to stay comparable across hosts.
+
+The `Etc/GMT+N` IDs have **inverted** signs, a tz database quirk: `Etc/GMT+5` is five hours
+*behind* UTC.
+
+| Zone ID | Offset (January) | Offset (July) |
+| --- | --- | --- |
+| `CET` | UTC+01:00 | UTC+02:00 |
+| `CST6CDT` | UTC-06:00 | UTC-05:00 |
+| `Cuba` | UTC-05:00 | UTC-04:00 |
+| `EET` | UTC+02:00 | UTC+03:00 |
+| `EST5EDT` | UTC-05:00 | UTC-04:00 |
+| `Egypt` | UTC+02:00 | UTC+03:00 |
+| `Eire` | UTC | UTC+01:00 |
+| `Etc/GMT` | UTC | UTC |
+| `Etc/GMT+0` | UTC | UTC |
+| `Etc/GMT+1` | UTC-01:00 | UTC-01:00 |
+| `Etc/GMT+10` | UTC-10:00 | UTC-10:00 |
+| `Etc/GMT+11` | UTC-11:00 | UTC-11:00 |
+| `Etc/GMT+12` | UTC-12:00 | UTC-12:00 |
+| `Etc/GMT+2` | UTC-02:00 | UTC-02:00 |
+| `Etc/GMT+3` | UTC-03:00 | UTC-03:00 |
+| `Etc/GMT+4` | UTC-04:00 | UTC-04:00 |
+| `Etc/GMT+5` | UTC-05:00 | UTC-05:00 |
+| `Etc/GMT+6` | UTC-06:00 | UTC-06:00 |
+| `Etc/GMT+7` | UTC-07:00 | UTC-07:00 |
+| `Etc/GMT+8` | UTC-08:00 | UTC-08:00 |
+| `Etc/GMT+9` | UTC-09:00 | UTC-09:00 |
+| `Etc/GMT-0` | UTC | UTC |
+| `Etc/GMT-1` | UTC+01:00 | UTC+01:00 |
+| `Etc/GMT-10` | UTC+10:00 | UTC+10:00 |
+| `Etc/GMT-11` | UTC+11:00 | UTC+11:00 |
+| `Etc/GMT-12` | UTC+12:00 | UTC+12:00 |
+| `Etc/GMT-13` | UTC+13:00 | UTC+13:00 |
+| `Etc/GMT-14` | UTC+14:00 | UTC+14:00 |
+| `Etc/GMT-2` | UTC+02:00 | UTC+02:00 |
+| `Etc/GMT-3` | UTC+03:00 | UTC+03:00 |
+| `Etc/GMT-4` | UTC+04:00 | UTC+04:00 |
+| `Etc/GMT-5` | UTC+05:00 | UTC+05:00 |
+| `Etc/GMT-6` | UTC+06:00 | UTC+06:00 |
+| `Etc/GMT-7` | UTC+07:00 | UTC+07:00 |
+| `Etc/GMT-8` | UTC+08:00 | UTC+08:00 |
+| `Etc/GMT-9` | UTC+09:00 | UTC+09:00 |
+| `Etc/GMT0` | UTC | UTC |
+| `Etc/Greenwich` | UTC | UTC |
+| `Etc/UCT` | UTC | UTC |
+| `Etc/UTC` | UTC | UTC |
+| `Etc/Universal` | UTC | UTC |
+| `Etc/Zulu` | UTC | UTC |
+| `GB` | UTC | UTC+01:00 |
+| `GB-Eire` | UTC | UTC+01:00 |
+| `GMT` | UTC | UTC |
+| `GMT0` | UTC | UTC |
+| `Greenwich` | UTC | UTC |
+| `Hongkong` | UTC+08:00 | UTC+08:00 |
+| `Iceland` | UTC | UTC |
+| `Iran` | UTC+03:30 | UTC+03:30 |
+| `Israel` | UTC+02:00 | UTC+03:00 |
+| `Jamaica` | UTC-05:00 | UTC-05:00 |
+| `Japan` | UTC+09:00 | UTC+09:00 |
+| `Kwajalein` | UTC+12:00 | UTC+12:00 |
+| `Libya` | UTC+02:00 | UTC+02:00 |
+| `MET` | UTC+01:00 | UTC+02:00 |
+| `MST7MDT` | UTC-07:00 | UTC-06:00 |
+| `NZ` | UTC+13:00 | UTC+12:00 |
+| `NZ-CHAT` | UTC+13:45 | UTC+12:45 |
+| `Navajo` | UTC-07:00 | UTC-06:00 |
+| `PRC` | UTC+08:00 | UTC+08:00 |
+| `PST8PDT` | UTC-08:00 | UTC-07:00 |
+| `Poland` | UTC+01:00 | UTC+02:00 |
+| `Portugal` | UTC | UTC+01:00 |
+| `ROK` | UTC+09:00 | UTC+09:00 |
+| `Singapore` | UTC+08:00 | UTC+08:00 |
+| `SystemV/AST4` | UTC-04:00 | UTC-04:00 |
+| `SystemV/AST4ADT` | UTC-04:00 | UTC-03:00 |
+| `SystemV/CST6` | UTC-06:00 | UTC-06:00 |
+| `SystemV/CST6CDT` | UTC-06:00 | UTC-05:00 |
+| `SystemV/EST5` | UTC-05:00 | UTC-05:00 |
+| `SystemV/EST5EDT` | UTC-05:00 | UTC-04:00 |
+| `SystemV/HST10` | UTC-10:00 | UTC-10:00 |
+| `SystemV/MST7` | UTC-07:00 | UTC-07:00 |
+| `SystemV/MST7MDT` | UTC-07:00 | UTC-06:00 |
+| `SystemV/PST8` | UTC-08:00 | UTC-08:00 |
+| `SystemV/PST8PDT` | UTC-08:00 | UTC-07:00 |
+| `SystemV/YST9` | UTC-09:00 | UTC-09:00 |
+| `SystemV/YST9YDT` | UTC-09:00 | UTC-08:00 |
+| `Turkey` | UTC+03:00 | UTC+03:00 |
+| `UCT` | UTC | UTC |
+| `UTC` | UTC | UTC |
+| `Universal` | UTC | UTC |
+| `W-SU` | UTC+03:00 | UTC+03:00 |
+| `WET` | UTC | UTC+01:00 |
+| `Zulu` | UTC | UTC |
+

--- a/server/src/main/kotlin/com/darkrockstudios/apps/hammer/Application.kt
+++ b/server/src/main/kotlin/com/darkrockstudios/apps/hammer/Application.kt
@@ -25,10 +25,12 @@ import com.darkrockstudios.apps.hammer.plugins.configureSerialization
 import com.darkrockstudios.apps.hammer.secret.KeyringCodec
 import com.darkrockstudios.apps.hammer.utilities.DevSelfSignedCert
 import com.darkrockstudios.apps.hammer.utilities.DiskCache
+import com.darkrockstudios.apps.hammer.utilities.applyServerTimeZone
 import com.darkrockstudios.apps.hammer.utilities.cacheDirectory
 import com.darkrockstudios.apps.hammer.utilities.configureDiskCachePruneJob
 import com.darkrockstudios.apps.hammer.utilities.getRootDataDirectory
 import com.darkrockstudios.apps.hammer.utilities.loadPemAsKeyStore
+import com.darkrockstudios.apps.hammer.utilities.resolveServerTimeZone
 import com.github.ajalt.clikt.core.CliktCommand
 import com.github.ajalt.clikt.core.main
 import com.github.ajalt.clikt.core.subcommands
@@ -90,6 +92,10 @@ class HammerServerCommand : CliktCommand(name = "Hammer Server") {
 
 		val logLevel = parseLogLevel(logLevelArg)
 		val config: ServerConfig = resolveServerConfig(configPath)
+
+		val timeZone = resolveServerTimeZone(config.timezone)
+		applyServerTimeZone(timeZone)
+		configLogger.info("Server time zone: $timeZone")
 
 		config.storage.validate()
 		config.analytics.validate()

--- a/server/src/main/kotlin/com/darkrockstudios/apps/hammer/ServerConfig.kt
+++ b/server/src/main/kotlin/com/darkrockstudios/apps/hammer/ServerConfig.kt
@@ -35,6 +35,12 @@ data class ServerConfig(
 	 * them. Assumes a single proxy: the address comes from the last `X-Forwarded-For` entry.
 	 */
 	val trustProxyForwarding: Boolean = false,
+	/**
+	 * IANA zone ID (e.g. "Europe/Paris") that server-rendered timestamps and log lines are stamped
+	 * in. Absent, the `HAMMER_TIMEZONE` environment variable is used, then `TZ`, then the host's own
+	 * zone. An unknown ID aborts startup.
+	 */
+	val timezone: String? = null,
 	val additionalSitemaps: List<String> = emptyList(),
 	/**
 	 * Generate per-page social share images (OpenGraph) on the fly for author and story pages.

--- a/server/src/main/kotlin/com/darkrockstudios/apps/hammer/frontend/MonitoringPage.kt
+++ b/server/src/main/kotlin/com/darkrockstudios/apps/hammer/frontend/MonitoringPage.kt
@@ -464,7 +464,7 @@ private fun securityAlertModel(alert: SecurityAlert): Map<String, Any> = mapOf(
  * are floored to the UTC day, so labeling one anywhere else shifts every point onto a neighboring
  * date.
  */
-private fun chartLabelZone(hourly: Boolean): ZoneId = if (hourly) ZoneId.systemDefault() else ZoneOffset.UTC
+internal fun chartLabelZone(hourly: Boolean): ZoneId = if (hourly) ZoneId.systemDefault() else ZoneOffset.UTC
 
 private fun buildErrorRateChart(points: List<TimeSeriesPoint>, labelFormat: String, zone: ZoneId): String {
 	val payload = ErrorRateChartPayload(
@@ -484,7 +484,7 @@ private fun buildLatencyChart(points: List<TimeSeriesPoint>, labelFormat: String
 	return Json.encodeToString(LatencyChartPayload.serializer(), payload)
 }
 
-private fun buildActiveUsersChart(daily: List<DailyActiveUsers>): String {
+internal fun buildActiveUsersChart(daily: List<DailyActiveUsers>): String {
 	val payload = ActiveUsersChartPayload(
 		labels = daily.map { formatInstant(it.day, "MMM dd", ZoneOffset.UTC) },
 		sync = daily.map { it.sync },
@@ -493,7 +493,7 @@ private fun buildActiveUsersChart(daily: List<DailyActiveUsers>): String {
 	return Json.encodeToString(ActiveUsersChartPayload.serializer(), payload)
 }
 
-private fun buildReadersChart(daily: List<ReaderDay>): String {
+internal fun buildReadersChart(daily: List<ReaderDay>): String {
 	val payload = ReadersChartPayload(
 		labels = daily.map { formatInstant(it.day, "MMM dd", ZoneOffset.UTC) },
 		readers = daily.map { it.count },
@@ -501,7 +501,7 @@ private fun buildReadersChart(daily: List<ReaderDay>): String {
 	return Json.encodeToString(ReadersChartPayload.serializer(), payload)
 }
 
-private fun buildTrafficChart(points: List<TimeSeriesPoint>): String {
+internal fun buildTrafficChart(points: List<TimeSeriesPoint>): String {
 	val payload = ChartPayload(
 		labels = points.map { formatInstant(it.bucketStart, "MMM dd", ZoneOffset.UTC) },
 		requests = points.map { it.requests },

--- a/server/src/main/kotlin/com/darkrockstudios/apps/hammer/frontend/MonitoringPage.kt
+++ b/server/src/main/kotlin/com/darkrockstudios/apps/hammer/frontend/MonitoringPage.kt
@@ -43,6 +43,8 @@ import kotlinx.serialization.Serializable
 import kotlinx.serialization.builtins.ListSerializer
 import kotlinx.serialization.json.Json
 import java.net.URLEncoder
+import java.time.ZoneId
+import java.time.ZoneOffset
 import kotlin.math.ceil
 import kotlin.time.Clock
 import kotlin.time.Duration.Companion.days
@@ -140,9 +142,10 @@ fun Route.adminMonitoringPages(
 			val range = call.request.queryParameters["range"] ?: RANGE_24H
 			val since = clock.now() - rangeToDuration(range)
 			val stats = metricsRepository.getEndpointStats(since)
-			val labelFormat = if (range == RANGE_24H) "HH:00" else "MMM dd"
-			val timeSeries = metricsRepository.getTimeSeries(since, range == RANGE_24H)
-			val latencyChart = buildLatencyChart(timeSeries, labelFormat)
+			val hourly = range == RANGE_24H
+			val labelFormat = if (hourly) "HH:00" else "MMM dd"
+			val timeSeries = metricsRepository.getTimeSeries(since, hourly)
+			val latencyChart = buildLatencyChart(timeSeries, labelFormat, chartLabelZone(hourly))
 
 			val model = mutableMapOf<String, Any>(
 				"page_stylesheet" to "/assets/css/admin.css",
@@ -164,9 +167,10 @@ fun Route.adminMonitoringPages(
 		get("/errors") {
 			val range = call.request.queryParameters["range"] ?: RANGE_24H
 			val since = clock.now() - rangeToDuration(range)
-			val labelFormat = if (range == RANGE_24H) "HH:00" else "MMM dd"
-			val timeSeries = metricsRepository.getTimeSeries(since, range == RANGE_24H)
-			val errorRateChart = buildErrorRateChart(timeSeries, labelFormat)
+			val hourly = range == RANGE_24H
+			val labelFormat = if (hourly) "HH:00" else "MMM dd"
+			val timeSeries = metricsRepository.getTimeSeries(since, hourly)
+			val errorRateChart = buildErrorRateChart(timeSeries, labelFormat, chartLabelZone(hourly))
 
 			val routeFilter = call.request.queryParameters["route"]?.takeIf { it.isNotBlank() }
 			val ignoreRules = configRepository.get(AdminServerConfig.IGNORED_ERROR_RULES)
@@ -455,9 +459,16 @@ private fun securityAlertModel(alert: SecurityAlert): Map<String, Any> = mapOf(
 	"href" to "/admin/monitoring/security",
 )
 
-private fun buildErrorRateChart(points: List<TimeSeriesPoint>, labelFormat: String): String {
+/**
+ * Hourly buckets are ordinary instants, so they read best in the server's own zone. Daily buckets
+ * are floored to the UTC day, so labeling one anywhere else shifts every point onto a neighboring
+ * date.
+ */
+private fun chartLabelZone(hourly: Boolean): ZoneId = if (hourly) ZoneId.systemDefault() else ZoneOffset.UTC
+
+private fun buildErrorRateChart(points: List<TimeSeriesPoint>, labelFormat: String, zone: ZoneId): String {
 	val payload = ErrorRateChartPayload(
-		labels = points.map { formatInstant(it.bucketStart, labelFormat) },
+		labels = points.map { formatInstant(it.bucketStart, labelFormat, zone) },
 		errorRates = points.map { pt ->
 			if (pt.requests > 0) pt.errors.toDouble() / pt.requests * 100.0 else 0.0
 		},
@@ -465,9 +476,9 @@ private fun buildErrorRateChart(points: List<TimeSeriesPoint>, labelFormat: Stri
 	return Json.encodeToString(ErrorRateChartPayload.serializer(), payload)
 }
 
-private fun buildLatencyChart(points: List<TimeSeriesPoint>, labelFormat: String): String {
+private fun buildLatencyChart(points: List<TimeSeriesPoint>, labelFormat: String, zone: ZoneId): String {
 	val payload = LatencyChartPayload(
-		labels = points.map { formatInstant(it.bucketStart, labelFormat) },
+		labels = points.map { formatInstant(it.bucketStart, labelFormat, zone) },
 		p95Ms = points.map { it.p95Ms },
 	)
 	return Json.encodeToString(LatencyChartPayload.serializer(), payload)
@@ -475,7 +486,7 @@ private fun buildLatencyChart(points: List<TimeSeriesPoint>, labelFormat: String
 
 private fun buildActiveUsersChart(daily: List<DailyActiveUsers>): String {
 	val payload = ActiveUsersChartPayload(
-		labels = daily.map { formatInstant(it.day, "MMM dd") },
+		labels = daily.map { formatInstant(it.day, "MMM dd", ZoneOffset.UTC) },
 		sync = daily.map { it.sync },
 		web = daily.map { it.web },
 	)
@@ -484,7 +495,7 @@ private fun buildActiveUsersChart(daily: List<DailyActiveUsers>): String {
 
 private fun buildReadersChart(daily: List<ReaderDay>): String {
 	val payload = ReadersChartPayload(
-		labels = daily.map { formatInstant(it.day, "MMM dd") },
+		labels = daily.map { formatInstant(it.day, "MMM dd", ZoneOffset.UTC) },
 		readers = daily.map { it.count },
 	)
 	return Json.encodeToString(ReadersChartPayload.serializer(), payload)
@@ -492,7 +503,7 @@ private fun buildReadersChart(daily: List<ReaderDay>): String {
 
 private fun buildTrafficChart(points: List<TimeSeriesPoint>): String {
 	val payload = ChartPayload(
-		labels = points.map { formatInstant(it.bucketStart, "MMM dd") },
+		labels = points.map { formatInstant(it.bucketStart, "MMM dd", ZoneOffset.UTC) },
 		requests = points.map { it.requests },
 		errors = points.map { it.errors },
 	)

--- a/server/src/main/kotlin/com/darkrockstudios/apps/hammer/frontend/ReviewFrontend.kt
+++ b/server/src/main/kotlin/com/darkrockstudios/apps/hammer/frontend/ReviewFrontend.kt
@@ -49,7 +49,7 @@ import io.ktor.server.routing.route
 import io.ktor.server.sessions.get
 import io.ktor.server.sessions.sessions
 import kotlinx.serialization.Serializable
-import java.time.ZoneOffset
+import java.time.ZoneId
 import java.time.format.DateTimeFormatter
 import kotlin.time.Clock
 import kotlin.time.Duration.Companion.days
@@ -883,7 +883,7 @@ private fun ApplicationCall.requestReviewUrl(token: String): String =
 
 internal fun formatReviewDate(instant: Instant): String =
 	DateTimeFormatter.ofPattern("MMM d, yyyy", java.util.Locale.ENGLISH)
-		.withZone(ZoneOffset.UTC)
+		.withZone(ZoneId.systemDefault())
 		.format(instant.toJavaInstant())
 
 /** Card models for the Editorial Reviews panel, newest first, revoked requests hidden. */

--- a/server/src/main/kotlin/com/darkrockstudios/apps/hammer/review/ReviewRepository.kt
+++ b/server/src/main/kotlin/com/darkrockstudios/apps/hammer/review/ReviewRepository.kt
@@ -805,7 +805,11 @@ class ReviewRepository(
 			return base.take(MAX_DRAFT_NAME_LENGTH).trim()
 		}
 
-		/** Name for the committed draft, same validDraftName constraints (so no comma in the date). */
+		/**
+		 * Name for the committed draft, same validDraftName constraints (so no comma in the date).
+		 * Dated in UTC, not the server's configured zone: this name is written into the author's
+		 * project and syncs to devices anywhere, so it should not depend on a server setting.
+		 */
 		fun reviewedDraftName(label: String, at: kotlin.time.Instant): String {
 			val date = java.time.format.DateTimeFormatter
 				.ofPattern("MMM d yyyy", java.util.Locale.ENGLISH)

--- a/server/src/main/kotlin/com/darkrockstudios/apps/hammer/utilities/ServerTimeZone.kt
+++ b/server/src/main/kotlin/com/darkrockstudios/apps/hammer/utilities/ServerTimeZone.kt
@@ -71,8 +71,8 @@ private fun reloadLogbackConfiguration() {
 	context.reset()
 	try {
 		ContextInitializer(context).autoConfig()
-	} catch (e: Throwable) {
-		// reset() already detached every appender, so without a fallback the server would run on
+	} catch (@Suppress("TooGenericExceptionCaught") e: Throwable) {
+		// reset() already detached every appender, so anything escaping here would leave the server
 		// with no console output and an empty admin log viewer.
 		System.err.println("Logging config failed to reload after the time zone change: ${e.message}")
 		BasicConfigurator().configure(context)

--- a/server/src/main/kotlin/com/darkrockstudios/apps/hammer/utilities/ServerTimeZone.kt
+++ b/server/src/main/kotlin/com/darkrockstudios/apps/hammer/utilities/ServerTimeZone.kt
@@ -1,0 +1,80 @@
+package com.darkrockstudios.apps.hammer.utilities
+
+import ch.qos.logback.classic.BasicConfigurator
+import ch.qos.logback.classic.LoggerContext
+import ch.qos.logback.classic.util.ContextInitializer
+import org.slf4j.LoggerFactory
+import java.time.DateTimeException
+import java.time.ZoneId
+import java.util.TimeZone
+
+const val TIMEZONE_ENV_VAR = "HAMMER_TIMEZONE"
+
+private val timeZoneLogger = LoggerFactory.getLogger("HammerServer")
+
+/**
+ * The zone every server-rendered timestamp and log line is stamped in: [configured] (`timezone` in
+ * `config.toml`) wins, then the `HAMMER_TIMEZONE` environment variable, then `TZ`, then the host's
+ * own zone. The JVM already honors `TZ` on Linux; reading it back here extends it to hosts that do
+ * not, so the same variable works everywhere.
+ *
+ * An unusable `timezone` or `HAMMER_TIMEZONE` throws, because both are deliberate settings and
+ * ignoring one would leave every timestamp wrong with nothing to point at. A `TZ` java.time cannot
+ * parse only warns and falls through to the host zone: the POSIX form (`CET-1CEST,M3.5.0`) is a
+ * legitimate value the platform has already applied, so it is not ours to reject.
+ */
+fun resolveServerTimeZone(
+	configured: String?,
+	readEnv: (String) -> String? = System::getenv,
+): ZoneId {
+	configured?.trim()?.ifBlank { null }?.let { return parseZone(it, "timezone in config.toml") }
+	readEnv(TIMEZONE_ENV_VAR)?.trim()?.ifBlank { null }?.let { return parseZone(it, TIMEZONE_ENV_VAR) }
+	readEnv("TZ")?.trim()?.ifBlank { null }?.let { tz ->
+		// A leading colon is the POSIX spelling of "what follows names a zone": TZ=":Europe/Paris".
+		runCatching { ZoneId.of(tz.removePrefix(":")) }.getOrNull()?.let { return it }
+		timeZoneLogger.warn(
+			"TZ is set to \"$tz\", which is not an IANA zone ID, so it is being left to the host. " +
+				"To name the zone explicitly, use $TIMEZONE_ENV_VAR or the timezone config setting.",
+		)
+	}
+	return ZoneId.systemDefault()
+}
+
+private fun parseZone(value: String, source: String): ZoneId =
+	try {
+		ZoneId.of(value)
+	} catch (e: DateTimeException) {
+		throw IllegalArgumentException(
+			"$source is set to \"$value\", which is not a known time zone. " +
+				"Use an IANA zone ID such as \"Europe/Paris\" or \"UTC\".",
+			e,
+		)
+	}
+
+/**
+ * Makes [zone] the JVM default, which is what `ZoneId.systemDefault()` (the zone every
+ * server-rendered timestamp is formatted in) and Logback's `%d` both read.
+ */
+fun applyServerTimeZone(zone: ZoneId) {
+	if (TimeZone.getDefault().toZoneId() == zone) return
+	TimeZone.setDefault(TimeZone.getTimeZone(zone))
+	reloadLogbackConfiguration()
+}
+
+/**
+ * Logback's date converter captures the default zone when it parses `logback.xml`, which happens the
+ * first time any logger is created, before the config file has even been read. Reloading rebuilds
+ * the converters against the zone just applied, so log lines carry it too.
+ */
+private fun reloadLogbackConfiguration() {
+	val context = LoggerFactory.getILoggerFactory() as? LoggerContext ?: return
+	context.reset()
+	try {
+		ContextInitializer(context).autoConfig()
+	} catch (e: Throwable) {
+		// reset() already detached every appender, so without a fallback the server would run on
+		// with no console output and an empty admin log viewer.
+		System.err.println("Logging config failed to reload after the time zone change: ${e.message}")
+		BasicConfigurator().configure(context)
+	}
+}

--- a/server/src/main/resources/logback.xml
+++ b/server/src/main/resources/logback.xml
@@ -1,7 +1,7 @@
 <configuration>
 	<appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
 		<encoder>
-			<pattern>%d{YYYY-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+			<pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
 		</encoder>
 	</appender>
 	<!-- Mirrors log events into an in-memory ring buffer for the admin log viewer. -->

--- a/server/src/test/kotlin/com/darkrockstudios/apps/hammer/ServerConfigTest.kt
+++ b/server/src/test/kotlin/com/darkrockstudios/apps/hammer/ServerConfigTest.kt
@@ -31,6 +31,16 @@ class ServerConfigTest {
 	}
 
 	@Test
+	fun `timezone defaults to null`() {
+		assertEquals(null, parse("").timezone)
+	}
+
+	@Test
+	fun `timezone parses a zone ID`() {
+		assertEquals("Europe/Paris", parse("""timezone = "Europe/Paris"""").timezone)
+	}
+
+	@Test
 	fun `termsOfService defaults to null`() {
 		assertEquals(null, parse("").termsOfService)
 	}

--- a/server/src/test/kotlin/com/darkrockstudios/apps/hammer/frontend/MonitoringChartLabelsTest.kt
+++ b/server/src/test/kotlin/com/darkrockstudios/apps/hammer/frontend/MonitoringChartLabelsTest.kt
@@ -1,0 +1,71 @@
+package com.darkrockstudios.apps.hammer.frontend
+
+import com.darkrockstudios.apps.hammer.database.ReaderDay
+import com.darkrockstudios.apps.hammer.monitoring.DailyActiveUsers
+import com.darkrockstudios.apps.hammer.monitoring.TimeSeriesPoint
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.time.ZoneId
+import java.time.ZoneOffset
+import java.util.TimeZone
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import kotlin.time.Instant
+
+/**
+ * Daily chart buckets are floored to the UTC day upstream, so their labels have to be rendered in
+ * UTC no matter what zone the server is configured for. Every case here uses a server zone behind
+ * UTC, where a naive local-zone label would land on the previous date.
+ */
+class MonitoringChartLabelsTest {
+
+	private lateinit var originalZone: TimeZone
+
+	// UTC midnight, which is Aug 16 in New York.
+	private val utcDay = Instant.parse("2026-08-17T00:00:00Z")
+
+	@BeforeEach
+	fun setServerZoneBehindUtc() {
+		originalZone = TimeZone.getDefault()
+		TimeZone.setDefault(TimeZone.getTimeZone("America/New_York"))
+	}
+
+	@AfterEach
+	fun restoreZone() {
+		TimeZone.setDefault(originalZone)
+	}
+
+	@Test
+	fun `active users chart labels the UTC day`() {
+		val json = buildActiveUsersChart(listOf(DailyActiveUsers(day = utcDay, sync = 3L, web = 5L)))
+
+		assertTrue(json.contains("Aug 17"), json)
+		assertFalse(json.contains("Aug 16"), json)
+	}
+
+	@Test
+	fun `readers chart labels the UTC day`() {
+		val json = buildReadersChart(listOf(ReaderDay(day = utcDay, count = 7L)))
+
+		assertTrue(json.contains("Aug 17"), json)
+		assertFalse(json.contains("Aug 16"), json)
+	}
+
+	@Test
+	fun `traffic chart labels the UTC day`() {
+		val point = TimeSeriesPoint(bucketStart = utcDay, requests = 10L, errors = 1L, p95Ms = 200L)
+
+		val json = buildTrafficChart(listOf(point))
+
+		assertTrue(json.contains("Aug 17"), json)
+		assertFalse(json.contains("Aug 16"), json)
+	}
+
+	@Test
+	fun `daily buckets are labeled in UTC and hourly buckets in the server zone`() {
+		assertEquals(ZoneOffset.UTC, chartLabelZone(hourly = false))
+		assertEquals(ZoneId.of("America/New_York"), chartLabelZone(hourly = true))
+	}
+}

--- a/server/src/test/kotlin/com/darkrockstudios/apps/hammer/utilities/ServerTimeZoneTest.kt
+++ b/server/src/test/kotlin/com/darkrockstudios/apps/hammer/utilities/ServerTimeZoneTest.kt
@@ -1,0 +1,105 @@
+package com.darkrockstudios.apps.hammer.utilities
+
+import org.junit.jupiter.api.Test
+import java.time.ZoneId
+import java.util.TimeZone
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+
+class ServerTimeZoneTest {
+
+	private fun env(vararg entries: Pair<String, String>): (String) -> String? {
+		val map = entries.toMap()
+		return { map[it] }
+	}
+
+	@Test
+	fun `config timezone wins over both environment variables`() {
+		val zone = resolveServerTimeZone(
+			configured = "Europe/Paris",
+			readEnv = env(TIMEZONE_ENV_VAR to "Asia/Tokyo", "TZ" to "America/New_York"),
+		)
+
+		assertEquals(ZoneId.of("Europe/Paris"), zone)
+	}
+
+	@Test
+	fun `HAMMER_TIMEZONE is used when the config leaves it unset`() {
+		val zone = resolveServerTimeZone(
+			configured = null,
+			readEnv = env(TIMEZONE_ENV_VAR to "Asia/Tokyo", "TZ" to "America/New_York"),
+		)
+
+		assertEquals(ZoneId.of("Asia/Tokyo"), zone)
+	}
+
+	@Test
+	fun `TZ is used when nothing else sets a zone`() {
+		val zone = resolveServerTimeZone(configured = null, readEnv = env("TZ" to "America/New_York"))
+
+		assertEquals(ZoneId.of("America/New_York"), zone)
+	}
+
+	@Test
+	fun `a TZ with the POSIX colon prefix is accepted`() {
+		val zone = resolveServerTimeZone(configured = null, readEnv = env("TZ" to ":Europe/Paris"))
+
+		assertEquals(ZoneId.of("Europe/Paris"), zone)
+	}
+
+	@Test
+	fun `falls back to the host zone when nothing is set`() {
+		val zone = resolveServerTimeZone(configured = null, readEnv = env())
+
+		assertEquals(ZoneId.systemDefault(), zone)
+	}
+
+	@Test
+	fun `blank settings are ignored`() {
+		val zone = resolveServerTimeZone(
+			configured = "  ",
+			readEnv = env(TIMEZONE_ENV_VAR to "", "TZ" to "Asia/Tokyo"),
+		)
+
+		assertEquals(ZoneId.of("Asia/Tokyo"), zone)
+	}
+
+	@Test
+	fun `an unknown config timezone aborts with the offending value`() {
+		val error = assertFailsWith<IllegalArgumentException> {
+			resolveServerTimeZone(configured = "Europe/Paree", readEnv = env())
+		}
+
+		assertTrue(error.message!!.contains("Europe/Paree"), "Message was: ${error.message}")
+	}
+
+	@Test
+	fun `an unknown HAMMER_TIMEZONE aborts`() {
+		val error = assertFailsWith<IllegalArgumentException> {
+			resolveServerTimeZone(configured = null, readEnv = env(TIMEZONE_ENV_VAR to "Not/AZone"))
+		}
+
+		assertTrue(error.message!!.contains(TIMEZONE_ENV_VAR), "Message was: ${error.message}")
+	}
+
+	@Test
+	fun `a POSIX-form TZ falls through to the host zone instead of aborting`() {
+		val zone = resolveServerTimeZone(configured = null, readEnv = env("TZ" to "CET-1CEST,M3.5.0,M10.5.0/3"))
+
+		assertEquals(ZoneId.systemDefault(), zone)
+	}
+
+	@Test
+	fun `applying a zone makes it the JVM default`() {
+		val original = TimeZone.getDefault()
+		try {
+			applyServerTimeZone(ZoneId.of("Pacific/Chatham"))
+
+			assertEquals(ZoneId.of("Pacific/Chatham"), ZoneId.systemDefault())
+		} finally {
+			// Back through apply(), not setDefault(), so the logging config is restored with it.
+			applyServerTimeZone(original.toZoneId())
+		}
+	}
+}


### PR DESCRIPTION
Closes #882.

Self-hosters outside UTC had no way to get server timestamps into their local zone, and nothing documented to point at.

## What this adds

A `timezone` setting in `config.toml`, with `HAMMER_TIMEZONE` and the standard `TZ` as environment-variable fallbacks (config wins over `HAMMER_TIMEZONE`, which wins over `TZ`). The zone is resolved and applied at startup and logged as `Server time zone: ...` so an operator can confirm it took.

It covers both things the issue asked for: the timestamps on every server-rendered page (dashboard, admin, monitoring, editorial reviews, published story dates) and the timestamps on log lines, in the console and the admin log viewer.

An unknown ID in `timezone` or `HAMMER_TIMEZONE` aborts startup rather than quietly running in the wrong zone. `TZ` is treated leniently: the POSIX form (`CET-1CEST,M3.5.0`) is a legitimate value the OS has already acted on, so an unreadable `TZ` warns and leaves the zone to the host. The `:Europe/Paris` colon spelling is accepted.

`TZ` alone already worked on Linux because the JVM reads it. Reading it back explicitly means the same variable also works on Windows and macOS hosts, which ignore it.

## The Logback wrinkle

Logback's date converter captures `ZoneId.systemDefault()` when it parses `logback.xml`, which happens the first time any logger is created, long before the config file is read. A plain `TimeZone.setDefault()` therefore fixes page timestamps but never log timestamps. `applyServerTimeZone` resets the `LoggerContext` and re-runs `autoConfig()`, with a `BasicConfigurator` fallback so a failed reload can't leave the server with no appenders at all. Verified by hand with a throwaway probe: log lines moved to the configured zone and back.

## Two bugs this exposed

- **Monitoring daily charts.** Daily buckets are UTC-floored (`date_trunc('day', ..., 'UTC')`, `truncateToUtcDay()`) but were labeled in the JVM default zone. That agreed as long as the default was UTC; with a configured zone every point on the traffic, active-users and readers charts slid onto a neighboring date. Daily labels are now pinned to UTC, while hourly buckets stay in the server zone where local hours are what an admin wants.
- **`logback.xml` used `YYYY`**, the week-based year, so lines written in late December would stamp the following year. Now `yyyy`.

## Deliberate non-changes

- `ReviewRepository.reviewedDraftName` stays UTC. That string is written into the author's project and syncs to devices anywhere, so it shouldn't depend on a server setting. Commented as such.
- Allowed Users expiries are date-only values stored as an instant in whatever zone was in effect when they were saved, so changing the zone later can show the neighboring date on the edit form. Pinning that to UTC would change what an existing "expires Sep 1" means for everyone, so the behavior is unchanged and the caveat is documented instead.

## Docs

- A "Time zone" section in both server guides covering precedence, what it affects, and what it doesn't (stored data, clients, and job scheduling, which is interval-based rather than wall-clock).
- `docker-compose.yml` passes `TZ` through; `config.example.toml` documents the setting.
- `docs/SERVER-TIMEZONES.md`: all 604 zone IDs from `ZoneId.getAvailableZoneIds()`, grouped by region with mid-January and mid-July offsets so daylight saving is visible, legacy aliases split out with a note about the inverted `Etc/GMT+N` signs.

## Testing

`ServerTimeZoneTest` covers precedence, blank handling, both abort paths, POSIX fall-through and the colon prefix, and that applying actually changes the JVM default. `ServerConfigTest` covers parsing. Full `:server:test` suite passes.
