### PR TITLE
Render shared stories in scene tree order

### DIFF
--- a/server/src/main/kotlin/com/darkrockstudios/apps/hammer/story/StoryRenderCache.kt
+++ b/server/src/main/kotlin/com/darkrockstudios/apps/hammer/story/StoryRenderCache.kt
@@ -76,7 +76,7 @@ class StoryRenderCache(
 			.getOrNull()
 
 	companion object {
-		private const val RENDER_VERSION = "v4"
+		private const val RENDER_VERSION = "v5"
 
 		/**
 		 * Everything a render of this story depends on, collapsed to a string: the renderer itself,

--- a/server/src/main/kotlin/com/darkrockstudios/apps/hammer/story/StoryRendererService.kt
+++ b/server/src/main/kotlin/com/darkrockstudios/apps/hammer/story/StoryRendererService.kt
@@ -87,9 +87,9 @@ class StoryRendererService(
 		// Get root-level scenes (direct children of root)
 		val rootScenes = scenesByParent[0]?.sortedBy { it.order } ?: emptyList()
 
-		var chapterNumber = 1
 		for (scene in rootScenes) {
-			builder.append("## $chapterNumber. ${scene.name}\n\n")
+			// The author's own heading, verbatim: a story renders as written, never renumbered.
+			builder.append("## ${scene.name}\n\n")
 
 			if (scene.sceneType == ApiSceneType.Scene) {
 				// Write scene content directly
@@ -100,8 +100,13 @@ class StoryRendererService(
 				// It's a Group - write all child scenes' content
 				writeGroupChildren(builder, scene.id, scenesByParent)
 			}
+		}
 
-			chapterNumber++
+		// A scene the walk can't reach still belongs to the author, and their readers can see it on
+		// the published page; it would be worse for it to be missing here than to sit at the end.
+		for (orphan in walkScenes(scenes).orphans) {
+			builder.append("## ${orphan.name}\n\n")
+			if (orphan.content.isNotBlank()) builder.appendScene(orphan.content)
 		}
 
 		return builder.toString()
@@ -141,8 +146,8 @@ class StoryRendererService(
 
 	/**
 	 * Resolve a story once, so a caller that needs its [PreparedExport.version] before deciding to
-	 * render doesn't pay for the lookup twice. Costs one project lookup plus one indexed hash query
-	 * with no decryption. Null when the project doesn't exist.
+	 * render doesn't pay for the lookup twice. A whole-story export costs one project lookup plus
+	 * one indexed hash query with no decryption. Null when the project doesn't exist.
 	 */
 	suspend fun prepareExport(
 		userId: Long,
@@ -151,19 +156,61 @@ class StoryRendererService(
 	): PreparedExport? {
 		val projectDef = projectEntityDatasource.getProject(userId, projectId) ?: return null
 		val allHashes = sceneHashes(userId, projectDef)
-		// The fingerprint covers only the filtered scenes, so the HTTP validator changes
-		// exactly when this share's visible content changes, and two shares with different
-		// scene sets never collide on a validator.
-		val sceneHashes = if (sceneFilter != null) allHashes.filter { it.id in sceneFilter } else allHashes
-		if (sceneFilter != null && sceneHashes.isEmpty()) return null
+
+		if (sceneFilter == null) {
+			return PreparedExport(
+				userId = userId,
+				projectId = projectId,
+				projectDef = projectDef,
+				sceneHashes = allHashes,
+				version = StoryRenderCache.fingerprint(projectDef.name, allHashes),
+			)
+		}
+
+		val presentIds = allHashes.map { it.id }.toSet()
+		val selectedIds = presentIds intersect sceneFilter
+		if (selectedIds.isEmpty()) return null
+
+		// Where a selected scene falls in the reading order is decided by the groups above it, so
+		// the share's validator has to cover those too or a reordered chapter is answered 304 with
+		// the old order. A scene's path is its whole ancestor chain, so one more read settles it.
+		val selected = loadScenes(userId, projectDef, selectedIds)
+		val ancestorIds = selected.flatMapTo(mutableSetOf()) { it.path }
+			.intersect(presentIds) - selectedIds
+		val ancestors = loadScenes(userId, projectDef, ancestorIds)
+
+		val coveredIds = selectedIds + ancestorIds
+		// Still only this share's scenes and the structure around them: an edit to a scene the
+		// share doesn't show leaves the validator alone, and two shares of different scene sets
+		// never collide on one.
+		val sceneHashes = allHashes.filter { it.id in coveredIds }
 		return PreparedExport(
 			userId = userId,
 			projectId = projectId,
 			projectDef = projectDef,
 			sceneHashes = sceneHashes,
 			sceneFilter = sceneFilter,
+			// Read once here and carried to the render, so a cache miss doesn't decrypt twice.
+			scenes = selected + ancestors,
+			scenesComplete = selected.size + ancestors.size == coveredIds.size,
 			version = StoryRenderCache.fingerprint(projectDef.name, sceneHashes),
 		)
+	}
+
+	/** Loads [ids], skipping any that fail; the caller compares sizes to detect a partial read. */
+	private suspend fun loadScenes(
+		userId: Long,
+		projectDef: ProjectDefinition,
+		ids: Collection<Int>,
+	): List<ApiProjectEntity.SceneEntity> = ids.mapNotNull { id ->
+		val result = projectEntityDatasource.loadEntity(
+			userId = userId,
+			projectDef = projectDef,
+			entityId = id,
+			entityType = ApiProjectEntity.Type.SCENE,
+			serializer = ApiProjectEntity.SceneEntity.serializer()
+		)
+		if (isSuccess(result)) result.data else null
 	}
 
 	/**
@@ -201,6 +248,7 @@ class StoryRendererService(
 		wordsPerPage = wordsPerPage,
 		cacheable = cacheable,
 		sceneFilter = prepared.sceneFilter,
+		preloaded = prepared.scenes?.let { PreloadedScenes(it, prepared.scenesComplete) },
 	)
 
 	private suspend fun renderOrCache(
@@ -212,6 +260,7 @@ class StoryRendererService(
 		wordsPerPage: Int,
 		cacheable: Boolean,
 		sceneFilter: Set<Int>? = null,
+		preloaded: PreloadedScenes? = null,
 	): PaginatedExportResult {
 		val cache = renderCache.takeIf { cacheable }
 
@@ -223,9 +272,9 @@ class StoryRendererService(
 					page = page,
 					wordsPerPage = wordsPerPage,
 					sceneHashes = sceneHashes,
-				) { renderPaginated(userId, projectDef, page, wordsPerPage, sceneFilter) }
+				) { renderPaginated(userId, projectDef, page, wordsPerPage, sceneFilter, preloaded) }
 			} else {
-				renderPaginated(userId, projectDef, page, wordsPerPage, sceneFilter).result
+				renderPaginated(userId, projectDef, page, wordsPerPage, sceneFilter, preloaded).result
 			}
 			PaginatedExportResult.Success(result)
 		} catch (e: Exception) {
@@ -246,20 +295,27 @@ class StoryRendererService(
 		page: Int,
 		wordsPerPage: Int,
 		sceneFilter: Set<Int>? = null,
+		preloaded: PreloadedScenes? = null,
 	): StoryRender {
-		val allSceneDefs = projectEntityDatasource.getEntityDefsByType(
-			userId = userId,
-			projectDef = projectDef,
-			type = ApiProjectEntity.Type.SCENE
-		)
-		// Filter before loading so unselected scenes are never decrypted.
-		val sceneDefs = if (sceneFilter != null) {
-			allSceneDefs.filter { it.id in sceneFilter }
+		// A scene-limited share arrives with its scenes and their ancestor groups already read;
+		// nothing else in the project is touched, so unshared prose is never decrypted. A whole
+		// story reads every scene, which is also every scene it renders.
+		val scenes: List<ApiProjectEntity.SceneEntity>
+		val complete: Boolean
+		if (preloaded != null) {
+			scenes = preloaded.scenes
+			complete = preloaded.complete
 		} else {
-			allSceneDefs
+			val sceneDefs = projectEntityDatasource.getEntityDefsByType(
+				userId = userId,
+				projectDef = projectDef,
+				type = ApiProjectEntity.Type.SCENE
+			)
+			scenes = loadScenes(userId, projectDef, sceneDefs.map { it.id })
+			complete = scenes.size == sceneDefs.size
 		}
 
-		if (sceneDefs.isEmpty()) {
+		if (scenes.isEmpty()) {
 			return StoryRender(
 				result = PaginatedStoryExportResult(
 					projectName = projectDef.name,
@@ -275,31 +331,20 @@ class StoryRendererService(
 					prevPage = 1,
 					estimatedReadingTimeMinutes = 1
 				),
-				complete = true,
+				complete = complete,
 			)
 		}
 
-		val scenes: List<ApiProjectEntity.SceneEntity> = sceneDefs.mapNotNull { def ->
-			val result = projectEntityDatasource.loadEntity(
-				userId = userId,
-				projectDef = projectDef,
-				entityId = def.id,
-				entityType = ApiProjectEntity.Type.SCENE,
-				serializer = ApiProjectEntity.SceneEntity.serializer()
-			)
-			if (isSuccess(result)) result.data else null
-		}
+		val selected = walkScenes(scenes).scenes
+			.let { ordered -> if (sceneFilter == null) ordered else ordered.filter { it.id in sceneFilter } }
 
-		// Process all scenes with their word counts (only count actual scenes, not groups)
-		val processedScenes = scenes
-			.filter { it.sceneType == ApiSceneType.Scene }
-			.map { scene ->
-				ProcessedScene(
-					scene = scene,
-					wordCount = WordCountUtils.countWords(scene.content),
-					markdown = scene.content
-				)
-			}
+		val processedScenes = selected.map { scene ->
+			ProcessedScene(
+				scene = scene,
+				wordCount = WordCountUtils.countWords(scene.content),
+				markdown = scene.content
+			)
+		}
 
 		val totalWordCount = processedScenes.sumOf { it.wordCount }
 		val estimatedReadingTime = WordCountUtils.estimateReadingTimeMinutes(totalWordCount)
@@ -334,9 +379,42 @@ class StoryRendererService(
 			// A scene that failed to load is silently absent from the prose. Serve the page, but
 			// never persist it: a transient decrypt or DB failure must not outlive itself in the
 			// cache, where the key wouldn't change until the author next edits.
-			complete = scenes.size == sceneDefs.size,
+			complete = complete,
 		)
 	}
+
+	/**
+	 * Flattens the scene tree to its leaf scenes in the order the author sees them: depth first,
+	 * siblings by [ApiProjectEntity.SceneEntity.order].
+	 */
+	private fun walkScenes(scenes: List<ApiProjectEntity.SceneEntity>): SceneWalk {
+		val scenesByParent = scenes.groupBy { it.path.lastOrNull() ?: ROOT_KEY }
+		val ordered = mutableListOf<ApiProjectEntity.SceneEntity>()
+		val visited = mutableSetOf<Int>()
+
+		fun visit(parentId: Int) {
+			val children = scenesByParent[parentId] ?: return
+			for (scene in children.sortedBy { it.order }) {
+				// A path cycle would otherwise recurse forever.
+				if (!visited.add(scene.id)) continue
+				if (scene.sceneType == ApiSceneType.Scene) ordered += scene else visit(scene.id)
+			}
+		}
+		visit(ROOT_ID)
+
+		val orphans = scenes.filter { it.sceneType == ApiSceneType.Scene && it.id !in visited }
+		return SceneWalk(scenes = ordered + orphans, orphans = orphans)
+	}
+
+	/**
+	 * The story's leaf scenes in reading order. [orphans] are the ones the walk couldn't reach,
+	 * a scene whose parent group is missing; they land at the end of [scenes] so that nothing the
+	 * author wrote silently disappears from a render.
+	 */
+	private class SceneWalk(
+		val scenes: List<ApiProjectEntity.SceneEntity>,
+		val orphans: List<ApiProjectEntity.SceneEntity>,
+	)
 
 	private fun paginateScenes(
 		scenes: List<ProcessedScene>,
@@ -560,7 +638,9 @@ class StoryRendererService(
 	}
 
 	companion object {
+		/** Bucket for a scene with no path at all; distinct from the real root, which is id 0. */
 		private const val ROOT_KEY = -1
+		private const val ROOT_ID = 0
 		const val DEFAULT_WORDS_PER_PAGE = 2000
 	}
 }
@@ -591,6 +671,19 @@ class PreparedExport internal constructor(
 	val version: String,
 	/** Scene ids the render is limited to; null renders the entire story. */
 	internal val sceneFilter: Set<Int>? = null,
+	/**
+	 * The scenes a limited share renders and the groups that place them, read while resolving the
+	 * version. Null for a whole-story export, which reads its scenes at render time instead.
+	 */
+	internal val scenes: List<ApiProjectEntity.SceneEntity>? = null,
+	/** False when one of [scenes] failed to load, which bars the render from the cache. */
+	internal val scenesComplete: Boolean = true,
+)
+
+/** Scenes resolved before the render, with whether the set is whole. */
+internal class PreloadedScenes(
+	val scenes: List<ApiProjectEntity.SceneEntity>,
+	val complete: Boolean,
 )
 
 @Serializable

--- a/server/src/test/kotlin/com/darkrockstudios/apps/hammer/story/StoryRendererServiceTest.kt
+++ b/server/src/test/kotlin/com/darkrockstudios/apps/hammer/story/StoryRendererServiceTest.kt
@@ -467,6 +467,218 @@ class StoryRendererServiceTest {
 		assertTrue(result.data.pageHtml.contains("Bravo content"))
 	}
 
+	@Test
+	fun `chapter headings are the author's own, unnumbered`() = runTest {
+		setupMocksForScenes(
+			listOf(
+				createScene(id = 1, name = "Prologue", content = "Prologue content.", order = 0),
+				createScene(id = 2, name = "Chapitre 1", content = "First chapter.", order = 1),
+			)
+		)
+
+		val result = service.renderStoryAsHtml(userId, projectId)
+
+		assertIs<StoryRenderResult.Success>(result)
+		assertTrue(result.html.contains("<h2>Prologue</h2>"), result.html)
+		assertTrue(result.html.contains("<h2>Chapitre 1</h2>"), result.html)
+	}
+
+	/**
+	 * Two chapters whose scenes were not created in reading order, so entity id order and tree
+	 * order disagree: FR/Prologue(2), ENG/Prologue(4), FR/Chapitre 1(5).
+	 */
+	private fun interleavedChapters() = listOf(
+		createScene(id = 1, name = "Unhealthy - FR", content = "", order = 0, sceneType = ApiSceneType.Group),
+		createScene(id = 2, name = "Prologue", content = "Prologue francais", order = 0, path = listOf(0, 1)),
+		createScene(id = 3, name = "Unhealthy - ENG", content = "", order = 1, sceneType = ApiSceneType.Group),
+		createScene(id = 4, name = "Prologue", content = "English prologue", order = 0, path = listOf(0, 3)),
+		createScene(id = 5, name = "Chapitre 1", content = "Chapitre un", order = 1, path = listOf(0, 1)),
+	)
+
+	private fun assertRendersInOrder(html: String, vararg content: String) {
+		val positions = content.map { it to html.indexOf(it) }
+		positions.forEach { (text, at) -> assertTrue(at >= 0, "'$text' is missing from the render:\n$html") }
+		positions.zipWithNext { (beforeText, before), (afterText, after) ->
+			assertTrue(before < after, "'$beforeText' should render before '$afterText':\n$html")
+		}
+	}
+
+	@Test
+	fun `paginated - scenes render in tree order, not entity id order`() = runTest {
+		setupMocksForScenes(interleavedChapters())
+
+		val result = service.renderStoryAsHtmlPaginated(userId, projectId)
+
+		assertIs<PaginatedExportResult.Success>(result)
+		assertRendersInOrder(result.data.pageHtml, "Prologue francais", "Chapitre un", "English prologue")
+	}
+
+	@Test
+	fun `filtered - selected scenes render in tree order, not entity id order`() = runTest {
+		setupMocksForScenes(interleavedChapters())
+
+		val prepared = service.prepareExport(userId, projectId, setOf(2, 4, 5))!!
+		val result = service.renderStoryAsHtmlPaginated(prepared)
+
+		assertIs<PaginatedExportResult.Success>(result)
+		assertRendersInOrder(result.data.pageHtml, "Prologue francais", "Chapitre un", "English prologue")
+	}
+
+	@Test
+	fun `filtered - a subset spanning two chapters keeps tree order`() = runTest {
+		setupMocksForScenes(interleavedChapters())
+
+		val prepared = service.prepareExport(userId, projectId, setOf(4, 5))!!
+		val result = service.renderStoryAsHtmlPaginated(prepared)
+
+		assertIs<PaginatedExportResult.Success>(result)
+		assertFalse(result.data.pageHtml.contains("Prologue francais"))
+		assertRendersInOrder(result.data.pageHtml, "Chapitre un", "English prologue")
+	}
+
+	@Test
+	fun `paginated - pagination follows tree order`() = runTest {
+		setupMocksForScenes(interleavedChapters())
+
+		// Three scenes of 2, 2, and 2 words: one per page, in tree order.
+		val pages = (1..3).map { page ->
+			val result = service.renderStoryAsHtmlPaginated(userId, projectId, page = page, wordsPerPage = 2)
+			assertIs<PaginatedExportResult.Success>(result)
+			result.data
+		}
+
+		assertEquals(3, pages.first().totalPages)
+		assertTrue(pages[0].pageHtml.contains("Prologue francais"))
+		assertTrue(pages[1].pageHtml.contains("Chapitre un"))
+		assertTrue(pages[2].pageHtml.contains("English prologue"))
+	}
+
+	@Test
+	fun `paginated - a scene orphaned from its group still renders`() = runTest {
+		setupMocksForScenes(
+			listOf(
+				createScene(id = 1, name = "Chapter 1", content = "", order = 0, sceneType = ApiSceneType.Group),
+				createScene(id = 2, name = "Scene 1", content = "Attached content", order = 0, path = listOf(0, 1)),
+				// Parent group 99 does not exist; the prose must not vanish from the page.
+				createScene(id = 3, name = "Lost Scene", content = "Orphaned content", order = 0, path = listOf(0, 99)),
+			)
+		)
+
+		val result = service.renderStoryAsHtmlPaginated(userId, projectId)
+
+		assertIs<PaginatedExportResult.Success>(result)
+		assertTrue(result.data.pageHtml.contains("Attached content"))
+		assertTrue(result.data.pageHtml.contains("Orphaned content"))
+		assertEquals(2, result.data.sceneCount)
+	}
+
+	/** Two chapters, one scene each, with [chapterOrder] deciding which chapter reads first. */
+	private fun twoChapters(chapterOrder: List<Int>) = listOf(
+		createScene(id = 1, name = "Chapter A", content = "", order = chapterOrder[0], sceneType = ApiSceneType.Group),
+		createScene(id = 2, name = "Scene X", content = "Alpha content", order = 0, path = listOf(0, 1)),
+		createScene(id = 3, name = "Chapter B", content = "", order = chapterOrder[1], sceneType = ApiSceneType.Group),
+		createScene(id = 4, name = "Scene Y", content = "Bravo content", order = 0, path = listOf(0, 3)),
+	)
+
+	@Test
+	fun `filtered - reordering the chapters around a share changes its version`() = runTest {
+		setupMocksForScenes(twoChapters(listOf(0, 1)))
+		val before = service.prepareExport(userId, projectId, setOf(2, 4))!!
+
+		// Neither selected scene is touched; only the groups that place them swap.
+		setupMocksForScenes(twoChapters(listOf(1, 0)))
+		val after = service.prepareExport(userId, projectId, setOf(2, 4))!!
+
+		assertNotEquals(
+			before.version,
+			after.version,
+			"a reader holding the old validator would be answered 304 with the old reading order"
+		)
+	}
+
+	@Test
+	fun `filtered - reordering the chapters around a share changes the rendered order`() = runTest {
+		setupMocksForScenes(twoChapters(listOf(1, 0)))
+
+		val prepared = service.prepareExport(userId, projectId, setOf(2, 4))!!
+		val result = service.renderStoryAsHtmlPaginated(prepared)
+
+		assertIs<PaginatedExportResult.Success>(result)
+		assertRendersInOrder(result.data.pageHtml, "Bravo content", "Alpha content")
+	}
+
+	@Test
+	fun `filtered - a share never reads a scene it does not show`() = runTest {
+		setupMocksForScenes(
+			listOf(
+				createScene(id = 1, name = "Chapter A", content = "", order = 0, sceneType = ApiSceneType.Group),
+				createScene(id = 2, name = "Scene X", content = "Alpha content", order = 0, path = listOf(0, 1)),
+				createScene(id = 3, name = "Secret", content = "Unshared prose", order = 1, path = listOf(0, 1)),
+			)
+		)
+
+		val prepared = service.prepareExport(userId, projectId, setOf(2))!!
+		val result = service.renderStoryAsHtmlPaginated(prepared)
+
+		assertIs<PaginatedExportResult.Success>(result)
+		assertFalse(result.data.pageHtml.contains("Unshared prose"))
+		// Unshared prose is never decrypted, not merely dropped after the fact.
+		coVerify(exactly = 0) {
+			datasource.loadEntity(
+				userId,
+				projectDef,
+				3,
+				ApiProjectEntity.Type.SCENE,
+				ApiProjectEntity.SceneEntity.serializer()
+			)
+		}
+	}
+
+	@Test
+	fun `filtered - an unrelated scene failing to load still caches the share`() = runTest {
+		setupMocksForScenes(
+			listOf(
+				createScene(id = 1, name = "Shared", content = "Alpha content", order = 0),
+				createScene(id = 2, name = "Elsewhere", content = "Bravo content", order = 1),
+			)
+		)
+		// A scene the share doesn't show fails to decrypt; it cannot affect this render's output.
+		coEvery {
+			datasource.loadEntity(
+				userId,
+				projectDef,
+				2,
+				ApiProjectEntity.Type.SCENE,
+				ApiProjectEntity.SceneEntity.serializer()
+			)
+		} returns SResult.failure("boom")
+
+		val prepared = cachingService.prepareExport(userId, projectId, setOf(1))!!
+		val result = cachingService.renderStoryAsHtmlPaginated(prepared, cacheable = true)
+
+		assertIs<PaginatedExportResult.Success>(result)
+		assertTrue(result.data.pageHtml.contains("Alpha content"))
+		assertEquals(1, cachedFiles().size, "the share renders the same every time; it should be cached")
+	}
+
+	@Test
+	fun `a scene orphaned from its group still renders on the author's full story`() = runTest {
+		setupMocksForScenes(
+			listOf(
+				createScene(id = 1, name = "Chapter 1", content = "", order = 0, sceneType = ApiSceneType.Group),
+				createScene(id = 2, name = "Scene 1", content = "Attached content", order = 0, path = listOf(0, 1)),
+				// Parent group 99 does not exist; readers can see this scene, so the author must too.
+				createScene(id = 3, name = "Lost Scene", content = "Orphaned content", order = 0, path = listOf(0, 99)),
+			)
+		)
+
+		val result = service.renderStoryAsHtml(userId, projectId)
+
+		assertIs<StoryRenderResult.Success>(result)
+		assertTrue(result.html.contains("Attached content"))
+		assertTrue(result.html.contains("Orphaned content"), result.html)
+	}
+
 	private fun createScene(
 		id: Int,
 		name: String,
@@ -491,9 +703,12 @@ class StoryRendererServiceTest {
 		val entityDefs = scenes.map { EntityDefinition(it.id, ApiProjectEntity.Type.SCENE) }
 		coEvery { datasource.getEntityDefsByType(userId, projectDef, ApiProjectEntity.Type.SCENE) } returns entityDefs
 
-		// Mirrors the real column: the stored hash covers the scene's content, so editing a scene
-		// here changes its hash the way a sync would.
-		stubSceneHashes(*scenes.map { EntityHash(it.id, "h${it.content.hashCode()}") }.toTypedArray())
+		// Mirrors the real column: the stored hash covers the whole serialized entity, so editing a
+		// scene or moving it changes its hash the way a sync would.
+		stubSceneHashes(
+			*scenes.map { EntityHash(it.id, "h${listOf(it.name, it.content, it.order, it.path).hashCode()}") }
+				.toTypedArray()
+		)
 
 		val entityIdSlot = slot<Int>()
 		coEvery {


### PR DESCRIPTION
## The bug

A story shared on the web came out shuffled. Reported case: two chapters,
`Unhealthy - FR` (Prologue, Chapitre 1) and `Unhealthy - ENG` (Prologue),
rendered as **FR Prologue → ENG Prologue → FR Chapitre 1**.

`renderPaginated` — the path behind every public share page — never walked
the scene tree. It took scenes straight from `getEntityDefsByType`, whose
query ends in `ORDER BY id`, so the page came out in *entity creation*
order. Any project whose scenes weren't written front to back renders
wrong. The bug predates the selective-share work; that feature just made
it easier to hit.

The other two render paths (`renderStoryAsHtml`, `renderSceneAsHtml`) do
traverse the tree, and the client-side export walks the real `SceneTree`,
which is why this only ever showed up on share pages.

## The fix

- `walkScenes` flattens the tree the way the author sees it: depth first,
  siblings by `order`. Scenes the walk can't reach (a missing parent
  group) are appended rather than dropped, and a `visited` set makes a
  corrupt path cycle terminate. The author's full-story view appends
  those orphans too — it would otherwise show the author a story missing
  a scene their readers can see.
- Chapter headings on that view no longer gain a `1. ` / `2. ` prefix.
  The author's own heading renders as written.
- `RENDER_VERSION` → `v5`. Reading order and heading text both changed
  and neither the cache key nor the reader's ETag carries an app version,
  so without the bump every already-cached share page would keep serving
  the old order until its author next edited a scene.

### Scene-limited shares

A share now reads its own scenes and the groups above them, nothing else.
`prepareExport` loads the selected scenes, takes the ancestor group ids
straight off their `path` chains, and loads only those; the render reuses
that set rather than reading again. Two consequences:

- Unshared prose is still never decrypted — the property the original
  filter-before-load was there for, now covered by a test.
- The share's validator covers the groups that decide where its scenes
  fall, so swapping two chapters around a share is no longer answered 304
  with the old order. An edit to a scene the share doesn't show still
  leaves the validator alone, and two shares of different scene sets
  still never collide on one.

`complete` now compares against the entities the render actually needed,
so an unrelated scene failing to decrypt no longer bars every share of
that project from the cache.

## Tests

Ten new tests in `StoryRendererServiceTest`, each run red before its fix:

- scenes render in tree order, not entity id order
- a scene-limited share keeps tree order
- a subset spanning two chapters keeps tree order
- pagination follows tree order
- reordering the chapters around a share changes its version
- reordering the chapters around a share changes the rendered order
- a share never reads a scene it does not show
- an unrelated scene failing to load still caches the share
- a scene orphaned from its group still renders (reader page + author view)
- chapter headings are the author's own, unnumbered

The fake entity hash in the test setup now covers name, order and path as
well as content, matching what the real column hashes.

Full `:server:test` suite green.
