### PR TITLE
Stop credential fields from auto-capitalizing what is typed

### DIFF
--- a/common/src/commonMain/composeResources/values/strings_account_settings.xml
+++ b/common/src/commonMain/composeResources/values/strings_account_settings.xml
@@ -43,6 +43,7 @@
 	<string name="settings_server_setup_url_hint">Server URL: hammer.ink</string>
 	<string name="settings_server_setup_email_hint">E-Mail: user@example.com</string>
 	<string name="settings_server_setup_password_hint">Password</string>
+	<string name="settings_server_setup_password_requirements">%1$d-%2$d characters</string>
 	<string name="settings_server_setup_password_show">Show password</string>
 	<string name="settings_server_setup_password_hide">Hide password</string>
 	<string name="settings_server_setup_login_button">Log In</string>

--- a/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/compose/designsystem/HdCredentialFields.kt
+++ b/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/compose/designsystem/HdCredentialFields.kt
@@ -1,0 +1,106 @@
+package com.darkrockstudios.apps.hammer.common.compose.designsystem
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.KeyboardCapitalization
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.input.PasswordVisualTransformation
+import androidx.compose.ui.text.input.VisualTransformation
+import com.darkrockstudios.apps.hammer.Res
+import com.darkrockstudios.apps.hammer.common.compose.Ui
+import com.darkrockstudios.apps.hammer.common.compose.resources.get
+import com.darkrockstudios.apps.hammer.settings_server_setup_password_hide
+import com.darkrockstudios.apps.hammer.settings_server_setup_password_show
+
+/**
+ * Credential entry built on [HdHairlineField].
+ *
+ * Anything the user has to reproduce byte-for-byte on another device — a
+ * password, the email it is keyed to — must reach the server exactly as typed.
+ * These wrappers pin the keyboard options that guarantee that, so no screen has
+ * to remember them: IME auto-capitalization and autocorrect are off, and the
+ * password variant carries its own show/hide toggle.
+ */
+@Composable
+fun HdPasswordField(
+	label: String,
+	value: String,
+	onValueChange: (String) -> Unit,
+	visible: Boolean,
+	onVisibleChange: (Boolean) -> Unit,
+	modifier: Modifier = Modifier,
+	placeholder: String? = null,
+	hint: String? = null,
+	error: String? = null,
+	imeAction: ImeAction = ImeAction.Done,
+	enabled: Boolean = true,
+	testTag: String? = null,
+) {
+	Column(
+		modifier = modifier.fillMaxWidth(),
+		verticalArrangement = Arrangement.spacedBy(Ui.Padding.L),
+	) {
+		HdHairlineField(
+			label = label,
+			value = value,
+			onValueChange = onValueChange,
+			placeholder = placeholder,
+			hint = hint,
+			error = error,
+			singleLine = true,
+			imeAction = imeAction,
+			capitalization = KeyboardCapitalization.None,
+			autoCorrectEnabled = false,
+			keyboardType = KeyboardType.Password,
+			visualTransformation = if (visible) VisualTransformation.None
+			else PasswordVisualTransformation(),
+			enabled = enabled,
+			testTag = testTag,
+		)
+
+		HdHairlineToggleRow(
+			checked = visible,
+			onCheckedChange = onVisibleChange,
+			label = if (visible) {
+				Res.string.settings_server_setup_password_hide.get()
+			} else {
+				Res.string.settings_server_setup_password_show.get()
+			},
+		)
+	}
+}
+
+@Composable
+fun HdEmailField(
+	label: String,
+	value: String,
+	onValueChange: (String) -> Unit,
+	modifier: Modifier = Modifier,
+	placeholder: String? = null,
+	hint: String? = null,
+	error: String? = null,
+	imeAction: ImeAction = ImeAction.Next,
+	enabled: Boolean = true,
+	testTag: String? = null,
+) {
+	HdHairlineField(
+		label = label,
+		value = value,
+		onValueChange = onValueChange,
+		modifier = modifier,
+		placeholder = placeholder,
+		hint = hint,
+		error = error,
+		singleLine = true,
+		imeAction = imeAction,
+		capitalization = KeyboardCapitalization.None,
+		autoCorrectEnabled = false,
+		keyboardType = KeyboardType.Email,
+		enabled = enabled,
+		testTag = testTag,
+	)
+}

