### PR TITLE
Publish iOS under the shared com.darkrockstudios.apps.hammer app ID

### DIFF
--- a/.github/workflows/publish-ios-app-store.yml
+++ b/.github/workflows/publish-ios-app-store.yml
@@ -15,6 +15,18 @@ on:
         required: false
   workflow_call:
 
+# Serialized against the Mac App Store publish: since iOS moved onto the macOS
+# app record for Universal Purchase, both publishes target the SAME App Store
+# Connect record, and deliver edits record-level App Information (categories,
+# copyright) as well as the per-platform version. A full release tag — one with
+# no `+platform` suffix — starts both in parallel, so they must queue instead.
+# The group name is deliberately constant, not per-tag: two overlapping releases
+# would collide the same way. cancel-in-progress stays false; aborting a publish
+# part-way through a review submission is far worse than waiting for a slot.
+concurrency:
+  group: app-store-connect
+  cancel-in-progress: false
+
 jobs:
   publish-ios-app-store:
     runs-on: macos-latest

--- a/.github/workflows/publish-mac-app-store.yml
+++ b/.github/workflows/publish-mac-app-store.yml
@@ -15,6 +15,18 @@ on:
         required: false
   workflow_call:
 
+# Serialized against the Mac App Store publish: since iOS moved onto the macOS
+# app record for Universal Purchase, both publishes target the SAME App Store
+# Connect record, and deliver edits record-level App Information (categories,
+# copyright) as well as the per-platform version. A full release tag — one with
+# no `+platform` suffix — starts both in parallel, so they must queue instead.
+# The group name is deliberately constant, not per-tag: two overlapping releases
+# would collide the same way. cancel-in-progress stays false; aborting a publish
+# part-way through a review submission is far worse than waiting for a slot.
+concurrency:
+  group: app-store-connect
+  cancel-in-progress: false
+
 jobs:
   publish-mac-app-store:
     runs-on: macos-latest

--- a/fastlane/Appfile
+++ b/fastlane/Appfile
@@ -8,3 +8,9 @@ for_platform :mac do
   apple_id("adamwbrown@gmail.com")
   team_id("8P3G3HT4J5")
 end
+
+for_platform :ios do
+  app_identifier("com.darkrockstudios.apps.hammer")
+  apple_id("adamwbrown@gmail.com")
+  team_id("8P3G3HT4J5")
+end

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -213,7 +213,14 @@ platform :ios do
       platform: "ios",
       app_version: app_marketing_version,
       skip_binary_upload: true,
-      skip_screenshots: true,
+      # Screenshots must be uploaded, unlike the :mac lane. iOS moved onto the
+      # macOS app record for Universal Purchase, and that record's iOS platform
+      # started with no screenshots at all — nothing carried over from the old
+      # standalone iOS listing. App Store Connect refuses to submit a version
+      # with no iPhone screenshots, and the failure lands after the binary is
+      # already uploaded. Uploading every release also keeps the store in sync
+      # with fastlane/metadata/ios.
+      skip_screenshots: false,
       metadata_path: "fastlane/metadata/ios",
       submit_for_review: true,
       automatic_release: true,

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -209,7 +209,7 @@ platform :ios do
   lane :ios_submit do |options|
     params = {
       api_key: appstore_api_key,
-      app_identifier: "com.darkrockstudios.apps.hammer.ios",
+      app_identifier: "com.darkrockstudios.apps.hammer",
       platform: "ios",
       app_version: app_marketing_version,
       skip_binary_upload: true,
@@ -233,7 +233,7 @@ platform :ios do
     if build_number.nil? || build_number.empty?
       latest = latest_testflight_build_number(
         api_key: api_key,
-        app_identifier: "com.darkrockstudios.apps.hammer.ios",
+        app_identifier: "com.darkrockstudios.apps.hammer",
         platform: "ios",
         initial_build_number: 0,
       )
@@ -262,7 +262,7 @@ platform :ios do
         teamID: "8P3G3HT4J5",
         signingStyle: "manual",
         provisioningProfiles: {
-          "com.darkrockstudios.apps.hammer.ios" => "Hammer AppStore iOS",
+          "com.darkrockstudios.apps.hammer" => "Hammer AppStore iOS",
         },
       },
       clean: true,
