### PR TITLE
Say why a login failed instead of answering a bare 401

### DIFF
--- a/base/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/base/http/HttpResponseError.kt
+++ b/base/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/base/http/HttpResponseError.kt
@@ -8,6 +8,29 @@ data class HttpResponseError(
 	val error: String,
 	/** A translated message to display to the user */
 	val displayMessage: String,
+	/**
+	 * Stable, machine-readable reason from [ApiErrorCode]. Null when the server predates
+	 * error codes, or when the failure has no code worth branching on.
+	 */
+	val errorCode: String? = null,
 ) {
 	override fun toString() = displayMessage
+}
+
+/**
+ * Reasons a request failed, stable across releases and independent of the translated
+ * [HttpResponseError.displayMessage]. Plain strings rather than an enum so an unknown
+ * value from a newer server deserializes instead of throwing.
+ */
+object ApiErrorCode {
+	/** Wrong password, or no such account. Deliberately one code — see AccountsRepository.login. */
+	const val INVALID_CREDENTIALS = "invalid_credentials"
+	const val ACCOUNT_EXISTS = "account_exists"
+	const val ACCOUNT_PENDING_DELETION = "account_pending_deletion"
+	const val INVALID_EMAIL = "invalid_email"
+	const val PASSWORD_TOO_SHORT = "password_too_short"
+	const val PASSWORD_TOO_LONG = "password_too_long"
+	const val PASSWORD_INVALID = "password_invalid"
+	const val NOT_WHITELISTED = "not_whitelisted"
+	const val TOKEN_INVALID = "token_invalid"
 }

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/server/Api.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/server/Api.kt
@@ -339,44 +339,28 @@ class TermsOfServiceRequiredException(
 
 typealias FailureHandler = suspend (HttpResponse) -> Throwable
 
-private suspend fun unparseableErrorBody(
-	status: HttpStatusCode,
-	strRes: StrRes,
-	cause: Throwable,
-): HttpFailureException {
-	Napier.w("Error response body unable to be parsed", cause)
+suspend fun defaultFailureHandler(response: HttpResponse, strRes: StrRes): Throwable {
+	val error = try {
+		response.body<HttpResponseError>()
+	} catch (e: NoTransformationFoundException) {
+		null.also { Napier.w("Error response body unable to be parsed", e) }
+	} catch (e: ContentConvertException) {
+		null.also { Napier.w("Error response body unable to be parsed", e) }
+	}
+
+	if (error != null) return HttpFailureException(statusCode = response.status, error = error)
+
+	// Only when the server said nothing usable. A 401 carrying "invalid email or
+	// password" must reach the user as that, not as the generic sync message.
 	return HttpFailureException(
-		statusCode = status,
+		statusCode = response.status,
 		error = HttpResponseError(
-			error = "Unhandled error body",
-			displayMessage = strRes.get(Res.string.sync_general_error),
+			error = if (response.status == HttpStatusCode.Unauthorized) "Unauthorized" else "Unhandled error body",
+			displayMessage = if (response.status == HttpStatusCode.Unauthorized) {
+				strRes.get(Res.string.sync_unauthorized)
+			} else {
+				strRes.get(Res.string.sync_general_error)
+			},
 		)
 	)
-}
-
-suspend fun defaultFailureHandler(response: HttpResponse, strRes: StrRes): Throwable {
-	return when(response.status) {
-		HttpStatusCode.Unauthorized -> {
-			HttpFailureException(
-				statusCode = response.status,
-				error = HttpResponseError(
-					error = "Unauthorized",
-					displayMessage = strRes.get(Res.string.sync_unauthorized),
-				)
-			)
-		}
-		else -> {
-			try {
-				val error = response.body<HttpResponseError>()
-				HttpFailureException(
-					statusCode = response.status,
-					error = error
-				)
-			} catch (e: NoTransformationFoundException) {
-				unparseableErrorBody(response.status, strRes, e)
-			} catch (e: ContentConvertException) {
-				unparseableErrorBody(response.status, strRes, e)
-			}
-		}
-	}
 }

--- a/common/src/desktopTest/kotlin/server/ApiFailureBodyTest.kt
+++ b/common/src/desktopTest/kotlin/server/ApiFailureBodyTest.kt
@@ -1,0 +1,137 @@
+package server
+
+import com.darkrockstudios.apps.hammer.Res
+import com.darkrockstudios.apps.hammer.base.http.ApiErrorCode
+import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettingsStore
+import com.darkrockstudios.apps.hammer.common.data.globalsettings.ServerSettings
+import com.darkrockstudios.apps.hammer.common.server.HttpFailureException
+import com.darkrockstudios.apps.hammer.common.server.ServerAccountApi
+import com.darkrockstudios.apps.hammer.common.util.DeviceLocaleResolver
+import com.darkrockstudios.apps.hammer.sync_general_error
+import com.darkrockstudios.apps.hammer.sync_unauthorized
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.headersOf
+import io.ktor.serialization.kotlinx.json.json
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.Json
+import org.junit.jupiter.api.BeforeEach
+import org.koin.dsl.module
+import utils.BaseTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
+
+/**
+ * What the server said about a failure has to survive the trip to the user. A 401
+ * explaining that the password was wrong used to be replaced by the generic sync
+ * message before anyone could read it (#835).
+ */
+class ApiFailureBodyTest : BaseTest() {
+
+	private lateinit var globalSettingsStore: GlobalSettingsStore
+	private lateinit var strRes: RecordingStrRes
+
+	@BeforeEach
+	override fun setup() {
+		super.setup()
+
+		strRes = RecordingStrRes()
+		globalSettingsStore = mockk(relaxed = true)
+		every { globalSettingsStore.serverSettings } returns ServerSettings(
+			url = "example.com",
+			email = "user@example.com",
+			userId = -1L,
+			bearerToken = null,
+			refreshToken = null,
+		)
+
+		setupKoin(
+			module {
+				single { DeviceLocaleResolver() }
+			}
+		)
+	}
+
+	@Test
+	fun `a 401 carrying a message reaches the caller as that message`() = runTest {
+		val api = createApi(
+			status = HttpStatusCode.Unauthorized,
+			body = """{"error":"Failed to authenticate","displayMessage":"Invalid email or password",""" +
+				""""errorCode":"${ApiErrorCode.INVALID_CREDENTIALS}"}""",
+			contentType = "application/json",
+		)
+
+		val failure = api.login("user@example.com", "password", "install-id").exceptionOrNull()
+
+		val httpFailure = assertIs<HttpFailureException>(failure)
+		assertEquals("Invalid email or password", httpFailure.error.displayMessage)
+		assertEquals(ApiErrorCode.INVALID_CREDENTIALS, httpFailure.error.errorCode)
+		assertFalse(
+			strRes.requested.contains(Res.string.sync_unauthorized),
+			"A message from the server must not be replaced by the generic one",
+		)
+	}
+
+	@Test
+	fun `a 403 naming the allowed-users list keeps its own message`() = runTest {
+		val api = createApi(
+			status = HttpStatusCode.Forbidden,
+			body = """{"error":"Failed to authenticate","displayMessage":"Not allowed on this server",""" +
+				""""errorCode":"${ApiErrorCode.NOT_WHITELISTED}"}""",
+			contentType = "application/json",
+		)
+
+		val failure = api.login("user@example.com", "password", "install-id").exceptionOrNull()
+
+		val httpFailure = assertIs<HttpFailureException>(failure)
+		assertEquals(HttpStatusCode.Forbidden, httpFailure.statusCode)
+		assertEquals(ApiErrorCode.NOT_WHITELISTED, httpFailure.error.errorCode)
+	}
+
+	@Test
+	fun `a 401 with nothing usable falls back to the unauthorized message`() = runTest {
+		val api = createApi(status = HttpStatusCode.Unauthorized, body = "")
+
+		val failure = api.login("user@example.com", "password", "install-id").exceptionOrNull()
+
+		assertIs<HttpFailureException>(failure)
+		assertTrue(strRes.requested.contains(Res.string.sync_unauthorized))
+	}
+
+	@Test
+	fun `another status with nothing usable falls back to the general message`() = runTest {
+		val api = createApi(status = HttpStatusCode.InternalServerError, body = "")
+
+		val failure = api.login("user@example.com", "password", "install-id").exceptionOrNull()
+
+		assertIs<HttpFailureException>(failure)
+		assertTrue(strRes.requested.contains(Res.string.sync_general_error))
+	}
+
+	private fun createApi(
+		status: HttpStatusCode,
+		body: String,
+		contentType: String? = null,
+	): ServerAccountApi {
+		val engine = MockEngine {
+			respond(
+				content = body,
+				status = status,
+				headers = contentType?.let { headersOf(HttpHeaders.ContentType, it) } ?: headersOf(),
+			)
+		}
+		val client = HttpClient(engine) {
+			install(ContentNegotiation) { json(Json { ignoreUnknownKeys = true }) }
+		}
+		return ServerAccountApi(client, globalSettingsStore, strRes)
+	}
+}

--- a/common/src/desktopTest/kotlin/server/ApiTlsFailureTest.kt
+++ b/common/src/desktopTest/kotlin/server/ApiTlsFailureTest.kt
@@ -6,7 +6,6 @@ import com.darkrockstudios.apps.hammer.common.data.globalsettings.ServerSettings
 import com.darkrockstudios.apps.hammer.common.server.HttpFailureException
 import com.darkrockstudios.apps.hammer.common.server.ServerAccountApi
 import com.darkrockstudios.apps.hammer.common.util.DeviceLocaleResolver
-import com.darkrockstudios.apps.hammer.common.util.StrRes
 import com.darkrockstudios.apps.hammer.server_error_connection_generic
 import com.darkrockstudios.apps.hammer.server_error_tls
 import io.ktor.client.HttpClient
@@ -17,7 +16,6 @@ import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.json.Json
-import org.jetbrains.compose.resources.StringResource
 import org.junit.jupiter.api.BeforeEach
 import org.koin.dsl.module
 import utils.BaseTest
@@ -94,19 +92,5 @@ class ApiTlsFailureTest : BaseTest() {
 
 		assertIs<HttpFailureException>(result.exceptionOrNull())
 		assertTrue(strRes.requested.contains(Res.string.server_error_connection_generic))
-	}
-}
-
-private class RecordingStrRes : StrRes {
-	val requested = mutableListOf<StringResource>()
-
-	override suspend fun get(str: StringResource): String {
-		requested += str
-		return "test"
-	}
-
-	override suspend fun get(str: StringResource, vararg args: Any): String {
-		requested += str
-		return "test"
 	}
 }

--- a/common/src/desktopTest/kotlin/server/RecordingStrRes.kt
+++ b/common/src/desktopTest/kotlin/server/RecordingStrRes.kt
@@ -1,0 +1,19 @@
+package server
+
+import com.darkrockstudios.apps.hammer.common.util.StrRes
+import org.jetbrains.compose.resources.StringResource
+
+/** Records which string resources a failure path asked for. */
+internal class RecordingStrRes : StrRes {
+	val requested = mutableListOf<StringResource>()
+
+	override suspend fun get(str: StringResource): String {
+		requested += str
+		return "test"
+	}
+
+	override suspend fun get(str: StringResource, vararg args: Any): String {
+		requested += str
+		return "test"
+	}
+}

--- a/docs/HOW-TO-RUN-A-SERVER-DOCKER.md
+++ b/docs/HOW-TO-RUN-A-SERVER-DOCKER.md
@@ -89,6 +89,24 @@ entries from your own browser or `curl` hitting `/api/...`, since only Hammer
 clients send the `X-Hammer-Protocol-Version` header. Those are unrelated to the
 client's failure.
 
+### A login that returns 401 after the account was created
+
+Passwords are 8 to 64 characters with no complexity rule and no forbidden characters, and the
+server hashes what it receives without stripping or truncating anything, so a password that was
+accepted at account creation will keep working. See
+[Account passwords](HOW-TO-RUN-A-SERVER.md#account-passwords) for the full policy and for the
+log lines that name why a login was rejected.
+
+Two container-specific causes are worth ruling out first:
+
+- **A stale volume.** If the account was created against a database that has since been
+  recreated (`docker compose down -v`, a changed volume mount), the account is simply gone and
+  every login is a legitimate 401. `Login rejected: no account for the submitted email` in the
+  log confirms it.
+- **Rate limiting seen as a login failure.** The login limiter allows 10 requests per minute
+  keyed on the source address, and behind a reverse proxy that address is the proxy's, shared
+  by everyone. Repeated attempts return `429`, not `401`.
+
 ### Do not set `bindHosts`
 
 [HOW-TO-RUN-A-SERVER.md](HOW-TO-RUN-A-SERVER.md#reverse-proxy-using-nginx) tells

--- a/docs/HOW-TO-RUN-A-SERVER.md
+++ b/docs/HOW-TO-RUN-A-SERVER.md
@@ -59,6 +59,30 @@ The Hammer server is a Java application that runs on Windows, Linux, and macOS.
 7. **IMPORTANT!** You must now download one of the clients and create an account on the server. The first account
    created will be the admin account.
 
+## Account passwords
+
+The server enforces exactly one password rule: **8 to 64 characters**. There is no complexity
+requirement, no character is forbidden, and nothing is silently stripped or truncated — the
+password is hashed with Argon2 exactly as it arrives, so any Unicode you can type (accents,
+symbols, emoji) is fair game. A password outside that length range is rejected at account
+creation with `400 Bad Request` and an explanatory message; it is never accepted and then
+mysteriously unusable at login.
+
+If a login fails, the server log names the reason:
+
+```
+Login rejected: no account for the submitted email
+Login rejected: password mismatch for user 1
+```
+
+The response body carries a machine-readable `errorCode` (`invalid_credentials`,
+`not_whitelisted`, `password_too_long`, …) alongside the translated message. Note that the
+*response* deliberately cannot distinguish a wrong password from an unknown email — that
+would let anyone enumerate your users — so the log above is the place to look.
+
+A login answering `403 Forbidden` with `not_whitelisted` means the credentials were fine and the
+account simply isn't allowed in; see [Whitelisting Users](#whitelisting-users).
+
 ## Network binding
 
 By default the server binds to all IPv4 interfaces (`0.0.0.0`), so it accepts connections from the

--- a/docs/HOW-TO-RUN-A-SERVER.md
+++ b/docs/HOW-TO-RUN-A-SERVER.md
@@ -81,7 +81,7 @@ The response body carries a machine-readable `errorCode` (`invalid_credentials`,
 would let anyone enumerate your users — so the log above is the place to look.
 
 A login answering `403 Forbidden` with `not_whitelisted` means the credentials were fine and the
-account simply isn't allowed in; see [Whitelisting Users](#whitelisting-users).
+account simply isn't allowed in; see [Allowed Users](#allowed-users).
 
 ## Network binding
 

--- a/server/src/main/kotlin/com/darkrockstudios/apps/hammer/account/AccountRoutes.kt
+++ b/server/src/main/kotlin/com/darkrockstudios/apps/hammer/account/AccountRoutes.kt
@@ -1,5 +1,6 @@
 package com.darkrockstudios.apps.hammer.account
 
+import com.darkrockstudios.apps.hammer.base.http.ApiErrorCode
 import com.darkrockstudios.apps.hammer.base.http.HTTP_STATUS_TERMS_OF_SERVICE
 import com.darkrockstudios.apps.hammer.base.http.HttpResponseError
 import com.darkrockstudios.apps.hammer.base.http.INVALID_USER_ID
@@ -58,9 +59,10 @@ private fun Route.createAccount() {
 			is CreateAccountResult.Failure -> {
 				val response = HttpResponseError(
 					error = "Failed to create account",
-					displayMessage = result.failure.displayMessageText(call, R("api_error_unknown"))
+					displayMessage = result.failure.displayMessageText(call, R("api_error_unknown")),
+					errorCode = createErrorCode(result.failure.exception),
 				)
-				call.respond(status = HttpStatusCode.Conflict, response)
+				call.respond(status = createErrorStatus(result.failure.exception), response)
 			}
 		}
 	}
@@ -88,13 +90,35 @@ private fun Route.login() {
 			val authToken = result.data
 			call.respond(authToken)
 		} else {
+			// A rejected whitelist isn't a credential problem, and answering 401 made it
+			// indistinguishable from a wrong password in both the logs and the client.
+			val notWhitelisted = result.exception is NotWhitelisted
 			val response = HttpResponseError(
 				error = "Failed to authenticate",
-				displayMessage = result.displayMessageText(call, R("api_error_unknown"))
+				displayMessage = result.displayMessageText(call, R("api_error_unknown")),
+				errorCode = if (notWhitelisted) ApiErrorCode.NOT_WHITELISTED
+				else ApiErrorCode.INVALID_CREDENTIALS,
 			)
-			call.respond(status = HttpStatusCode.Unauthorized, response)
+			val status = if (notWhitelisted) HttpStatusCode.Forbidden else HttpStatusCode.Unauthorized
+			call.respond(status = status, message = response)
 		}
 	}
+}
+
+private fun createErrorStatus(cause: Throwable?): HttpStatusCode = when (cause) {
+	is AccountAlreadyExists, is AccountPendingDeletion -> HttpStatusCode.Conflict
+	is InvalidEmail, is InvalidPassword -> HttpStatusCode.BadRequest
+	is NotWhitelisted -> HttpStatusCode.Forbidden
+	else -> HttpStatusCode.Conflict
+}
+
+private fun createErrorCode(cause: Throwable?): String? = when (cause) {
+	is AccountAlreadyExists -> ApiErrorCode.ACCOUNT_EXISTS
+	is AccountPendingDeletion -> ApiErrorCode.ACCOUNT_PENDING_DELETION
+	is InvalidEmail -> ApiErrorCode.INVALID_EMAIL
+	is InvalidPassword -> InvalidPassword.getCode(cause.result)
+	is NotWhitelisted -> ApiErrorCode.NOT_WHITELISTED
+	else -> null
 }
 
 private fun Route.refreshToken() {
@@ -117,7 +141,8 @@ private fun Route.refreshToken() {
 				status = HttpStatusCode.Unauthorized,
 				HttpResponseError(
 					error = "Unauthorized",
-					displayMessage = result.displayMessageText(call, R("api_accounts_tokenrefresh_error"))
+					displayMessage = result.displayMessageText(call, R("api_accounts_tokenrefresh_error")),
+					errorCode = ApiErrorCode.TOKEN_INVALID,
 				)
 			)
 		}

--- a/server/src/main/kotlin/com/darkrockstudios/apps/hammer/account/AccountsComponent.kt
+++ b/server/src/main/kotlin/com/darkrockstudios/apps/hammer/account/AccountsComponent.kt
@@ -96,7 +96,8 @@ class AccountsComponent(
 		val message = pluginRegistry.activeAllowedUsersSource()?.rejectionMessage()
 		return SResult.failure(
 			error = "User not on whitelist",
-			displayMessage = message ?: Msg.r("api_allowedusers_rejected")
+			displayMessage = message ?: Msg.r("api_allowedusers_rejected"),
+			exception = NotWhitelisted()
 		)
 	}
 }