--- a/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/compose/designsystem/HdHairlineField.kt
+++ b/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/compose/designsystem/HdHairlineField.kt
@@ -47,6 +47,7 @@ fun HdHairlineField(
 	maxLines: Int = if (singleLine) 1 else Int.MAX_VALUE,
 	imeAction: ImeAction = if (singleLine) ImeAction.Next else ImeAction.Default,
 	capitalization: KeyboardCapitalization = KeyboardCapitalization.Sentences,
+	autoCorrectEnabled: Boolean? = null,
 	keyboardType: KeyboardType = KeyboardType.Text,
 	visualTransformation: VisualTransformation = VisualTransformation.None,
 	enabled: Boolean = true,
@@ -107,6 +108,7 @@ fun HdHairlineField(
 					keyboardOptions = KeyboardOptions(
 						imeAction = imeAction,
 						capitalization = capitalization,
+						autoCorrectEnabled = autoCorrectEnabled,
 						keyboardType = keyboardType,
 					),
 				)

--- a/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/projectselection/settings/ServerSetupDialog.kt
+++ b/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/projectselection/settings/ServerSetupDialog.kt
@@ -10,13 +10,12 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardType
-import androidx.compose.ui.text.input.PasswordVisualTransformation
-import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.DialogProperties
 import com.arkivanov.decompose.extensions.compose.subscribeAsState
 import com.darkrockstudios.apps.hammer.*
+import com.darkrockstudios.apps.hammer.base.validate.PasswordValidator
 import com.darkrockstudios.apps.hammer.common.components.projectselection.accountsettings.AccountSettings
 import com.darkrockstudios.apps.hammer.common.compose.AnimatedDialogContainer
 import com.darkrockstudios.apps.hammer.common.compose.Ui
@@ -135,38 +134,26 @@ fun ServerSetupDialogContent(
 					enabled = !state.serverWorking && !existingServer,
 				)
 
-				HdHairlineField(
+				HdEmailField(
 					label = "EMAIL",
 					value = state.serverEmail ?: "",
 					onValueChange = { component.updateServerEmail(it) },
 					placeholder = Res.string.settings_server_setup_email_hint.get(),
-					singleLine = true,
-					imeAction = ImeAction.Next,
-					keyboardType = KeyboardType.Email,
 					enabled = !state.serverWorking && !existingServer,
 				)
 
-				HdHairlineField(
+				HdPasswordField(
 					label = "PASSWORD",
 					value = state.serverPassword ?: "",
 					onValueChange = { component.updateServerPassword(it) },
+					visible = passwordVisible,
+					onVisibleChange = { passwordVisible = it },
 					placeholder = Res.string.settings_server_setup_password_hint.get(),
-					singleLine = true,
-					imeAction = ImeAction.Done,
-					keyboardType = KeyboardType.Password,
-					visualTransformation = if (passwordVisible) VisualTransformation.None
-					else PasswordVisualTransformation(),
+					hint = Res.string.settings_server_setup_password_requirements.get(
+						PasswordValidator.MIN_LENGTH,
+						PasswordValidator.MAX_LENGTH,
+					),
 					enabled = !state.serverWorking,
-				)
-
-				HdHairlineToggleRow(
-					checked = passwordVisible,
-					onCheckedChange = { passwordVisible = it },
-					label = if (passwordVisible) {
-						Res.string.settings_server_setup_password_hide.get()
-					} else {
-						Res.string.settings_server_setup_password_show.get()
-					},
 				)
 
 				state.serverError?.let { error ->

--- a/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/reauthentication/ReauthenticationUi.kt
+++ b/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/reauthentication/ReauthenticationUi.kt
@@ -10,10 +10,6 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.RectangleShape
-import androidx.compose.ui.text.input.ImeAction
-import androidx.compose.ui.text.input.KeyboardType
-import androidx.compose.ui.text.input.PasswordVisualTransformation
-import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.DialogProperties
@@ -141,27 +137,14 @@ internal fun ReauthenticationContent(
 					selectable = true,
 				)
 
-				HdHairlineField(
+				HdPasswordField(
 					label = Res.string.settings_server_setup_password_hint.get(),
 					value = state.serverPassword,
 					onValueChange = onPasswordChange,
+					visible = passwordVisible,
+					onVisibleChange = onPasswordVisibleChange,
 					placeholder = Res.string.settings_server_setup_password_hint.get(),
-					singleLine = true,
-					imeAction = ImeAction.Done,
-					keyboardType = KeyboardType.Password,
-					visualTransformation = if (passwordVisible) VisualTransformation.None
-					else PasswordVisualTransformation(),
 					enabled = !state.serverWorking,
-				)
-
-				HdHairlineToggleRow(
-					checked = passwordVisible,
-					onCheckedChange = onPasswordVisibleChange,
-					label = if (passwordVisible) {
-						Res.string.settings_server_setup_password_hide.get()
-					} else {
-						Res.string.settings_server_setup_password_show.get()
-					},
 				)
 
 				state.serverError?.let { error ->

--- a/composeUi/src/desktopMain/kotlin/com/darkrockstudios/apps/hammer/common/preview/designsystem/DesignSystem.Preview.kt
+++ b/composeUi/src/desktopMain/kotlin/com/darkrockstudios/apps/hammer/common/preview/designsystem/DesignSystem.Preview.kt
@@ -37,6 +37,7 @@ import com.darkrockstudios.apps.hammer.common.compose.designsystem.HdCategorySwa
 import com.darkrockstudios.apps.hammer.common.compose.designsystem.HdCollapseGlyph
 import com.darkrockstudios.apps.hammer.common.compose.designsystem.HdDailyGoalProgress
 import com.darkrockstudios.apps.hammer.common.compose.designsystem.HdDeltaBadge
+import com.darkrockstudios.apps.hammer.common.compose.designsystem.HdEmailField
 import com.darkrockstudios.apps.hammer.common.compose.designsystem.HdEngravingPlaceholder
 import com.darkrockstudios.apps.hammer.common.compose.designsystem.HdEntryCard
 import com.darkrockstudios.apps.hammer.common.compose.designsystem.HdEntryFilterBar
@@ -56,6 +57,7 @@ import com.darkrockstudios.apps.hammer.common.compose.designsystem.HdMiniBarChar
 import com.darkrockstudios.apps.hammer.common.compose.designsystem.HdMonoLabel
 import com.darkrockstudios.apps.hammer.common.compose.designsystem.HdNavRail
 import com.darkrockstudios.apps.hammer.common.compose.designsystem.HdNavRailDestination
+import com.darkrockstudios.apps.hammer.common.compose.designsystem.HdPasswordField
 import com.darkrockstudios.apps.hammer.common.compose.designsystem.HdPlainSection
 import com.darkrockstudios.apps.hammer.common.compose.designsystem.HdReferenceChip
 import com.darkrockstudios.apps.hammer.common.compose.designsystem.HdReferenceChipVariant
@@ -686,6 +688,38 @@ fun HairlineFieldPreview() {
 				singleLine = false,
 				minLines = 3,
 				modifier = Modifier.fillMaxWidth(),
+			)
+		}
+	}
+}
+
+@Preview
+@Composable
+fun CredentialFieldsPreview() {
+	AppTheme(globalSettingsPreview, useDarkTheme = true) {
+		PreviewSurface {
+			HdEmailField(
+				label = "EMAIL",
+				value = "alice@example.com",
+				onValueChange = {},
+				placeholder = "E-Mail: user@example.com",
+				modifier = Modifier.fillMaxWidth(),
+			)
+			HdPasswordField(
+				label = "PASSWORD",
+				value = "correcthorsebattery",
+				onValueChange = {},
+				visible = false,
+				onVisibleChange = {},
+				hint = "8-64 characters",
+			)
+			HdPasswordField(
+				label = "PASSWORD",
+				value = "hunter2",
+				onValueChange = {},
+				visible = true,
+				onVisibleChange = {},
+				error = "Password is too short",
 			)
 		}
 	}


### PR DESCRIPTION
`HdHairlineField` defaults to `KeyboardCapitalization.Sentences`, and neither the
server setup dialog nor the reauthentication dialog overrode it on their email or
password fields. An IME that honours `CAP_SENTENCES` on a password variation
capitalizes the first character as it is entered, so an account gets created with
a password the user cannot reproduce in a browser, where nothing capitalizes
anything. The failure looks exactly like a rejected password, which is one
plausible reading of #835.

## Changes

- **`HdPasswordField` / `HdEmailField`** (new, `HdCredentialFields.kt`) pin the
  keyboard options credential entry needs: no auto-capitalization, no autocorrect,
  and the right `KeyboardType`. A screen can no longer forget them.
- `HdPasswordField` also absorbs the show/hide toggle that both dialogs had
  inlined identically, and carries the 8-64 character rule as a field hint
  formatted from `PasswordValidator` so it cannot drift from what the server
  enforces.
- `HdHairlineField` gains an `autoCorrectEnabled` passthrough.
- `ServerSetupDialog` and `ReauthenticationUi` drop their hand-rolled password
  plumbing and use the new fields.

Only `values/strings_account_settings.xml` gains a string; the other locales come
from the translation service.

## Verification

`CredentialFieldsPreview` in the design-system gallery renders the masked field
with its hint, the revealed field with an error, and the email field. Both the
`ServerSetupDialog` and `Reauthentication` previews were re-rendered and are
unchanged apart from the new hint.