@@ -276,7 +276,7 @@ platform :ios do
     # cutting off a legitimately slow processing run at a tighter deadline.
     upload_to_testflight(
       api_key: api_key,
-      app_identifier: "com.darkrockstudios.apps.hammer.ios",
+      app_identifier: "com.darkrockstudios.apps.hammer",
       app_platform: "ios",
       ipa: lane_context[SharedValues::IPA_OUTPUT_PATH],
       skip_waiting_for_build_processing: !options[:wait],

--- a/fastlane/metadata/ios/en-US/name.txt
+++ b/fastlane/metadata/ios/en-US/name.txt
@@ -1,1 +1,1 @@
-Hammer-Editor
+Hammer Editor

--- a/ios/ios.xcodeproj/project.pbxproj
+++ b/ios/ios.xcodeproj/project.pbxproj
@@ -492,7 +492,7 @@
 					"-framework",
 					Hammer,
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.darkrockstudios.apps.hammer.ios;
+				PRODUCT_BUNDLE_IDENTIFIER = com.darkrockstudios.apps.hammer;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "Hammer AppStore iOS";
@@ -525,7 +525,7 @@
 					"-framework",
 					Hammer,
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.darkrockstudios.apps.hammer.ios;
+				PRODUCT_BUNDLE_IDENTIFIER = com.darkrockstudios.apps.hammer;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "Hammer AppStore iOS";


### PR DESCRIPTION
iOS and macOS were shipping as two separate App Store listings under two bundle
IDs, which isn't how Apple intends this to work. The supported model is
Universal Purchase: one app record, one bundle ID, one platform entry per OS.

**The binaries stay separate.** This is not a universal or Catalyst app — each
platform is still built and uploaded independently and keeps its own version
stream, build numbers and screenshots.

## Changes

- `ios.xcodeproj` — `PRODUCT_BUNDLE_IDENTIFIER` for the Debug and Release
  configs of the `ios` target moves to `com.darkrockstudios.apps.hammer`. The
  `iosUITests` target keeps its own suffixed ID; it is never uploaded.
- `Fastfile` — all four iOS `app_identifier` values plus the
  `provisioningProfiles` map key.
- `Appfile` — adds the `for_platform :ios` block that was missing entirely.
- `metadata/ios/en-US/name.txt` — "Hammer-Editor" loses its hyphen. That name
  only existed because the unhyphenated one was taken by our own macOS record;
  a merged record has a single name. `metadata/ios` and `metadata/osx` are now
  byte-identical apart from screenshots.

## Already done outside the repo

- App ID `com.darkrockstudios.apps.hammer` confirmed to support
  iOS/iPadOS/macOS/tvOS/watchOS/visionOS.
- iOS platform added to the existing macOS app record in App Store Connect.
- Old profile deleted, `Hammer AppStore iOS` regenerated against the merged
  bundle ID, and `IOS_APPSTORE_PROVISIONING_PROFILE_BASE64` updated.

## Releasing this

Run the iOS job on its own first, not a combined `+mac-app-store+ios-app-store`
tag. The per-store jobs run in parallel, which was harmless when the two
platforms were separate app records but now means two concurrent `deliver` runs
writing App Information to the same record. Metadata values are identical so a
clobber is a no-op, but a concurrent-write error landing mid-submission is
awkward to unpick. Serializing those two jobs is worth doing separately.

## Follow-ups

- Old iOS listing needs Remove from Sale. Its bundle ID is burned permanently.
- The new bundle ID means a new container, so existing iOS users' projects in
  the old app's Documents directory are invisible to the new app. Worth a final
  update to the old listing telling people to export first.
- The iOS signing cert expires 2026-10-17 and the new profile expires with it.
  Rolling to a modern Apple Distribution cert also means swapping
  `IOS_DISTRIBUTION_CERT_P12_BASE64` and moving `CODE_SIGN_IDENTITY` off the
  legacy "iPhone Distribution" value.