--- a/server/src/main/kotlin/com/darkrockstudios/apps/hammer/account/AccountsRepository.kt
+++ b/server/src/main/kotlin/com/darkrockstudios/apps/hammer/account/AccountsRepository.kt
@@ -10,6 +10,7 @@ import com.darkrockstudios.apps.hammer.database.AccountDao
 import com.darkrockstudios.apps.hammer.database.AuthTokenDao
 import com.darkrockstudios.apps.hammer.database.CommunityAuthor
 import com.darkrockstudios.apps.hammer.utilities.*
+import org.slf4j.LoggerFactory
 import kotlin.io.encoding.Base64
 import kotlin.time.Clock
 import kotlin.time.Duration.Companion.days
@@ -100,13 +101,13 @@ class AccountsRepository(
 					SResult.failure(
 						"account pending deletion",
 						Msg.r("api_accounts_login_error_pending_deletion"),
-						CreateFailed("Account pending deletion")
+						AccountPendingDeletion()
 					)
 				} else {
 					SResult.failure(
 						"account already exists",
 						Msg.r("api_accounts_create_error_accountexists"),
-						CreateFailed("Account already exists")
+						AccountAlreadyExists()
 					)
 				}
 			}
@@ -114,7 +115,7 @@ class AccountsRepository(
 			!EmailValidator.validate(email) -> SResult.failure(
 				"invalid email",
 				Msg.r("api_accounts_create_error_invalidemail"),
-				CreateFailed("Invalid email")
+				InvalidEmail()
 			)
 
 			passwordResult != PasswordValidationResult.VALID -> SResult.failure(
@@ -181,16 +182,27 @@ class AccountsRepository(
 				// state to its owner and nothing to password guessers.
 				SResult.failure(
 					"Account pending deletion",
-					Msg.r("api_accounts_login_error_pending_deletion")
+					Msg.r("api_accounts_login_error_pending_deletion"),
+					AccountPendingDeletion()
 				)
 			} else {
 				val token = createToken(account.id, installId)
 				SResult.success(token)
 			}
 		} else {
-			// One message for both unknown-account and wrong-password so the
-			// response body doesn't reveal whether the account exists.
-			SResult.failure("Invalid credentials", Msg.r("api_accounts_login_error_invalid"))
+			// The response can't distinguish these two — that would let anyone
+			// enumerate accounts — but the operator's log can, and without it a
+			// failing login is undiagnosable from the server side.
+			if (account == null) {
+				log.info("Login rejected: no account for the submitted email")
+			} else {
+				log.info("Login rejected: password mismatch for user ${account.id}")
+			}
+			SResult.failure(
+				"Invalid credentials",
+				Msg.r("api_accounts_login_error_invalid"),
+				LoginFailed("Invalid credentials")
+			)
 		}
 	}
 
