### PR TITLE
Map unchecked IO failures to a real error message

### DIFF
--- a/common/src/commonMain/composeResources/values/strings_account_settings.xml
+++ b/common/src/commonMain/composeResources/values/strings_account_settings.xml
@@ -153,5 +153,6 @@
 		name="server_error_connection_generic">Network error connecting to %1$s. Check your connection and try again.
 	</string>
 	<string name="server_error_tls">Could not make a secure connection to %1$s. Hammer only connects over HTTPS, so the server needs a valid TLS certificate of its own or a reverse proxy that provides one.</string>
+	<string name="server_error_network_unavailable">Hammer could not open a network connection on this device, so the request never reached the server. Security software, a VPN, or a firewall may be blocking it.</string>
 
 </resources>

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/projectsync/ProjectSynchronizationComponent.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/projectsync/ProjectSynchronizationComponent.kt
@@ -378,8 +378,10 @@ class ProjectSynchronizationComponent(
 		}
 	}
 
-	private suspend fun onSyncComplete() {
-		updateSyncLog(syncLogI("Sync complete!", projectDef))
+	private suspend fun onSyncComplete(success: Boolean) {
+		if (success) {
+			updateSyncLog(syncLogI("Sync complete!", projectDef))
+		}
 		updateSync(false, 1f)
 	}
 

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/sync/projectsync/ClientProjectSynchronizer.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/sync/projectsync/ClientProjectSynchronizer.kt
@@ -71,7 +71,7 @@ class ClientProjectSynchronizer(
 		onProgress: suspend (Float, SyncLogMessage?) -> Unit,
 		onLog: OnSyncLog,
 		onConflict: EntityConflictHandler<ApiProjectEntity>,
-		onComplete: suspend () -> Unit,
+		onComplete: suspend (success: Boolean) -> Unit,
 		onlyNew: Boolean = false,
 		onUnauthorized: suspend () -> Unit,
 	): Boolean = coroutineScope {
@@ -110,7 +110,7 @@ class ClientProjectSynchronizer(
 		onProgress: suspend (Float, SyncLogMessage?) -> Unit,
 		onLog: OnSyncLog,
 		onConflict: EntityConflictHandler<ApiProjectEntity>,
-		onComplete: suspend () -> Unit,
+		onComplete: suspend (success: Boolean) -> Unit,
 		onUnauthorized: suspend () -> Unit = {}
 	): CResult<SyncOperationState> {
 		var currentState = initialState
@@ -142,7 +142,7 @@ class ClientProjectSynchronizer(
 	private suspend fun handleSyncFailure(
 		e: Throwable,
 		onLog: OnSyncLog,
-		onComplete: suspend () -> Unit,
+		onComplete: suspend (success: Boolean) -> Unit,
 		onUnauthorized: suspend () -> Unit = {}
 	) {
 		Napier.e("Sync failed: ${e.message}", e)
@@ -154,7 +154,7 @@ class ClientProjectSynchronizer(
 			)
 		)
 		endSync()
-		onComplete()
+		onComplete(false)
 
 		// Check if the error is a 401 Unauthorized error
 		if (e is HttpFailureException && e.statusCode == HttpStatusCode.Unauthorized) {

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/sync/projectsync/operations/BackupOperation.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/sync/projectsync/operations/BackupOperation.kt
@@ -21,7 +21,7 @@ class BackupOperation(
 		onProgress: suspend (Float, SyncLogMessage?) -> Unit,
 		onLog: OnSyncLog,
 		onConflict: EntityConflictHandler<ApiProjectEntity>,
-		onComplete: suspend () -> Unit
+		onComplete: suspend (success: Boolean) -> Unit
 	): CResult<SyncOperationState> {
 		if (
 			globalSettingsStore.globalSettings.automaticBackups &&

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/sync/projectsync/operations/CoalateIdsOperation.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/sync/projectsync/operations/CoalateIdsOperation.kt
@@ -18,7 +18,7 @@ class CollateIdsOperation(
 		onProgress: suspend (Float, SyncLogMessage?) -> Unit,
 		onLog: OnSyncLog,
 		onConflict: EntityConflictHandler<ApiProjectEntity>,
-		onComplete: suspend () -> Unit
+		onComplete: suspend (success: Boolean) -> Unit
 	): CResult<SyncOperationState> {
 
 		state as FetchServerDataState

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/sync/projectsync/operations/EnsureProjectIdOperation.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/sync/projectsync/operations/EnsureProjectIdOperation.kt
@@ -24,7 +24,7 @@ class EnsureProjectIdOperation(
 		onProgress: suspend (Float, SyncLogMessage?) -> Unit,
 		onLog: OnSyncLog,
 		onConflict: EntityConflictHandler<ApiProjectEntity>,
-		onComplete: suspend () -> Unit
+		onComplete: suspend (success: Boolean) -> Unit
 	): CResult<SyncOperationState> {
 		val metadata = projectMetadataDatasource.loadMetadata(projectDef)
 		if (metadata.info.serverProjectId == null) {

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/sync/projectsync/operations/EntityDeleteOperation.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/sync/projectsync/operations/EntityDeleteOperation.kt
@@ -23,7 +23,7 @@ class EntityDeleteOperation(
 		onProgress: suspend (Float, SyncLogMessage?) -> Unit,
 		onLog: OnSyncLog,
 		onConflict: EntityConflictHandler<ApiProjectEntity>,
-		onComplete: suspend () -> Unit
+		onComplete: suspend (success: Boolean) -> Unit
 	): CResult<SyncOperationState> {
 		state as IdConflictResolutionState
 

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/sync/projectsync/operations/EntityTransferOperation.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/sync/projectsync/operations/EntityTransferOperation.kt
@@ -59,7 +59,7 @@ class EntityTransferOperation(
 		onProgress: suspend (Float, SyncLogMessage?) -> Unit,
 		onLog: OnSyncLog,
 		onConflict: EntityConflictHandler<ApiProjectEntity>,
-		onComplete: suspend () -> Unit
+		onComplete: suspend (success: Boolean) -> Unit
 	): CResult<SyncOperationState> {
 		state as EntityDeleteOperationState
 

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/sync/projectsync/operations/FetchLocalDataOperation.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/sync/projectsync/operations/FetchLocalDataOperation.kt
@@ -25,7 +25,7 @@ class FetchLocalDataOperation(
 		onProgress: suspend (Float, SyncLogMessage?) -> Unit,
 		onLog: OnSyncLog,
 		onConflict: EntityConflictHandler<ApiProjectEntity>,
-		onComplete: suspend () -> Unit
+		onComplete: suspend (success: Boolean) -> Unit
 	): CResult<SyncOperationState> {
 		return try {
 			state as InitialSyncOperationState

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/sync/projectsync/operations/FetchServerDataOperation.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/sync/projectsync/operations/FetchServerDataOperation.kt
@@ -30,7 +30,7 @@ class FetchServerDataOperation(
 		onProgress: suspend (Float, SyncLogMessage?) -> Unit,
 		onLog: OnSyncLog,
 		onConflict: EntityConflictHandler<ApiProjectEntity>,
-		onComplete: suspend () -> Unit
+		onComplete: suspend (success: Boolean) -> Unit
 	): CResult<SyncOperationState> {
 
 		state as FetchLocalDataState

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/sync/projectsync/operations/FinalizeSyncOperation.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/sync/projectsync/operations/FinalizeSyncOperation.kt
@@ -35,7 +35,7 @@ class FinalizeSyncOperation(
 		onProgress: suspend (Float, SyncLogMessage?) -> Unit,
 		onLog: OnSyncLog,
 		onConflict: EntityConflictHandler<ApiProjectEntity>,
-		onComplete: suspend () -> Unit
+		onComplete: suspend (success: Boolean) -> Unit
 	): CResult<SyncOperationState> {
 
 		state as EntityTransferState
@@ -126,7 +126,7 @@ class FinalizeSyncOperation(
 
 		yield()
 
-		onComplete()
+		onComplete(allSuccess)
 
 		return if (allSuccess) {
 			CResult.success(state)

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/sync/projectsync/operations/IdConflictResolutionOperation.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/sync/projectsync/operations/IdConflictResolutionOperation.kt
@@ -19,7 +19,7 @@ class IdConflictResolutionOperation(
 		onProgress: suspend (Float, SyncLogMessage?) -> Unit,
 		onLog: OnSyncLog,
 		onConflict: EntityConflictHandler<ApiProjectEntity>,
-		onComplete: suspend () -> Unit
+		onComplete: suspend (success: Boolean) -> Unit
 	): CResult<SyncOperationState> {
 
 		state as CollateIdsState

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/sync/projectsync/operations/PrepareForSyncOperation.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/sync/projectsync/operations/PrepareForSyncOperation.kt
@@ -18,7 +18,7 @@ class PrepareForSyncOperation(
 		onProgress: suspend (Float, SyncLogMessage?) -> Unit,
 		onLog: OnSyncLog,
 		onConflict: EntityConflictHandler<ApiProjectEntity>,
-		onComplete: suspend () -> Unit
+		onComplete: suspend (success: Boolean) -> Unit
 	): CResult<SyncOperationState> {
 		idAllocator.findNextId()
 

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/sync/projectsync/operations/ProjectDataSyncOperation.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/sync/projectsync/operations/ProjectDataSyncOperation.kt
@@ -40,7 +40,7 @@ class ProjectDataSyncOperation(
 		onProgress: suspend (Float, SyncLogMessage?) -> Unit,
 		onLog: OnSyncLog,
 		onConflict: EntityConflictHandler<ApiProjectEntity>,
-		onComplete: suspend () -> Unit,
+		onComplete: suspend (success: Boolean) -> Unit,
 	): CResult<SyncOperationState> {
 		state as IdConflictResolutionState
 

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/sync/projectsync/operations/SyncOperation.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/sync/projectsync/operations/SyncOperation.kt
@@ -20,6 +20,6 @@ abstract class SyncOperation(
 		onProgress: suspend (Float, SyncLogMessage?) -> Unit,
 		onLog: OnSyncLog,
 		onConflict: EntityConflictHandler<ApiProjectEntity>,
-		onComplete: suspend () -> Unit
+		onComplete: suspend (success: Boolean) -> Unit
 	): CResult<SyncOperationState>
 }

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/sync/projectsync/operations/WritingActivitySyncOperation.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/sync/projectsync/operations/WritingActivitySyncOperation.kt
@@ -46,7 +46,7 @@ class WritingActivitySyncOperation(
 		onProgress: suspend (Float, SyncLogMessage?) -> Unit,
 		onLog: OnSyncLog,
 		onConflict: EntityConflictHandler<ApiProjectEntity>,
-		onComplete: suspend () -> Unit,
+		onComplete: suspend (success: Boolean) -> Unit,
 	): CResult<SyncOperationState> {
 		state as EntityTransferState
 

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/server/Api.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/server/Api.kt
@@ -15,6 +15,7 @@ import com.darkrockstudios.apps.hammer.network_request_failure_parse_body
 import com.darkrockstudios.apps.hammer.server_error_connection_generic
 import com.darkrockstudios.apps.hammer.server_error_connection_timeout
 import com.darkrockstudios.apps.hammer.server_error_dns
+import com.darkrockstudios.apps.hammer.server_error_network_unavailable
 import com.darkrockstudios.apps.hammer.server_error_timeout
 import com.darkrockstudios.apps.hammer.server_error_tls
 import com.darkrockstudios.apps.hammer.sync_general_error
@@ -152,30 +153,59 @@ abstract class Api(
 				)
 			)
 		} catch (e: IOException) {
-			if (e.isTlsFailure()) {
-				Napier.e("TLS Error", e)
-				Result.failure(
-					HttpFailureException(
-						statusCode = outerResponse?.status ?: HttpStatusCode.BadGateway,
-						error = HttpResponseError(
-							error = e.message ?: "TLS Error",
-							displayMessage = strRes.get(Res.string.server_error_tls, server.url),
-						)
+			ioFailure(e, server.url, path, outerResponse)
+		} catch (e: RuntimeException) {
+			// Only an unchecked IO wrapper lands here, which means the platform could not build its
+			// HTTP client at all, so the request never left the device.
+			ioFailure(e.asIoFailure() ?: throw e, server.url, path, outerResponse, local = true)
+		}
+	}
+
+	private suspend fun <T> ioFailure(
+		e: IOException,
+		serverUrl: String,
+		path: String,
+		outerResponse: HttpResponse?,
+		local: Boolean = false,
+	): Result<T> = when {
+		e.isTlsFailure() -> {
+			Napier.e("TLS Error", e)
+			Result.failure(
+				HttpFailureException(
+					statusCode = outerResponse?.status ?: HttpStatusCode.BadGateway,
+					error = HttpResponseError(
+						error = e.message ?: "TLS Error",
+						displayMessage = strRes.get(Res.string.server_error_tls, serverUrl),
 					)
 				)
-			} else {
-				// Generic network error (connection refused, etc.)
-				Napier.e("Network Error", e)
-				Result.failure(
-					HttpFailureException(
-						statusCode = outerResponse?.status ?: HttpStatusCode.RequestTimeout,
-						error = HttpResponseError(
-							error = e.message ?: "Network Error",
-							displayMessage = strRes.get(Res.string.server_error_connection_generic, path),
-						)
+			)
+		}
+
+		local -> {
+			Napier.e("Network Unavailable", e)
+			Result.failure(
+				HttpFailureException(
+					statusCode = outerResponse?.status ?: HttpStatusCode.ServiceUnavailable,
+					error = HttpResponseError(
+						error = e.message ?: "Network Unavailable",
+						displayMessage = strRes.get(Res.string.server_error_network_unavailable),
 					)
 				)
-			}
+			)
+		}
+
+		else -> {
+			// Generic network error (connection refused, etc.)
+			Napier.e("Network Error", e)
+			Result.failure(
+				HttpFailureException(
+					statusCode = outerResponse?.status ?: HttpStatusCode.RequestTimeout,
+					error = HttpResponseError(
+						error = e.message ?: "Network Error",
+						displayMessage = strRes.get(Res.string.server_error_connection_generic, path),
+					)
+				)
+			)
 		}
 	}
 

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/server/IoFailure.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/server/IoFailure.kt
@@ -1,0 +1,9 @@
+package com.darkrockstudios.apps.hammer.common.server
+
+import okio.IOException
+
+/**
+ * The [IOException] this throwable is, or the one a platform hides behind an unchecked wrapper,
+ * or null when it is not an IO failure.
+ */
+expect fun Throwable.asIoFailure(): IOException?

--- a/common/src/desktopTest/kotlin/components/projectsync/ProjectSynchronizationComponentTest.kt
+++ b/common/src/desktopTest/kotlin/components/projectsync/ProjectSynchronizationComponentTest.kt
@@ -68,7 +68,7 @@ class ProjectSynchronizationComponentTest : ComponentTest() {
 		val onProgress: suspend (Float, SyncLogMessage?) -> Unit,
 		val onLog: suspend (SyncLogMessage?) -> Unit,
 		val onConflict: suspend (ApiProjectEntity) -> Unit,
-		val onComplete: suspend () -> Unit,
+		val onComplete: suspend (Boolean) -> Unit,
 		val onUnauthorized: suspend () -> Unit,
 	)
 
@@ -132,7 +132,7 @@ class ProjectSynchronizationComponentTest : ComponentTest() {
 	fun `Successful sync reports progress and auto-closes the dialog`() = runTest(mainTestDispatcher) {
 		stubSync { callbacks ->
 			callbacks.onProgress(0.5f, null)
-			callbacks.onComplete()
+			callbacks.onComplete(true)
 			true
 		}
 
@@ -158,7 +158,7 @@ class ProjectSynchronizationComponentTest : ComponentTest() {
 			autoCloseSyncDialog = false,
 		)
 		stubSync { callbacks ->
-			callbacks.onComplete()
+			callbacks.onComplete(true)
 			true
 		}
 
@@ -196,7 +196,7 @@ class ProjectSynchronizationComponentTest : ComponentTest() {
 		stubSync { callbacks ->
 			callbacks.onProgress(0.25f, SyncLogMessage("first", SyncLogLevel.INFO, projectDef.name, Instant.DISTANT_PAST))
 			callbacks.onLog(SyncLogMessage("second", SyncLogLevel.WARN, projectDef.name, Instant.DISTANT_PAST))
-			callbacks.onComplete()
+			callbacks.onComplete(true)
 			true
 		}
 		every { globalSettingsStore.globalSettings } returns GlobalSettings(
@@ -213,6 +213,26 @@ class ProjectSynchronizationComponentTest : ComponentTest() {
 		val messages = comp.state.value.syncLog.map { it.message }
 		assertTrue(messages.contains("first"))
 		assertTrue(messages.contains("second"))
+	}
+
+	@Test
+	fun `Failed sync does not log Sync complete`() = runTest(mainTestDispatcher) {
+		stubSync { callbacks ->
+			callbacks.onLog(SyncLogMessage("Sync failed: boom", SyncLogLevel.ERROR, projectDef.name, Instant.DISTANT_PAST))
+			callbacks.onComplete(false)
+			false
+		}
+
+		val comp = newComponent()
+		context.resume()
+
+		comp.syncProject { }
+		advanceUntilIdle()
+
+		val messages = comp.state.value.syncLog.map { it.message }
+		assertTrue(messages.contains("Sync failed: boom"))
+		assertFalse(messages.contains("Sync complete!"))
+		assertFalse(comp.state.value.isSyncing)
 	}
 
 	@Test

--- a/common/src/desktopTest/kotlin/repositories/writingactivity/WritingActivitySyncOperationTest.kt
+++ b/common/src/desktopTest/kotlin/repositories/writingactivity/WritingActivitySyncOperationTest.kt
@@ -52,7 +52,7 @@ class WritingActivitySyncOperationTest : BaseTest() {
 	private val onProgress: suspend (Float, SyncLogMessage?) -> Unit = mockk(relaxed = true)
 	private val onLog: OnSyncLog = mockk(relaxed = true)
 	private val onConflict: EntityConflictHandler<ApiProjectEntity> = mockk(relaxed = true)
-	private val onComplete: suspend () -> Unit = mockk(relaxed = true)
+	private val onComplete: suspend (Boolean) -> Unit = mockk(relaxed = true)
 
 	private val ownDeviceId = "device-self"
 	private val deviceLabel = "My Desktop"

--- a/common/src/desktopTest/kotlin/server/ApiTlsFailureTest.kt
+++ b/common/src/desktopTest/kotlin/server/ApiTlsFailureTest.kt
@@ -8,6 +8,7 @@ import com.darkrockstudios.apps.hammer.common.server.ServerAccountApi
 import com.darkrockstudios.apps.hammer.common.util.DeviceLocaleResolver
 import com.darkrockstudios.apps.hammer.common.util.StrRes
 import com.darkrockstudios.apps.hammer.server_error_connection_generic
+import com.darkrockstudios.apps.hammer.server_error_network_unavailable
 import com.darkrockstudios.apps.hammer.server_error_tls
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.mock.MockEngine
@@ -21,15 +22,19 @@ import org.jetbrains.compose.resources.StringResource
 import org.junit.jupiter.api.BeforeEach
 import org.koin.dsl.module
 import utils.BaseTest
+import java.io.UncheckedIOException
 import java.net.ConnectException
 import javax.net.ssl.SSLHandshakeException
 import kotlin.test.Test
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
 import kotlin.test.assertIs
 import kotlin.test.assertTrue
 
 /**
  * A server reachable only over plain HTTP fails the client's TLS handshake, which needs to read as
- * "this server isn't serving HTTPS" rather than as a generic connectivity problem.
+ * "this server isn't serving HTTPS" rather than as a generic connectivity problem. Covers the rest
+ * of the network failure mapping too, including the unchecked wrappers the JDK throws.
  */
 class ApiTlsFailureTest : BaseTest() {
 
@@ -86,6 +91,47 @@ class ApiTlsFailureTest : BaseTest() {
 		assertTrue(strRes.requested.contains(Res.string.server_error_tls))
 	}
 
+	/**
+	 * `java.net.http.HttpClient`'s constructor wraps a failed `Selector.open()` this way, which is
+	 * how a Windows machine that cannot open the JDK's loopback socket pair fails. Nothing reached
+	 * the network, so it must not read as a server or connectivity problem.
+	 */
+	@Test
+	fun `an unchecked io wrapper reports the network being unavailable`() = runTest {
+		val api = createApi(
+			UncheckedIOException(java.io.IOException("Unable to establish loopback connection"))
+		)
+
+		val result = api.createAccount("user@example.com", "password", "install-id")
+
+		assertIs<HttpFailureException>(result.exceptionOrNull())
+		assertTrue(strRes.requested.contains(Res.string.server_error_network_unavailable))
+		assertFalse(strRes.requested.contains(Res.string.server_error_connection_generic))
+	}
+
+	@Test
+	fun `an unchecked io wrapper still recognises a tls failure`() = runTest {
+		val api = createApi(
+			UncheckedIOException(
+				java.io.IOException("request failed", SSLHandshakeException("bad certificate"))
+			)
+		)
+
+		val result = api.createAccount("user@example.com", "password", "install-id")
+
+		assertIs<HttpFailureException>(result.exceptionOrNull())
+		assertTrue(strRes.requested.contains(Res.string.server_error_tls))
+	}
+
+	@Test
+	fun `an unchecked non-io failure propagates`() = runTest {
+		val api = createApi(IllegalStateException("boom"))
+
+		assertFailsWith<IllegalStateException> {
+			api.createAccount("user@example.com", "password", "install-id")
+		}
+	}
+
 	@Test
 	fun `an ordinary connection failure keeps the generic message`() = runTest {
 		val api = createApi(ConnectException("Connection refused"))
@@ -94,6 +140,7 @@ class ApiTlsFailureTest : BaseTest() {
 
 		assertIs<HttpFailureException>(result.exceptionOrNull())
 		assertTrue(strRes.requested.contains(Res.string.server_error_connection_generic))
+		assertFalse(strRes.requested.contains(Res.string.server_error_network_unavailable))
 	}
 }
 

--- a/common/src/desktopTest/kotlin/synchronizer/ClientProjectSynchronizerTest.kt
+++ b/common/src/desktopTest/kotlin/synchronizer/ClientProjectSynchronizerTest.kt
@@ -205,7 +205,7 @@ class ClientProjectSynchronizerTest : BaseTest() {
 		val onProgress = mockk<suspend (Float, SyncLogMessage?) -> Unit>(relaxed = true)
 		val onLog = mockk<OnSyncLog>(relaxed = true)
 		val onConflict = mockk<EntityConflictHandler<ApiProjectEntity>>(relaxed = true)
-		val onComplete = mockk<suspend () -> Unit>(relaxed = true)
+		val onComplete = mockk<suspend (Boolean) -> Unit>(relaxed = true)
 
 		val success = syncer.sync(
 			onProgress = onProgress,
@@ -322,7 +322,7 @@ class ClientProjectSynchronizerTest : BaseTest() {
 		val onProgress = mockk<suspend (Float, SyncLogMessage?) -> Unit>(relaxed = true)
 		val onLog = mockk<OnSyncLog>(relaxed = true)
 		val onConflict = mockk<EntityConflictHandler<ApiProjectEntity>>(relaxed = true)
-		val onComplete = mockk<suspend () -> Unit>(relaxed = true)
+		val onComplete = mockk<suspend (Boolean) -> Unit>(relaxed = true)
 
 		val success = syncer.sync(
 			onProgress = onProgress,
@@ -448,7 +448,7 @@ class ClientProjectSynchronizerTest : BaseTest() {
 		val onProgress = mockk<suspend (Float, SyncLogMessage?) -> Unit>(relaxed = true)
 		val onLog = mockk<OnSyncLog>(relaxed = true)
 		val onConflict = mockk<EntityConflictHandler<ApiProjectEntity>>(relaxed = true)
-		val onComplete = mockk<suspend () -> Unit>(relaxed = true)
+		val onComplete = mockk<suspend (Boolean) -> Unit>(relaxed = true)
 		val onUnauthorized = mockk<suspend () -> Unit>(relaxed = true)
 
 		val success = syncer.sync(

--- a/common/src/desktopTest/kotlin/synchronizer/operations/BackupOperationTest.kt
+++ b/common/src/desktopTest/kotlin/synchronizer/operations/BackupOperationTest.kt
@@ -63,7 +63,7 @@ class BackupOperationTest : BaseTest() {
 		val onProgress = mockk<suspend (Float, SyncLogMessage?) -> Unit>(relaxed = true)
 		val onLog = mockk<OnSyncLog>(relaxed = true)
 		val onConflict = mockk<EntityConflictHandler<ApiProjectEntity>>(relaxed = true)
-		val onComplete = mockk<suspend () -> Unit>(relaxed = true)
+		val onComplete = mockk<suspend (Boolean) -> Unit>(relaxed = true)
 
 		val initialState = CollateIdsState(
 			onlyNew = false,
@@ -99,7 +99,7 @@ class BackupOperationTest : BaseTest() {
 		val onProgress = mockk<suspend (Float, SyncLogMessage?) -> Unit>(relaxed = true)
 		val onLog = mockk<OnSyncLog>(relaxed = true)
 		val onConflict = mockk<EntityConflictHandler<ApiProjectEntity>>(relaxed = true)
-		val onComplete = mockk<suspend () -> Unit>(relaxed = true)
+		val onComplete = mockk<suspend (Boolean) -> Unit>(relaxed = true)
 
 		val initialState = CollateIdsState(
 			onlyNew = false,
@@ -135,7 +135,7 @@ class BackupOperationTest : BaseTest() {
 		val onProgress = mockk<suspend (Float, SyncLogMessage?) -> Unit>(relaxed = true)
 		val onLog = mockk<OnSyncLog>(relaxed = true)
 		val onConflict = mockk<EntityConflictHandler<ApiProjectEntity>>(relaxed = true)
-		val onComplete = mockk<suspend () -> Unit>(relaxed = true)
+		val onComplete = mockk<suspend (Boolean) -> Unit>(relaxed = true)
 
 		val initialState = CollateIdsState(
 			onlyNew = false,

--- a/common/src/desktopTest/kotlin/synchronizer/operations/CollateIdsOperationTest.kt
+++ b/common/src/desktopTest/kotlin/synchronizer/operations/CollateIdsOperationTest.kt
@@ -50,7 +50,7 @@ class CollateIdsOperationTest : BaseTest() {
 		val onProgress = mockk<suspend (Float, SyncLogMessage?) -> Unit>(relaxed = true)
 		val onLog = mockk<OnSyncLog>(relaxed = true)
 		val onConflict = mockk<EntityConflictHandler<ApiProjectEntity>>(relaxed = true)
-		val onComplete = mockk<suspend () -> Unit>(relaxed = true)
+		val onComplete = mockk<suspend (Boolean) -> Unit>(relaxed = true)
 
 		val initialState = FetchServerDataState(
 			onlyNew = false,

--- a/common/src/desktopTest/kotlin/synchronizer/operations/EnsureProjectIdOperationTest.kt
+++ b/common/src/desktopTest/kotlin/synchronizer/operations/EnsureProjectIdOperationTest.kt
@@ -101,7 +101,7 @@ class EnsureProjectIdOperationTest : BaseTest() {
 		val onProgress = mockk<suspend (Float, SyncLogMessage?) -> Unit>(relaxed = true)
 		val onLog = mockk<OnSyncLog>(relaxed = true)
 		val onConflict = mockk<EntityConflictHandler<ApiProjectEntity>>(relaxed = true)
-		val onComplete = mockk<suspend () -> Unit>(relaxed = true)
+		val onComplete = mockk<suspend (Boolean) -> Unit>(relaxed = true)
 
 		val initialState = InitialSyncOperationState(false)
 		val result = op.execute(
@@ -146,7 +146,7 @@ class EnsureProjectIdOperationTest : BaseTest() {
 		val onProgress = mockk<suspend (Float, SyncLogMessage?) -> Unit>(relaxed = true)
 		val onLog = mockk<OnSyncLog>(relaxed = true)
 		val onConflict = mockk<EntityConflictHandler<ApiProjectEntity>>(relaxed = true)
-		val onComplete = mockk<suspend () -> Unit>(relaxed = true)
+		val onComplete = mockk<suspend (Boolean) -> Unit>(relaxed = true)
 
 		val initialState = InitialSyncOperationState(false)
 		val result = op.execute(
@@ -190,7 +190,7 @@ class EnsureProjectIdOperationTest : BaseTest() {
 		val onProgress = mockk<suspend (Float, SyncLogMessage?) -> Unit>(relaxed = true)
 		val logs = mutableListOf<SyncLogMessage>()
 		val onConflict = mockk<EntityConflictHandler<ApiProjectEntity>>(relaxed = true)
-		val onComplete = mockk<suspend () -> Unit>(relaxed = true)
+		val onComplete = mockk<suspend (Boolean) -> Unit>(relaxed = true)
 
 		val initialState = InitialSyncOperationState(false)
 		val result = op.execute(
@@ -230,7 +230,7 @@ class EnsureProjectIdOperationTest : BaseTest() {
 		val onProgress = mockk<suspend (Float, SyncLogMessage?) -> Unit>(relaxed = true)
 		val logs = mutableListOf<SyncLogMessage>()
 		val onConflict = mockk<EntityConflictHandler<ApiProjectEntity>>(relaxed = true)
-		val onComplete = mockk<suspend () -> Unit>(relaxed = true)
+		val onComplete = mockk<suspend (Boolean) -> Unit>(relaxed = true)
 
 		val initialState = InitialSyncOperationState(false)
 		val result = op.execute(

--- a/common/src/desktopTest/kotlin/synchronizer/operations/EntityDeleteOperationTest.kt
+++ b/common/src/desktopTest/kotlin/synchronizer/operations/EntityDeleteOperationTest.kt
@@ -62,7 +62,7 @@ class EntityDeleteOperationTest : BaseTest() {
 		val onProgress = mockk<suspend (Float, SyncLogMessage?) -> Unit>(relaxed = true)
 		val onLog = mockk<OnSyncLog>(relaxed = true)
 		val onConflict = mockk<EntityConflictHandler<ApiProjectEntity>>(relaxed = true)
-		val onComplete = mockk<suspend () -> Unit>(relaxed = true)
+		val onComplete = mockk<suspend (Boolean) -> Unit>(relaxed = true)
 
 		val initialState = IdConflictResolutionState(
 			onlyNew = false,

--- a/common/src/desktopTest/kotlin/synchronizer/operations/EntityTransferOperationTest.kt
+++ b/common/src/desktopTest/kotlin/synchronizer/operations/EntityTransferOperationTest.kt
@@ -140,7 +140,7 @@ class EntityTransferOperationTest : BaseTest() {
 		val onProgress = mockk<suspend (Float, SyncLogMessage?) -> Unit>(relaxed = true)
 		val onLog = mockk<OnSyncLog>(relaxed = true)
 		val onConflict = mockk<EntityConflictHandler<ApiProjectEntity>>(relaxed = true)
-		val onComplete = mockk<suspend () -> Unit>(relaxed = true)
+		val onComplete = mockk<suspend (Boolean) -> Unit>(relaxed = true)
 
 		val initialState = EntityDeleteOperationState(
 			onlyNew = false,

--- a/common/src/desktopTest/kotlin/synchronizer/operations/FetchLocalDataOperationTest.kt
+++ b/common/src/desktopTest/kotlin/synchronizer/operations/FetchLocalDataOperationTest.kt
@@ -110,7 +110,7 @@ class FetchLocalDataOperationTest : BaseTest() {
 		val onProgress = mockk<suspend (Float, SyncLogMessage?) -> Unit>(relaxed = true)
 		val onLog = mockk<OnSyncLog>(relaxed = true)
 		val onConflict = mockk<EntityConflictHandler<ApiProjectEntity>>(relaxed = true)
-		val onComplete = mockk<suspend () -> Unit>(relaxed = true)
+		val onComplete = mockk<suspend (Boolean) -> Unit>(relaxed = true)
 
 		val initialState = InitialSyncOperationState(false)
 		val result = op.execute(
@@ -206,7 +206,7 @@ class FetchLocalDataOperationTest : BaseTest() {
 		val onProgress = mockk<suspend (Float, SyncLogMessage?) -> Unit>(relaxed = true)
 		val onLog = mockk<OnSyncLog>(relaxed = true)
 		val onConflict = mockk<EntityConflictHandler<ApiProjectEntity>>(relaxed = true)
-		val onComplete = mockk<suspend () -> Unit>(relaxed = true)
+		val onComplete = mockk<suspend (Boolean) -> Unit>(relaxed = true)
 
 		val initialState = InitialSyncOperationState(false)
 		val result = op.execute(
@@ -240,7 +240,7 @@ class FetchLocalDataOperationTest : BaseTest() {
 		val onProgress = mockk<suspend (Float, SyncLogMessage?) -> Unit>(relaxed = true)
 		val onLog = mockk<OnSyncLog>(relaxed = true)
 		val onConflict = mockk<EntityConflictHandler<ApiProjectEntity>>(relaxed = true)
-		val onComplete = mockk<suspend () -> Unit>(relaxed = true)
+		val onComplete = mockk<suspend (Boolean) -> Unit>(relaxed = true)
 
 		val initialState = InitialSyncOperationState(false)
 		val result = op.execute(

--- a/common/src/desktopTest/kotlin/synchronizer/operations/FetchServerDataOperationTest.kt
+++ b/common/src/desktopTest/kotlin/synchronizer/operations/FetchServerDataOperationTest.kt
@@ -110,7 +110,7 @@ class FetchServerDataOperationTest : BaseTest() {
 		val onProgress = mockk<suspend (Float, SyncLogMessage?) -> Unit>(relaxed = true)
 		val onLog = mockk<OnSyncLog>(relaxed = true)
 		val onConflict = mockk<EntityConflictHandler<ApiProjectEntity>>(relaxed = true)
-		val onComplete = mockk<suspend () -> Unit>(relaxed = true)
+		val onComplete = mockk<suspend (Boolean) -> Unit>(relaxed = true)
 
 		val initialState = FetchLocalDataState(
 			onlyNew = false,
@@ -168,7 +168,7 @@ class FetchServerDataOperationTest : BaseTest() {
 		val onProgress = mockk<suspend (Float, SyncLogMessage?) -> Unit>(relaxed = true)
 		val onLog = mockk<OnSyncLog>(relaxed = true)
 		val onConflict = mockk<EntityConflictHandler<ApiProjectEntity>>(relaxed = true)
-		val onComplete = mockk<suspend () -> Unit>(relaxed = true)
+		val onComplete = mockk<suspend (Boolean) -> Unit>(relaxed = true)
 
 		val initialState = FetchLocalDataState(
 			onlyNew = false,

--- a/common/src/desktopTest/kotlin/synchronizer/operations/FinalizeSyncOperationTest.kt
+++ b/common/src/desktopTest/kotlin/synchronizer/operations/FinalizeSyncOperationTest.kt
@@ -121,7 +121,7 @@ class FinalizeSyncOperationTest : BaseTest() {
 		val onProgress = mockk<suspend (Float, SyncLogMessage?) -> Unit>(relaxed = true)
 		val onLog = mockk<OnSyncLog>(relaxed = true)
 		val onConflict = mockk<EntityConflictHandler<ApiProjectEntity>>(relaxed = true)
-		val onComplete = mockk<suspend () -> Unit>(relaxed = true)
+		val onComplete = mockk<suspend (Boolean) -> Unit>(relaxed = true)
 
 		val initialState = EntityTransferState(
 			onlyNew = false,
@@ -153,7 +153,7 @@ class FinalizeSyncOperationTest : BaseTest() {
 		coVerify { serverProjectApi.endProjectSync(1L, projId, beganResponse.syncId, 12, clock.now()) }
 		// Downloaded ids may sit above the allocator's sync-start snapshot; it must re-derive.
 		coVerify { idAllocator.findNextId() }
-		coVerify { onComplete() }
+		coVerify { onComplete(true) }
 
 		val saved = slot<ProjectSynchronizationData>()
 		coVerify { syncDataDatasource.saveSyncData(capture(saved)) }

--- a/common/src/desktopTest/kotlin/synchronizer/operations/IdConflictResolutionOperationTest.kt
+++ b/common/src/desktopTest/kotlin/synchronizer/operations/IdConflictResolutionOperationTest.kt
@@ -75,7 +75,7 @@ class IdConflictResolutionOperationTest : BaseTest() {
 		val onProgress = mockk<suspend (Float, SyncLogMessage?) -> Unit>(relaxed = true)
 		val onLog = mockk<OnSyncLog>(relaxed = true)
 		val onConflict = mockk<EntityConflictHandler<ApiProjectEntity>>(relaxed = true)
-		val onComplete = mockk<suspend () -> Unit>(relaxed = true)
+		val onComplete = mockk<suspend (Boolean) -> Unit>(relaxed = true)
 
 		val initialState = CollateIdsState(
 			onlyNew = false,
@@ -155,7 +155,7 @@ class IdConflictResolutionOperationTest : BaseTest() {
 		val onProgress = mockk<suspend (Float, SyncLogMessage?) -> Unit>(relaxed = true)
 		val onLog = mockk<OnSyncLog>(relaxed = true)
 		val onConflict = mockk<EntityConflictHandler<ApiProjectEntity>>(relaxed = true)
-		val onComplete = mockk<suspend () -> Unit>(relaxed = true)
+		val onComplete = mockk<suspend (Boolean) -> Unit>(relaxed = true)
 
 		val initialState = CollateIdsState(
 			onlyNew = false,
@@ -217,7 +217,7 @@ class IdConflictResolutionOperationTest : BaseTest() {
 		val onProgress = mockk<suspend (Float, SyncLogMessage?) -> Unit>(relaxed = true)
 		val onLog = mockk<OnSyncLog>(relaxed = true)
 		val onConflict = mockk<EntityConflictHandler<ApiProjectEntity>>(relaxed = true)
-		val onComplete = mockk<suspend () -> Unit>(relaxed = true)
+		val onComplete = mockk<suspend (Boolean) -> Unit>(relaxed = true)
 
 		val initialState = CollateIdsState(
 			onlyNew = false,

--- a/common/src/desktopTest/kotlin/synchronizer/operations/PrepareForSyncOperationTest.kt
+++ b/common/src/desktopTest/kotlin/synchronizer/operations/PrepareForSyncOperationTest.kt
@@ -70,7 +70,7 @@ class PrepareForSyncOperationTest : BaseTest() {
 		val onProgress = mockk<suspend (Float, SyncLogMessage?) -> Unit>(relaxed = true)
 		val onLog = mockk<OnSyncLog>(relaxed = true)
 		val onConflict = mockk<EntityConflictHandler<ApiProjectEntity>>(relaxed = true)
-		val onComplete = mockk<suspend () -> Unit>(relaxed = true)
+		val onComplete = mockk<suspend (Boolean) -> Unit>(relaxed = true)
 
 		val initialState = InitialSyncOperationState(false)
 		val result = op.execute(

--- a/common/src/iosMain/kotlin/com/darkrockstudios/apps/hammer/common/server/IoFailure.ios.kt
+++ b/common/src/iosMain/kotlin/com/darkrockstudios/apps/hammer/common/server/IoFailure.ios.kt
@@ -1,0 +1,5 @@
+package com.darkrockstudios.apps.hammer.common.server
+
+import okio.IOException
+
+actual fun Throwable.asIoFailure(): IOException? = this as? IOException

--- a/common/src/jvmMain/kotlin/com/darkrockstudios/apps/hammer/common/server/IoFailure.jvm.kt
+++ b/common/src/jvmMain/kotlin/com/darkrockstudios/apps/hammer/common/server/IoFailure.jvm.kt
@@ -1,0 +1,15 @@
+package com.darkrockstudios.apps.hammer.common.server
+
+import java.io.IOException
+import java.io.UncheckedIOException
+
+/**
+ * `java.net.http.HttpClient`'s constructor wraps a failed `Selector.open()` in an
+ * [UncheckedIOException], so a machine that cannot open the JDK's internal loopback socket pair
+ * fails with an unchecked exception before a request is ever sent.
+ */
+actual fun Throwable.asIoFailure(): IOException? = when (this) {
+	is IOException -> this
+	is UncheckedIOException -> cause as? IOException
+	else -> null
+}


### PR DESCRIPTION
A user syncing against hammer.ink got this in their sync log:

```
Sync failed: java.io.IOException: Unable to establish loopback connection
Sync complete!
```

Two separate problems.

## Unchecked IO failures escaped the error mapping

The Ktor Java engine builds its `java.net.http.HttpClient` lazily on the first
request. `HttpClientImpl`'s constructor starts a `SelectorManager`, and if
`Selector.open()` throws it wraps the `IOException` in an `UncheckedIOException`,
whose message is `cause.toString()` (hence the class name in the log).

On Windows that selector's wakeup mechanism is a TCP socket pair on 127.0.0.1
(`sun.nio.ch.PipeImpl`), so a machine with a firewall, VPN filter driver, or an
exhausted ephemeral port range fails there before a request is ever sent. The
string does not exist in the Linux JDK, which is what pins this to Windows.

`UncheckedIOException` is a `RuntimeException`, so it slipped past every catch in
`Api.makeRequest` and reached the generic handler in `ClientProjectSynchronizer`,
which logs the raw message.

New `expect`/`actual` `Throwable.asIoFailure()` alongside the existing
`isTlsFailure()`, and a second catch in `makeRequest` that routes unchecked
wrappers into the same mapping. `RuntimeException` rather than `Exception` keeps
the net narrow, and `?: throw e` means anything that is not an IO failure
(`CancellationException` included) propagates exactly as before.

A genuine connect failure arrives as a checked `IOException` and hits the first
catch, so the second one only ever sees unchecked wrappers, i.e. cases where the
client could not be built and nothing left the device. Those get a dedicated
message rather than the "check your connection" one, which would send people
chasing their internet instead of their firewall.

## "Sync complete!" was logged after failures

`handleSyncFailure` calls `onComplete`, which logged the success line
unconditionally. `onComplete` now carries the outcome and the log is gated on it;
the progress reset still runs either way.

## Testing

Four new tests. Both fixes were verified load-bearing by reverting them
individually and confirming the new tests fail on exactly the reverted behaviour.
Full `:common:desktopTest` green, plus `compileAndroidMain` and
`compileKotlinIosSimulatorArm64` for the expect/actual.