@@ -323,6 +335,8 @@ class AccountsRepository(
 	}
 
 	companion object {
+		private val log = LoggerFactory.getLogger(AccountsRepository::class.java)
+
 		const val CIPHER_SALT_LENGTH = 16
 
 		// A refresh token stays valid until this long past its access token's expiry.

--- a/server/src/main/kotlin/com/darkrockstudios/apps/hammer/account/AccountsRepositoryExceptions.kt
+++ b/server/src/main/kotlin/com/darkrockstudios/apps/hammer/account/AccountsRepositoryExceptions.kt
@@ -1,12 +1,22 @@
 package com.darkrockstudios.apps.hammer.account
 
+import com.darkrockstudios.apps.hammer.base.http.ApiErrorCode
 import com.darkrockstudios.apps.hammer.base.validate.PasswordValidationResult
 import com.darkrockstudios.apps.hammer.utilities.Msg
 
 open class CreateFailed(message: String) : Exception(message)
+class AccountAlreadyExists : CreateFailed("Account already exists")
+class AccountPendingDeletion : CreateFailed("Account pending deletion")
+class InvalidEmail : CreateFailed("Invalid email")
 class InvalidPassword(val result: PasswordValidationResult) :
 	CreateFailed("Invalid Password") {
 	companion object {
+		fun getCode(result: PasswordValidationResult): String = when (result) {
+			PasswordValidationResult.TOO_SHORT -> ApiErrorCode.PASSWORD_TOO_SHORT
+			PasswordValidationResult.TOO_LONG -> ApiErrorCode.PASSWORD_TOO_LONG
+			else -> ApiErrorCode.PASSWORD_INVALID
+		}
+
 		fun getMessage(result: PasswordValidationResult): Msg = when (result) {
 			PasswordValidationResult.TOO_SHORT -> Msg.r("api_accounts_create_error_password_tooshort")
 			PasswordValidationResult.TOO_LONG -> Msg.r("api_accounts_create_error_password_toolong")
@@ -20,5 +30,8 @@ class InvalidPassword(val result: PasswordValidationResult) :
 }
 
 class LoginFailed(message: String) : Exception(message)
+
+/** Credentials were fine (or irrelevant); the account simply isn't allowed on this server. */
+class NotWhitelisted : Exception("User not on whitelist")
 
 class AccountNotFound(userId: Long) : Exception("User ID ($userId) not found")

--- a/server/src/main/kotlin/com/darkrockstudios/apps/hammer/frontend/Frontend.kt
+++ b/server/src/main/kotlin/com/darkrockstudios/apps/hammer/frontend/Frontend.kt
@@ -269,9 +269,10 @@ fun Application.configureStatusPages(
 			}
 		}
 		status(HttpStatusCode.Unauthorized) { call, status ->
-			if (call.request.isApiCall()) {
-				call.respond(HttpStatusCode.Unauthorized)
-			} else {
+			// API routes answer 401 with their own HttpResponseError body; responding again
+			// here would replace it with an empty one, leaving the client no way to tell a
+			// wrong password from an unknown account or an expired token.
+			if (!call.request.isApiCall()) {
 				call.respond(
 					HttpStatusCode.Unauthorized,
 					MustacheContent("unauthorized.mustache", call.withDefaults(ERROR_PAGE_STYLE))

--- a/server/src/test/kotlin/com/darkrockstudios/apps/hammer/e2e/AccountErrorCodeTest.kt
+++ b/server/src/test/kotlin/com/darkrockstudios/apps/hammer/e2e/AccountErrorCodeTest.kt
@@ -1,0 +1,122 @@
+package com.darkrockstudios.apps.hammer.e2e
+
+import com.darkrockstudios.apps.hammer.base.http.ApiErrorCode
+import com.darkrockstudios.apps.hammer.base.http.HAMMER_PROTOCOL_HEADER
+import com.darkrockstudios.apps.hammer.base.http.HAMMER_PROTOCOL_VERSION
+import com.darkrockstudios.apps.hammer.base.http.HttpResponseError
+import com.darkrockstudios.apps.hammer.base.validate.PasswordValidator
+import com.darkrockstudios.apps.hammer.e2e.util.EndToEndTest
+import com.darkrockstudios.apps.hammer.utils.SERVER_EMPTY_NO_WHITELIST
+import com.darkrockstudios.apps.hammer.utils.createTestServer
+import io.ktor.client.request.*
+import io.ktor.client.request.forms.*
+import io.ktor.client.statement.*
+import io.ktor.http.*
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.json.Json
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+
+/**
+ * Every failure the account routes can answer with, mapped to the status and
+ * [ApiErrorCode] a client branches on. A wrong status here is what made a rejected
+ * signup indistinguishable from a real conflict (#835).
+ */
+class AccountErrorCodeTest : EndToEndTest() {
+
+	@Test
+	fun `Create Account - an existing email is a 409 naming the conflict`(): Unit = runBlocking {
+		startEmptyServer()
+
+		val first = createAccount("taken@example.com", VALID_PASSWORD)
+		assertEquals(HttpStatusCode.Created, first.status)
+
+		val second = createAccount("taken@example.com", VALID_PASSWORD)
+
+		assertEquals(HttpStatusCode.Conflict, second.status)
+		assertEquals(ApiErrorCode.ACCOUNT_EXISTS, second.errorCode())
+	}
+
+	@Test
+	fun `Create Account - an email pending deletion is a 409, not a plain conflict`(): Unit = runBlocking {
+		startEmptyServer()
+
+		assertEquals(HttpStatusCode.Created, createAccount("leaving@example.com", VALID_PASSWORD).status)
+		// Soft delete keeps the row, which reserves the email for the retention window.
+		database().executeAsync("UPDATE account SET deleted_at = NOW() WHERE email = 'leaving@example.com'")
+
+		val response = createAccount("leaving@example.com", VALID_PASSWORD)
+
+		assertEquals(HttpStatusCode.Conflict, response.status)
+		assertEquals(ApiErrorCode.ACCOUNT_PENDING_DELETION, response.errorCode())
+	}
+
+	@Test
+	fun `Create Account - a malformed email is a 400`(): Unit = runBlocking {
+		startEmptyServer()
+
+		val response = createAccount("not-an-email", VALID_PASSWORD)
+
+		assertEquals(HttpStatusCode.BadRequest, response.status)
+		assertEquals(ApiErrorCode.INVALID_EMAIL, response.errorCode())
+	}
+
+	@Test
+	fun `Create Account - a short password is a 400 naming the rule`(): Unit = runBlocking {
+		startEmptyServer()
+
+		val response = createAccount("short@example.com", "x".repeat(PasswordValidator.MIN_LENGTH - 1))
+
+		assertEquals(HttpStatusCode.BadRequest, response.status)
+		assertEquals(ApiErrorCode.PASSWORD_TOO_SHORT, response.errorCode())
+	}
+
+	@Test
+	fun `Refresh Token - an unknown token is a 401 the client can act on`(): Unit = runBlocking {
+		startEmptyServer()
+
+		assertEquals(HttpStatusCode.Created, createAccount("refresh@example.com", VALID_PASSWORD).status)
+
+		val response = client().post(api("account/refresh_token/1")) {
+			headers { append(HAMMER_PROTOCOL_HEADER, HAMMER_PROTOCOL_VERSION.toString()) }
+			setBody(
+				FormDataContent(
+					Parameters.build {
+						append("installId", INSTALL_ID)
+						append("refreshToken", "not-a-real-refresh-token")
+					}
+				)
+			)
+		}
+
+		assertEquals(HttpStatusCode.Unauthorized, response.status)
+		assertEquals(ApiErrorCode.TOKEN_INVALID, response.errorCode())
+	}
+
+	private suspend fun startEmptyServer() {
+		createTestServer(SERVER_EMPTY_NO_WHITELIST, fileSystem, database())
+		doStartServer()
+	}
+
+	private suspend fun createAccount(email: String, password: String): HttpResponse =
+		client().post(api("account/create")) {
+			headers { append(HAMMER_PROTOCOL_HEADER, HAMMER_PROTOCOL_VERSION.toString()) }
+			setBody(
+				FormDataContent(
+					Parameters.build {
+						append("email", email)
+						append("password", password)
+						append("installId", INSTALL_ID)
+					}
+				)
+			)
+		}
+
+	private suspend fun HttpResponse.errorCode(): String? =
+		Json.decodeFromString<HttpResponseError>(bodyAsText()).errorCode
+
+	companion object {
+		private const val VALID_PASSWORD = "password123!@#"
+		private const val INSTALL_ID = "fake-install-id"
+	}
+}

--- a/server/src/test/kotlin/com/darkrockstudios/apps/hammer/e2e/AccountTest.kt
+++ b/server/src/test/kotlin/com/darkrockstudios/apps/hammer/e2e/AccountTest.kt
@@ -1,11 +1,15 @@
 package com.darkrockstudios.apps.hammer.e2e
 
+import com.darkrockstudios.apps.hammer.base.http.ApiErrorCode
 import com.darkrockstudios.apps.hammer.base.http.HAMMER_PROTOCOL_HEADER
 import com.darkrockstudios.apps.hammer.base.http.HAMMER_PROTOCOL_VERSION
+import com.darkrockstudios.apps.hammer.base.http.HttpResponseError
 import com.darkrockstudios.apps.hammer.base.http.Token
 import com.darkrockstudios.apps.hammer.base.http.createTokenBase64
+import com.darkrockstudios.apps.hammer.base.validate.PasswordValidator
 import com.darkrockstudios.apps.hammer.e2e.util.EndToEndTest
 import com.darkrockstudios.apps.hammer.utils.SERVER_CONFIG_ONE
+import com.darkrockstudios.apps.hammer.utils.SERVER_EMPTY_NO_WHITELIST
 import com.darkrockstudios.apps.hammer.utils.SERVER_EMPTY_YES_WHITELIST
 import com.darkrockstudios.apps.hammer.utils.createTestServer
 import io.ktor.client.request.*
@@ -74,7 +78,7 @@ class AccountTest : EndToEndTest() {
 				)
 			}
 
-			assertEquals(HttpStatusCode.Conflict, response.status)
+			assertEquals(HttpStatusCode.Forbidden, response.status)
 			assertNull(
 				database().serverDatabase.accountQueries.findAccount("test2@example.com").executeAsOneOrNull(),
 				"A whitelist-rejected signup must not persist an account",
@@ -136,6 +140,58 @@ class AccountTest : EndToEndTest() {
 	}
 
 	@Test
+	fun `Create Account - password outside the policy is a 400 naming the rule`(): Unit = runBlocking {
+		createTestServer(SERVER_EMPTY_NO_WHITELIST, fileSystem, database())
+		doStartServer()
+		client().apply {
+			val response = post(api("account/create")) {
+				headers {
+					append(HAMMER_PROTOCOL_HEADER, HAMMER_PROTOCOL_VERSION.toString())
+				}
+				setBody(
+					FormDataContent(
+						Parameters.build {
+							append("email", "toolong@example.com")
+							append("password", "x".repeat(PasswordValidator.MAX_LENGTH + 1))
+							append("installId", "fake-install-id")
+						}
+					)
+				)
+			}
+
+			assertEquals(HttpStatusCode.BadRequest, response.status)
+			val error = Json.decodeFromString<HttpResponseError>(response.bodyAsText())
+			assertEquals(ApiErrorCode.PASSWORD_TOO_LONG, error.errorCode)
+		}
+	}
+
+	@Test
+	fun `Login - whitelist rejection is a 403, not a credential failure`(): Unit = runBlocking {
+		createTestServer(SERVER_CONFIG_ONE, fileSystem, database())
+		doStartServer()
+		client().apply {
+			val response = post(api("account/login")) {
+				headers {
+					append(HAMMER_PROTOCOL_HEADER, HAMMER_PROTOCOL_VERSION.toString())
+				}
+				setBody(
+					FormDataContent(
+						Parameters.build {
+							append("email", "notonthelist@example.com")
+							append("password", "password123!@#")
+							append("installId", "fake-install-id")
+						}
+					)
+				)
+			}
+
+			assertEquals(HttpStatusCode.Forbidden, response.status)
+			val error = Json.decodeFromString<HttpResponseError>(response.bodyAsText())
+			assertEquals(ApiErrorCode.NOT_WHITELISTED, error.errorCode)
+		}
+	}
+
+	@Test
 	fun `Login - First User - Bad Password`(): Unit = runBlocking {
 		createTestServer(SERVER_CONFIG_ONE, fileSystem, database())
 		doStartServer()
@@ -156,6 +212,8 @@ class AccountTest : EndToEndTest() {
 			}
 
 			assertEquals(HttpStatusCode.Unauthorized, response.status)
+			val error = Json.decodeFromString<HttpResponseError>(response.bodyAsText())
+			assertEquals(ApiErrorCode.INVALID_CREDENTIALS, error.errorCode)
 		}
 	}
 }

--- a/server/src/test/kotlin/com/darkrockstudios/apps/hammer/e2e/PasswordComplexityLoginTest.kt
+++ b/server/src/test/kotlin/com/darkrockstudios/apps/hammer/e2e/PasswordComplexityLoginTest.kt
@@ -1,0 +1,84 @@
+package com.darkrockstudios.apps.hammer.e2e
+
+import com.darkrockstudios.apps.hammer.base.http.HAMMER_PROTOCOL_HEADER
+import com.darkrockstudios.apps.hammer.base.http.HAMMER_PROTOCOL_VERSION
+import com.darkrockstudios.apps.hammer.e2e.util.EndToEndTest
+import com.darkrockstudios.apps.hammer.utils.SERVER_EMPTY_NO_WHITELIST
+import com.darkrockstudios.apps.hammer.utils.createTestServer
+import io.ktor.client.request.*
+import io.ktor.client.request.forms.*
+import io.ktor.client.statement.*
+import io.ktor.http.*
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+
+/**
+ * Issue #835: an account created with a complex password could not log in afterwards.
+ */
+class PasswordComplexityLoginTest : EndToEndTest() {
+
+	@Test
+	fun `Complex passwords survive the create then login round trip`(): Unit = roundTrip(
+		"asciiSpecials" to "Tr0ub4dor&3xample!",
+		"plusEqualsAmp" to "p@ss+word=123&x",
+		"percentAndAccent" to "100%%Sécur|té2024#",
+		"heavyNonAscii" to "ĄŻ§±¶•ªº¿Œ‰›ﬁ‡°",
+		"surroundingSpaces" to "  spaced out pass  ",
+	)
+
+	@Test
+	fun `Exotic passwords survive the create then login round trip`(): Unit = roundTrip(
+		"quotesAndSlashes" to "pass\"word'with\\slash",
+		"maxLength" to "A1!".repeat(21) + "b",
+		"emoji" to "🔐Secret🔑Pass1!",
+		"newline" to "line1\nline2!A1",
+	)
+
+	// The login rate limiter allows 10 requests per window, so at most five pairs per server.
+	private fun roundTrip(vararg passwords: Pair<String, String>): Unit = runBlocking {
+		createTestServer(SERVER_EMPTY_NO_WHITELIST, fileSystem, database())
+		doStartServer()
+
+		val failures = mutableListOf<String>()
+
+		passwords.forEachIndexed { index, (name, password) ->
+			val email = "user$index@example.com"
+
+			val created = client().post(api("account/create")) {
+				headers { append(HAMMER_PROTOCOL_HEADER, HAMMER_PROTOCOL_VERSION.toString()) }
+				setBody(
+					FormDataContent(
+						Parameters.build {
+							append("email", email)
+							append("password", password)
+							append("installId", "fake-install-id")
+						}
+					)
+				)
+			}
+			if (created.status != HttpStatusCode.Created) {
+				failures += "$name: create -> ${created.status} ${created.bodyAsText()}"
+				return@forEachIndexed
+			}
+
+			val loggedIn = client().post(api("account/login")) {
+				headers { append(HAMMER_PROTOCOL_HEADER, HAMMER_PROTOCOL_VERSION.toString()) }
+				setBody(
+					FormDataContent(
+						Parameters.build {
+							append("email", email)
+							append("password", password)
+							append("installId", "fake-install-id")
+						}
+					)
+				)
+			}
+			if (loggedIn.status != HttpStatusCode.OK) {
+				failures += "$name (len=${password.length}): login -> ${loggedIn.status} ${loggedIn.bodyAsText()}"
+			}
+		}
+
+		assertEquals(emptyList(), failures.toList(), "Round trip failures")
+	}
+}

--- a/server/src/test/kotlin/com/darkrockstudios/apps/hammer/e2e/PasswordComplexityLoginTest.kt
+++ b/server/src/test/kotlin/com/darkrockstudios/apps/hammer/e2e/PasswordComplexityLoginTest.kt
@@ -38,6 +38,15 @@ class PasswordComplexityLoginTest : EndToEndTest() {
 	// The login rate limiter allows 10 requests per window, so at most five pairs per server.
 	private fun roundTrip(vararg passwords: Pair<String, String>): Unit = runBlocking {
 		createTestServer(SERVER_EMPTY_NO_WHITELIST, fileSystem, database())
+
+		// Allowed Users is always enforced, and only the first account (the bootstrap
+		// admin) is exempt, so every other address has to be on the list to get in.
+		passwords.indices.forEach { index ->
+			database().executeAsync(
+				"INSERT INTO white_list(email, date_added) VALUES ('user$index@example.com', NOW())"
+			)
+		}
+
 		doStartServer()
 
 		val failures = mutableListOf<String>()


### PR DESCRIPTION
A failed login gave nobody anything to work with. StatusPages matched status 401
and re-responded with a bare status for API calls, discarding the
`HttpResponseError` the route had just written, and the client's own 401 branch
discarded whatever body did survive in favour of a generic string. Two layers
erasing the same message, so a self-hoster saw "401 Unauthorized" in the log, an
empty body on the wire, and a generic message in the app. That is the diagnostic
dead end behind #835.

## Changes

- **StatusPages** leaves API responses alone, since the routes answer 401 with
  their own body. The client parses the body for every status and only falls back
  to a generic message when the server sent nothing usable.
- **`HttpResponseError` carries an optional `errorCode`** from a shared
  `ApiErrorCode` vocabulary: plain strings rather than an enum, so an unknown code
  from a newer server deserializes instead of throwing.
- **Account creation uses accurate statuses** rather than a blanket 409: 400 for a
  policy or email violation, 409 for a real conflict, 403 for the allowed-users
  list. Login answers 403 when the allowed-users list was the problem, since that
  is not a credential failure.
- **The login path logs which failure occurred.** The response still cannot
  distinguish an unknown account from a wrong password, because that would let
  anyone enumerate users, but the operator's log now can.
- The self-hosting docs gain the password policy (8-64 characters, no complexity
  rule, nothing stripped or truncated) and the log lines to look for, which is
  what the reporter of #835 asked for.

## Tests

`PasswordComplexityLoginTest` drives create-then-login round trips over specials,
non-ASCII, emoji, max length, embedded quotes, newlines and surrounding spaces.
`AccountTest` covers the new statuses and codes. Full `:server:test` (1201 tests)
and `desktopTest` are green locally.

## Notes for review

- The commit predates the current `develop`, so two conflicts were resolved on the
  way in: `whiteListRejectedFailure()` keeps develop's `pluginRegistry`
  rejection-message form and only gains the `NotWhitelisted()` exception, and
  `AccountsRepository` no longer re-adds the `Argon2Factory` import that the
  pure-JVM hasher swap removed.
- The round-trip test needed a follow-up commit: Allowed Users is now always
  enforced and only the first account is exempt, so the test seeds the list for
  the addresses it creates.
- Forward compatibility of the new `errorCode` field on older clients rests on the
  tolerant network serializer in #934. Worth landing that one first.
