### PR TITLE
Fix the Microsoft Store build, and stamp builds with their distribution channel

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -72,7 +72,7 @@ jobs:
           timeout_minutes: 30
           max_attempts: 3
           shell: pwsh
-          command: ./gradlew :desktop:packageReleaseMsi
+          command: ./gradlew :desktop:packageReleaseMsi -Pchannel=github
 
       - name: Rename MSI Artifact
         shell: cmd
@@ -104,7 +104,7 @@ jobs:
           timeout_minutes: 30
           max_attempts: 3
           shell: pwsh
-          command: ./gradlew :desktop:packageReleaseExe
+          command: ./gradlew :desktop:packageReleaseExe -Pchannel=github
 
       - name: Rename EXE Artifact
         shell: cmd
@@ -192,7 +192,7 @@ jobs:
         with:
           timeout_minutes: 30
           max_attempts: 3
-          command: ./gradlew :desktop:packageReleaseDeb
+          command: ./gradlew :desktop:packageReleaseDeb -Pchannel=github
 
       - name: Rename DEB Artifact
         run: |
@@ -216,7 +216,7 @@ jobs:
         with:
           timeout_minutes: 30
           max_attempts: 3
-          command: ./gradlew :desktop:packageReleaseRpm
+          command: ./gradlew :desktop:packageReleaseRpm -Pchannel=github
 
       - name: Rename RPM Artifact
         run: |
@@ -240,7 +240,7 @@ jobs:
         with:
           timeout_minutes: 30
           max_attempts: 3
-          command: ./gradlew buildDistAppImage
+          command: ./gradlew buildDistAppImage -Pchannel=appimage
 
       - name: Create Release
         uses: ncipollo/release-action@339a81892b84b4eeb0f6e744e4574d79d0d9b8dd # v1.21.0
@@ -283,7 +283,7 @@ jobs:
         with:
           timeout_minutes: 30
           max_attempts: 3
-          command: ./gradlew :desktop:packageReleaseDmg
+          command: ./gradlew :desktop:packageReleaseDmg -Pchannel=github
 
       - name: Rename DMG Artifact
         run: |
@@ -307,7 +307,7 @@ jobs:
         with:
           timeout_minutes: 30
           max_attempts: 3
-          command: ./gradlew :desktop:packageReleasePkg
+          command: ./gradlew :desktop:packageReleasePkg -Pchannel=github
 
       - name: Rename PKG Artifact
         run: |
@@ -564,7 +564,7 @@ jobs:
         with:
           timeout_minutes: 30
           max_attempts: 3
-          command: ./gradlew buildDistFlatpak
+          command: ./gradlew buildDistFlatpak -Pchannel=flathub
 
       - name: Create Release
         uses: ncipollo/release-action@339a81892b84b4eeb0f6e744e4574d79d0d9b8dd # v1.21.0

--- a/.github/workflows/publish-microsoft-store.yml
+++ b/.github/workflows/publish-microsoft-store.yml
@@ -27,7 +27,7 @@ jobs:
           cache: gradle
 
       - name: Build MSIX package
-        run: ./gradlew :desktop:packageMsix
+        run: ./gradlew :desktop:packageMsix -Pchannel=ms-store
 
       - name: Upload Gradle problems report on failure
         if: failure()

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -146,7 +146,44 @@ flowchart TD
 
 ## Build Variants
 
+### The distribution channel
+
+Every build is stamped with the distribution vehicle it was produced for, via
+`-Pchannel=<token>`:
+
+```
+./gradlew :desktop:packageMsix -Pchannel=ms-store
+```
+
+Omitting it produces a `dev` build. An unknown token fails the build rather than
+silently falling back, so a typo in a release workflow cannot ship a store binary as
+`dev`. Each release pipeline passes its own channel; `prepare-release.yml` uses `github`
+for the installers it attaches to the GitHub release.
+
+The token list lives in two places that must stay in step, pinned by a test on each side:
+
+| Location | Role |
+| --- | --- |
+| `buildSrc/src/main/java/distributionChannel.kt` | Build-side enum and the `-Pchannel` resolver. |
+| `base/src/commonMain/.../DistributionChannel.kt` | Runtime enum. `DistributionChannel.current` reads the baked-in `BuildMetadata.CHANNEL`. |
+
+Branch on `DistributionChannel.current` for behaviour that varies per vehicle: self-update
+(forbidden in the app stores, expected for the GitHub and AppImage builds), where "get the
+app" links point, external-payment policy, and sandbox-aware path resolution. It is a flat
+enum on purpose: every channel-conditional branch is a greppable `when` on the type.
+Capability flags (`canSelfUpdate`, `isSandboxed`, …) can be introduced later, from real
+duplication rather than a guess at the axes.
+
+Note that every branch compiles into every build, so a store-forbidden code path is
+physically present in a store binary even when unreachable. If a store ever objects to
+presence rather than behaviour, promote that one case to a real source set rather than
+restructuring everything.
+
 ### The F-Droid build flag
+
+Predates the channel constant and is still the switch for the two things that must happen
+before any Kotlin runs (see the table below). A build with the F-Droid flag set and no
+`-Pchannel` reports the `fdroid` channel.
 
 F-Droid builds are produced by the same modules as the Google Play build, but with a
 single build flag toggled. There are no Gradle product flavors; instead the flag is read
@@ -184,9 +221,10 @@ Access), which Google Play does not allow, so the feature is gated to F-Droid bu
 - `HammerApplication` forces internal storage on non-F-Droid builds, so a leftover
   preference can never point a Google Play build at a directory it has no permission for.
 
-When adding new runtime behaviour that should differ between channels, branch on
-`com.darkrockstudios.apps.hammer.common.BuildConfig.FDROID` rather than re-reading the
-Gradle property.
+For behaviour that is specifically about F-Droid's manifest and storage permissions,
+branch on `com.darkrockstudios.apps.hammer.common.BuildConfig.FDROID` rather than
+re-reading the Gradle property. For anything else that varies per vehicle, use
+`DistributionChannel.current`.
 
 ## Client Development
 

--- a/android/src/main/kotlin/com/darkrockstudios/apps/hammer/android/HammerApplication.kt
+++ b/android/src/main/kotlin/com/darkrockstudios/apps/hammer/android/HammerApplication.kt
@@ -16,7 +16,6 @@ import com.darkrockstudios.apps.hammer.android.shortcuts.shortcutsModule
 import com.darkrockstudios.apps.hammer.android.widgets.AddNoteWidgetReceiver
 import com.darkrockstudios.apps.hammer.android.widgets.StoriesListWidgetReceiver
 import com.darkrockstudios.apps.hammer.android.widgets.StoryInfoWidgetReceiver
-import com.darkrockstudios.apps.hammer.base.BuildMetadata
 import com.darkrockstudios.apps.hammer.common.BuildConfig
 import com.darkrockstudios.apps.hammer.common.data.migrator.DataMigrator
 import com.darkrockstudios.apps.hammer.common.dependencyinjection.NapierLogger
@@ -25,7 +24,7 @@ import com.darkrockstudios.apps.hammer.common.dependencyinjection.imageLoadingMo
 import com.darkrockstudios.apps.hammer.common.dependencyinjection.mainModule
 import com.darkrockstudios.apps.hammer.common.getConfigDirectory
 import com.darkrockstudios.apps.hammer.common.logStartupBanner
-import com.darkrockstudios.apps.hammer.common.platformStartupInfo
+import com.darkrockstudios.apps.hammer.common.startupBanner
 import com.darkrockstudios.apps.hammer.common.setExternalDirectories
 import com.darkrockstudios.apps.hammer.common.setInternalDirectories
 import com.darkrockstudios.apps.hammer.common.util.AndroidSettingsKeys
@@ -151,7 +150,7 @@ class HammerApplication : Application(), SingletonImageLoader.Factory {
 		dir.mkdirs()
 		File(dir, "crash-${System.currentTimeMillis()}.txt").writeText(
 			buildString {
-				append("Hammer v${BuildMetadata.APP_VERSION} | ${platformStartupInfo()}\n")
+				append(startupBanner() + "\n")
 				append("Uncaught exception on thread '${thread.name}'\n\n")
 				append(throwable.stackTraceToString())
 			}

--- a/base/build.gradle.kts
+++ b/base/build.gradle.kts
@@ -1,3 +1,4 @@
+import com.darkrockstudios.build.resolveDistributionChannel
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
@@ -76,6 +77,13 @@ buildConfig {
 
 	buildConfigField("String", "APP_VERSION", "\"${libs.versions.app.get()}\"")
 	buildConfigField("String", "DATA_VERSION", "\"${libs.versions.data.version.get()}\"")
+
+	// Mirrors the F-Droid detection in settings.gradle.kts so a plain F-Droid build reports its
+	// channel without every call site having to pass -Pchannel too.
+	val isFDroid = project.findProperty("fdroid")?.toString()?.isNotEmpty() == true ||
+		System.getenv("FDROID_BUILD") != null
+	val channel = resolveDistributionChannel(project.findProperty("channel")?.toString(), isFDroid)
+	buildConfigField("String", "CHANNEL", "\"${channel.token}\"")
 }
 
 val GIT_TASK_NAME = "install-git-hooks"

--- a/base/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/base/DistributionChannel.kt
+++ b/base/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/base/DistributionChannel.kt
@@ -1,0 +1,41 @@
+package com.darkrockstudios.apps.hammer.base
+
+/**
+ * The distribution vehicle this build was produced for, baked in at build time from
+ * `-Pchannel=<token>`. Branch on [current] for the rules that vary per vehicle: self-update
+ * (forbidden in the app stores, expected for the GitHub and AppImage builds), where "get the app"
+ * links point, external-payment policy, and sandbox-aware path resolution.
+ *
+ * Deliberately a flat enum rather than a set of capability flags. Every branch is a greppable
+ * `when` on this type, so each channel-conditional behaviour is findable in one search; flags can
+ * be added later if two channels start sharing a trait and branches begin to duplicate.
+ *
+ * Because every branch compiles into every build, a store-forbidden code path is physically
+ * present in a store binary even when unreachable. If a store ever objects to presence rather
+ * than behaviour, that is the trigger to promote that one case to a real source set.
+ *
+ * Kept in step with the build-side enum in `buildSrc/src/main/java/distributionChannel.kt`.
+ */
+enum class DistributionChannel(val token: String, val displayName: String) {
+	DEV("dev", "Development"),
+	GITHUB("github", "GitHub"),
+	PLAY("google-play", "Google Play"),
+	FDROID("fdroid", "F-Droid"),
+	SNAP("snap", "Snap"),
+	APPIMAGE("appimage", "AppImage"),
+	FLATHUB("flathub", "Flathub"),
+	MICROSOFT_STORE("ms-store", "Microsoft Store"),
+	MAC_APP_STORE("mac-app-store", "Mac App Store"),
+	IOS_APP_STORE("ios-app-store", "iOS App Store"),
+	;
+
+	companion object {
+		/**
+		 * An unrecognised token falls back to [DEV] rather than throwing: the build validates the
+		 * token, so reaching here with an unknown one means something is already wrong and taking
+		 * down the app over a log-header string would be worse.
+		 */
+		val current: DistributionChannel =
+			entries.firstOrNull { it.token == BuildMetadata.CHANNEL } ?: DEV
+	}
+}

--- a/base/src/commonTest/kotlin/com/darkrockstudios/apps/hammer/base/DistributionChannelTest.kt
+++ b/base/src/commonTest/kotlin/com/darkrockstudios/apps/hammer/base/DistributionChannelTest.kt
@@ -1,0 +1,35 @@
+package com.darkrockstudios.apps.hammer.base
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class DistributionChannelTest {
+
+	/**
+	 * Pins the tokens against the build-side enum in
+	 * `buildSrc/src/main/java/distributionChannel.kt`. A channel added or renamed on one side and
+	 * not the other would otherwise ship a build whose reported channel silently falls back to
+	 * [DistributionChannel.DEV].
+	 */
+	@Test
+	fun `tokens match the build side enum`() {
+		val expected = listOf(
+			"dev",
+			"github",
+			"google-play",
+			"fdroid",
+			"snap",
+			"appimage",
+			"flathub",
+			"ms-store",
+			"mac-app-store",
+			"ios-app-store",
+		)
+		assertEquals(expected, DistributionChannel.entries.map { it.token })
+	}
+
+	@Test
+	fun `current resolves the baked in token`() {
+		assertEquals(BuildMetadata.CHANNEL, DistributionChannel.current.token)
+	}
+}

--- a/buildSrc/src/main/java/distributionChannel.kt
+++ b/buildSrc/src/main/java/distributionChannel.kt
@@ -1,0 +1,45 @@
+package com.darkrockstudios.build
+
+/**
+ * Build-side mirror of the runtime `DistributionChannel` enum in `:base`. The two lists have to
+ * stay in step; `DistributionChannelTest` in `:base` pins the token strings so a change to one
+ * without the other fails a test rather than shipping a build that reports the wrong channel.
+ *
+ * Tokens match [Platform.tagToken] wherever the two overlap.
+ */
+enum class DistributionChannel(val token: String) {
+	DEV("dev"),
+	GITHUB("github"),
+	PLAY("google-play"),
+	FDROID("fdroid"),
+	SNAP("snap"),
+	APPIMAGE("appimage"),
+	FLATHUB("flathub"),
+	MICROSOFT_STORE("ms-store"),
+	MAC_APP_STORE("mac-app-store"),
+	IOS_APP_STORE("ios-app-store"),
+	;
+
+	companion object {
+		fun fromToken(token: String): DistributionChannel? = entries.firstOrNull { it.token == token }
+	}
+}
+
+/**
+ * Resolves the channel for this build from `-Pchannel=<token>`, defaulting to [FDROID] when the
+ * F-Droid build flags are set and [DEV] otherwise. Throws on an unknown token, so a typo in a
+ * release workflow fails the build instead of quietly shipping a store binary as [DEV].
+ */
+fun resolveDistributionChannel(
+	channelProperty: String?,
+	isFDroid: Boolean,
+): DistributionChannel {
+	val requested = channelProperty?.trim()?.takeIf { it.isNotEmpty() }
+		?: return if (isFDroid) DistributionChannel.FDROID else DistributionChannel.DEV
+
+	return DistributionChannel.fromToken(requested)
+		?: error(
+			"Unknown -Pchannel=$requested. Valid channels: " +
+				DistributionChannel.entries.joinToString(", ") { it.token }
+		)
+}

--- a/buildSrc/src/test/java/DistributionChannelTest.kt
+++ b/buildSrc/src/test/java/DistributionChannelTest.kt
@@ -1,0 +1,50 @@
+import com.darkrockstudios.build.DistributionChannel
+import com.darkrockstudios.build.resolveDistributionChannel
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+class DistributionChannelTest {
+
+	@Test
+	fun `no channel property is a dev build`() {
+		assertEquals(DistributionChannel.DEV, resolveDistributionChannel(null, isFDroid = false))
+		assertEquals(DistributionChannel.DEV, resolveDistributionChannel("", isFDroid = false))
+		assertEquals(DistributionChannel.DEV, resolveDistributionChannel("  ", isFDroid = false))
+	}
+
+	@Test
+	fun `the fdroid build flag stands in for the channel property`() {
+		assertEquals(DistributionChannel.FDROID, resolveDistributionChannel(null, isFDroid = true))
+	}
+
+	@Test
+	fun `an explicit channel wins over the fdroid flag`() {
+		assertEquals(
+			DistributionChannel.GITHUB,
+			resolveDistributionChannel("github", isFDroid = true)
+		)
+	}
+
+	@Test
+	fun `every token resolves to its own channel`() {
+		for (channel in DistributionChannel.entries) {
+			assertEquals(channel, resolveDistributionChannel(channel.token, isFDroid = false))
+		}
+	}
+
+	/** A typo in a release workflow must fail the build, not ship a store binary as DEV. */
+	@Test
+	fun `an unknown token fails the build`() {
+		val error = assertFailsWith<IllegalStateException> {
+			resolveDistributionChannel("microsoftStore", isFDroid = false)
+		}
+		assertEquals(true, error.message?.contains("ms-store"))
+	}
+
+	@Test
+	fun `tokens are unique`() {
+		val tokens = DistributionChannel.entries.map { it.token }
+		assertEquals(tokens.size, tokens.toSet().size)
+	}
+}

--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -155,7 +155,7 @@ kotlin {
 				api(libs.serialization.jvm)
 				api(libs.coroutines.swing)
 				implementation(libs.appdirs)
-				implementation(libs.ktor.client.java)
+				implementation(libs.ktor.client.okhttp)
 				implementation(libs.turbine)
 			}
 		}

--- a/common/src/commonMain/composeResources/values/strings_about_app.xml
+++ b/common/src/commonMain/composeResources/values/strings_about_app.xml
@@ -27,4 +27,6 @@
 	<string name="about_logs_export_button">Export Logs</string>
 	<string name="about_logs_no_logs">No log files found</string>
 	<string name="about_logs_open_tooltip">Open log directory</string>
+	<string name="about_logs_export_success">Logs exported.</string>
+	<string name="about_logs_export_failed">Could not export the logs. See the log directory.</string>
 </resources>

--- a/common/src/commonMain/composeResources/values/strings_account_settings.xml
+++ b/common/src/commonMain/composeResources/values/strings_account_settings.xml
@@ -153,5 +153,6 @@
 		name="server_error_connection_generic">Network error connecting to %1$s. Check your connection and try again.
 	</string>
 	<string name="server_error_tls">Could not make a secure connection to %1$s. Hammer only connects over HTTPS, so the server needs a valid TLS certificate of its own or a reverse proxy that provides one.</string>
+	<string name="server_error_network_unavailable">Hammer could not open a network connection on this device, so the request never reached the server. Security software, a VPN, or a firewall may be blocking it.</string>
 
 </resources>

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/StartupBanner.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/StartupBanner.kt
@@ -1,16 +1,23 @@
 package com.darkrockstudios.apps.hammer.common
 
 import com.darkrockstudios.apps.hammer.base.BuildMetadata
+import com.darkrockstudios.apps.hammer.base.DistributionChannel
 import io.github.aakira.napier.Napier
 
 /**
  * Logs a single identifying line as early as possible in startup: the build version plus
  * platform/environment details. First line in every log, so user-submitted logs are
- * self-describing (version, OS, display server, …) without a round-trip to ask.
+ * self-describing (version, channel, OS, display server, …) without a round-trip to ask.
  */
 fun logStartupBanner() {
-	Napier.i("Hammer v${BuildMetadata.APP_VERSION} | ${platformStartupInfo()}")
+	Napier.i(startupBanner())
 }
+
+/** The identifying line itself, shared by the startup banner and the crash dumps. */
+fun startupBanner(): String =
+	"Hammer v${BuildMetadata.APP_VERSION}" +
+		" | channel: ${DistributionChannel.current.token}" +
+		" | ${platformStartupInfo()}"
 
 /** Platform + environment details for the startup banner. */
 expect fun platformStartupInfo(): String

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/server/Api.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/server/Api.kt
@@ -15,6 +15,7 @@ import com.darkrockstudios.apps.hammer.network_request_failure_parse_body
 import com.darkrockstudios.apps.hammer.server_error_connection_generic
 import com.darkrockstudios.apps.hammer.server_error_connection_timeout
 import com.darkrockstudios.apps.hammer.server_error_dns
+import com.darkrockstudios.apps.hammer.server_error_network_unavailable
 import com.darkrockstudios.apps.hammer.server_error_timeout
 import com.darkrockstudios.apps.hammer.server_error_tls
 import com.darkrockstudios.apps.hammer.sync_general_error
@@ -152,30 +153,59 @@ abstract class Api(
 				)
 			)
 		} catch (e: IOException) {
-			if (e.isTlsFailure()) {
-				Napier.e("TLS Error", e)
-				Result.failure(
-					HttpFailureException(
-						statusCode = outerResponse?.status ?: HttpStatusCode.BadGateway,
-						error = HttpResponseError(
-							error = e.message ?: "TLS Error",
-							displayMessage = strRes.get(Res.string.server_error_tls, server.url),
-						)
+			ioFailure(e, server.url, path, outerResponse)
+		} catch (e: RuntimeException) {
+			// Only an unchecked IO wrapper lands here, which means the platform could not build its
+			// HTTP client at all, so the request never left the device.
+			ioFailure(e.asIoFailure() ?: throw e, server.url, path, outerResponse, local = true)
+		}
+	}
+
+	private suspend fun <T> ioFailure(
+		e: IOException,
+		serverUrl: String,
+		path: String,
+		outerResponse: HttpResponse?,
+		local: Boolean = false,
+	): Result<T> = when {
+		e.isTlsFailure() -> {
+			Napier.e("TLS Error", e)
+			Result.failure(
+				HttpFailureException(
+					statusCode = outerResponse?.status ?: HttpStatusCode.BadGateway,
+					error = HttpResponseError(
+						error = e.message ?: "TLS Error",
+						displayMessage = strRes.get(Res.string.server_error_tls, serverUrl),
 					)
 				)
-			} else {
-				// Generic network error (connection refused, etc.)
-				Napier.e("Network Error", e)
-				Result.failure(
-					HttpFailureException(
-						statusCode = outerResponse?.status ?: HttpStatusCode.RequestTimeout,
-						error = HttpResponseError(
-							error = e.message ?: "Network Error",
-							displayMessage = strRes.get(Res.string.server_error_connection_generic, path),
-						)
+			)
+		}
+
+		local -> {
+			Napier.e("Network Unavailable", e)
+			Result.failure(
+				HttpFailureException(
+					statusCode = outerResponse?.status ?: HttpStatusCode.ServiceUnavailable,
+					error = HttpResponseError(
+						error = e.message ?: "Network Unavailable",
+						displayMessage = strRes.get(Res.string.server_error_network_unavailable),
 					)
 				)
-			}
+			)
+		}
+
+		else -> {
+			// Generic network error (connection refused, etc.)
+			Napier.e("Network Error", e)
+			Result.failure(
+				HttpFailureException(
+					statusCode = outerResponse?.status ?: HttpStatusCode.RequestTimeout,
+					error = HttpResponseError(
+						error = e.message ?: "Network Error",
+						displayMessage = strRes.get(Res.string.server_error_connection_generic, path),
+					)
+				)
+			)
 		}
 	}
 

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/server/IoFailure.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/server/IoFailure.kt
@@ -1,0 +1,9 @@
+package com.darkrockstudios.apps.hammer.common.server
+
+import okio.IOException
+
+/**
+ * The [IOException] this throwable is, or the one a platform hides behind an unchecked wrapper,
+ * or null when it is not an IO failure.
+ */
+expect fun Throwable.asIoFailure(): IOException?

--- a/common/src/desktopMain/kotlin/com/darkrockstudios/apps/hammer/common/MsixPaths.kt
+++ b/common/src/desktopMain/kotlin/com/darkrockstudios/apps/hammer/common/MsixPaths.kt
@@ -1,0 +1,45 @@
+package com.darkrockstudios.apps.hammer.common
+
+import com.darkrockstudios.apps.hammer.base.DistributionChannel
+
+/**
+ * Package family name of the Microsoft Store build: `Identity/@Name` from `msix/AppxManifest.xml`
+ * plus the hash Windows derives from the publisher ID. The hash is not in the manifest and cannot
+ * be computed from it, so it is hardcoded; it only changes if the Store identity does.
+ */
+private const val PACKAGE_FAMILY_NAME = "DarkRockStudios.HammerEditor_eee5gzg80tyea"
+
+private const val PACKAGES = "Packages"
+private const val LOCAL_CACHE = "LocalCache\\Local"
+
+/**
+ * Rewrites a path so the Windows shell can find it.
+ *
+ * MSIX filesystem redirection is asymmetric: the app's writes under `%LOCALAPPDATA%` land inside
+ * the package container, but reads fall through, so `File.exists()` is true from inside the
+ * container and the app is satisfied. Explorer runs outside the container and correctly reports
+ * nothing at the literal path, which is what the "location is not available" dialog on the
+ * open-logs button was.
+ *
+ * A no-op on every other channel and platform, and on a path that is already un-redirected.
+ */
+fun shellPath(path: String): String =
+	if (DistributionChannel.current == DistributionChannel.MICROSOFT_STORE && hostOs == HostOs.Windows) {
+		unredirectMsixPath(path, System.getenv("LOCALAPPDATA"))
+	} else {
+		path
+	}
+
+/** The rewrite itself, with `%LOCALAPPDATA%` passed in so it can be tested off Windows. */
+internal fun unredirectMsixPath(path: String, localAppData: String?): String {
+	if (localAppData.isNullOrBlank()) return path
+
+	val base = localAppData.trimEnd('\\')
+	val prefix = "$base\\"
+	if (!path.startsWith(prefix, ignoreCase = true)) return path
+
+	val relative = path.substring(prefix.length)
+	if (relative.startsWith("$PACKAGES\\", ignoreCase = true)) return path
+
+	return "$base\\$PACKAGES\\$PACKAGE_FAMILY_NAME\\$LOCAL_CACHE\\$relative"
+}

--- a/common/src/desktopMain/kotlin/com/darkrockstudios/apps/hammer/common/dependencyinjection/getHttpPlatformEngine.kt
+++ b/common/src/desktopMain/kotlin/com/darkrockstudios/apps/hammer/common/dependencyinjection/getHttpPlatformEngine.kt
@@ -3,8 +3,9 @@ package com.darkrockstudios.apps.hammer.common.dependencyinjection
 import com.darkrockstudios.apps.hammer.common.getInDevelopmentMode
 import io.ktor.client.*
 import io.ktor.client.engine.*
-import io.ktor.client.engine.java.*
+import io.ktor.client.engine.okhttp.*
 import io.ktor.client.plugins.compression.*
+import okhttp3.OkHttpClient
 import java.net.InetAddress
 import java.net.Socket
 import java.security.KeyStore
@@ -15,8 +16,14 @@ import javax.net.ssl.SSLEngine
 import javax.net.ssl.TrustManagerFactory
 import javax.net.ssl.X509ExtendedTrustManager
 
+/**
+ * OkHttp, not the `java` engine: `java.net.http.HttpClient`'s constructor opens an NIO
+ * [java.nio.channels.Selector], whose Windows wakeup pipe is an AF_UNIX socket that the MSIX
+ * sandbox rejects with EINVAL, so every Store build hard-crashes on the first network call
+ * (JDK-8312215). OkHttp uses blocking socket IO and survives the sandbox.
+ */
 actual fun getHttpPlatformEngine(): HttpClientEngineFactory<*> =
-	if (getInDevelopmentMode()) DevLoopbackTrustJava else Java
+	if (getInDevelopmentMode()) DevLoopbackTrustOkHttp else OkHttp
 
 actual fun <T : HttpClientEngineConfig> HttpClientConfig<T>.installCompression() {
 	install(ContentEncoding) {
@@ -30,21 +37,28 @@ actual fun <T : HttpClientEngineConfig> HttpClientConfig<T>.installCompression()
  * client can reach a `--dev` server's auto-generated cert on localhost. Connections to any
  * non-loopback host still go through the platform's full certificate and hostname validation, so a
  * `--dev` build pointed at a real remote server is not exposed to a man-in-the-middle. Selected only
- * when [getInDevelopmentMode] is true; release builds always use plain [Java].
+ * when [getInDevelopmentMode] is true; release builds always use plain [OkHttp].
  */
-private object DevLoopbackTrustJava : HttpClientEngineFactory<JavaHttpConfig> {
-	override fun create(block: JavaHttpConfig.() -> Unit): HttpClientEngine =
-		Java.create {
+private object DevLoopbackTrustOkHttp : HttpClientEngineFactory<OkHttpConfig> {
+	override fun create(block: OkHttpConfig.() -> Unit): HttpClientEngine =
+		OkHttp.create {
 			block()
+			val trustManager = loopbackTrustManager()
+			val defaultVerifier = OkHttpClient.Builder().build().hostnameVerifier
 			config {
-				sslContext(loopbackTrustingSslContext())
+				sslSocketFactory(loopbackTrustingSslContext(trustManager).socketFactory, trustManager)
+				// OkHttp verifies the hostname itself rather than through the trust manager's
+				// endpoint identification, so loopback has to be waived here too.
+				hostnameVerifier { hostname, session ->
+					isLoopbackHost(hostname) || defaultVerifier.verify(hostname, session)
+				}
 			}
 		}
 }
 
-private fun loopbackTrustingSslContext(): SSLContext {
+private fun loopbackTrustManager(): X509ExtendedTrustManager {
 	val default = platformTrustManager()
-	val trustManager = object : X509ExtendedTrustManager() {
+	return object : X509ExtendedTrustManager() {
 		override fun checkServerTrusted(chain: Array<out X509Certificate>?, authType: String?, socket: Socket?) {
 			if (socket?.inetAddress?.isLoopbackAddress == true) return
 			default.checkServerTrusted(chain, authType, socket)
@@ -71,10 +85,12 @@ private fun loopbackTrustingSslContext(): SSLContext {
 
 		override fun getAcceptedIssuers(): Array<X509Certificate> = default.acceptedIssuers
 	}
-	return SSLContext.getInstance("TLSv1.3").apply {
+}
+
+private fun loopbackTrustingSslContext(trustManager: X509ExtendedTrustManager): SSLContext =
+	SSLContext.getInstance("TLSv1.3").apply {
 		init(null, arrayOf(trustManager), SecureRandom())
 	}
-}
 
 private fun isLoopbackHost(host: String?): Boolean {
 	if (host.isNullOrBlank()) return false

--- a/common/src/desktopTest/kotlin/server/ApiTlsFailureTest.kt
+++ b/common/src/desktopTest/kotlin/server/ApiTlsFailureTest.kt
@@ -8,6 +8,7 @@ import com.darkrockstudios.apps.hammer.common.server.ServerAccountApi
 import com.darkrockstudios.apps.hammer.common.util.DeviceLocaleResolver
 import com.darkrockstudios.apps.hammer.common.util.StrRes
 import com.darkrockstudios.apps.hammer.server_error_connection_generic
+import com.darkrockstudios.apps.hammer.server_error_network_unavailable
 import com.darkrockstudios.apps.hammer.server_error_tls
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.mock.MockEngine
@@ -21,15 +22,19 @@ import org.jetbrains.compose.resources.StringResource
 import org.junit.jupiter.api.BeforeEach
 import org.koin.dsl.module
 import utils.BaseTest
+import java.io.UncheckedIOException
 import java.net.ConnectException
 import javax.net.ssl.SSLHandshakeException
 import kotlin.test.Test
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
 import kotlin.test.assertIs
 import kotlin.test.assertTrue
 
 /**
  * A server reachable only over plain HTTP fails the client's TLS handshake, which needs to read as
- * "this server isn't serving HTTPS" rather than as a generic connectivity problem.
+ * "this server isn't serving HTTPS" rather than as a generic connectivity problem. Covers the rest
+ * of the network failure mapping too, including the unchecked wrappers the JDK throws.
  */
 class ApiTlsFailureTest : BaseTest() {
 
@@ -86,6 +91,47 @@ class ApiTlsFailureTest : BaseTest() {
 		assertTrue(strRes.requested.contains(Res.string.server_error_tls))
 	}
 
+	/**
+	 * `java.net.http.HttpClient`'s constructor wraps a failed `Selector.open()` this way, which is
+	 * how a Windows machine that cannot open the JDK's loopback socket pair fails. Nothing reached
+	 * the network, so it must not read as a server or connectivity problem.
+	 */
+	@Test
+	fun `an unchecked io wrapper reports the network being unavailable`() = runTest {
+		val api = createApi(
+			UncheckedIOException(java.io.IOException("Unable to establish loopback connection"))
+		)
+
+		val result = api.createAccount("user@example.com", "password", "install-id")
+
+		assertIs<HttpFailureException>(result.exceptionOrNull())
+		assertTrue(strRes.requested.contains(Res.string.server_error_network_unavailable))
+		assertFalse(strRes.requested.contains(Res.string.server_error_connection_generic))
+	}
+
+	@Test
+	fun `an unchecked io wrapper still recognises a tls failure`() = runTest {
+		val api = createApi(
+			UncheckedIOException(
+				java.io.IOException("request failed", SSLHandshakeException("bad certificate"))
+			)
+		)
+
+		val result = api.createAccount("user@example.com", "password", "install-id")
+
+		assertIs<HttpFailureException>(result.exceptionOrNull())
+		assertTrue(strRes.requested.contains(Res.string.server_error_tls))
+	}
+
+	@Test
+	fun `an unchecked non-io failure propagates`() = runTest {
+		val api = createApi(IllegalStateException("boom"))
+
+		assertFailsWith<IllegalStateException> {
+			api.createAccount("user@example.com", "password", "install-id")
+		}
+	}
+
 	@Test
 	fun `an ordinary connection failure keeps the generic message`() = runTest {
 		val api = createApi(ConnectException("Connection refused"))
@@ -94,6 +140,7 @@ class ApiTlsFailureTest : BaseTest() {
 
 		assertIs<HttpFailureException>(result.exceptionOrNull())
 		assertTrue(strRes.requested.contains(Res.string.server_error_connection_generic))
+		assertFalse(strRes.requested.contains(Res.string.server_error_network_unavailable))
 	}
 }
 

--- a/common/src/desktopTest/kotlin/util/MsixPathsTest.kt
+++ b/common/src/desktopTest/kotlin/util/MsixPathsTest.kt
@@ -1,0 +1,53 @@
+package util
+
+import com.darkrockstudios.apps.hammer.common.unredirectMsixPath
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * The literal path the app sees, and the container path Explorer needs, taken from the Store
+ * install that reported the broken open-logs button.
+ */
+private const val LOCAL_APP_DATA = "C:\\Users\\someone\\AppData\\Local"
+private const val APP_VISIBLE = "$LOCAL_APP_DATA\\DarkrockStudios\\hammer\\0\\logs"
+private const val CONTAINER =
+	"$LOCAL_APP_DATA\\Packages\\DarkRockStudios.HammerEditor_eee5gzg80tyea" +
+		"\\LocalCache\\Local\\DarkrockStudios\\hammer\\0\\logs"
+
+class MsixPathsTest {
+
+	@Test
+	fun `a redirected path is rewritten into the package container`() {
+		assertEquals(CONTAINER, unredirectMsixPath(APP_VISIBLE, LOCAL_APP_DATA))
+	}
+
+	@Test
+	fun `a path already inside the container is left alone`() {
+		assertEquals(CONTAINER, unredirectMsixPath(CONTAINER, LOCAL_APP_DATA))
+	}
+
+	@Test
+	fun `a path outside local appdata is left alone`() {
+		val outside = "C:\\Users\\someone\\Documents\\Hammer"
+		assertEquals(outside, unredirectMsixPath(outside, LOCAL_APP_DATA))
+	}
+
+	@Test
+	fun `a trailing separator on local appdata does not double up`() {
+		assertEquals(CONTAINER, unredirectMsixPath(APP_VISIBLE, "$LOCAL_APP_DATA\\"))
+	}
+
+	/** Windows paths are case-insensitive, and the env var's casing is not guaranteed to match. */
+	@Test
+	fun `the local appdata prefix matches case insensitively`() {
+		val lowercased = LOCAL_APP_DATA.lowercase()
+		val expected = CONTAINER.replaceFirst(LOCAL_APP_DATA, lowercased)
+		assertEquals(expected, unredirectMsixPath(APP_VISIBLE, lowercased))
+	}
+
+	@Test
+	fun `a missing local appdata leaves the path alone`() {
+		assertEquals(APP_VISIBLE, unredirectMsixPath(APP_VISIBLE, null))
+		assertEquals(APP_VISIBLE, unredirectMsixPath(APP_VISIBLE, ""))
+	}
+}

--- a/common/src/iosMain/kotlin/com/darkrockstudios/apps/hammer/common/NapierProxy.kt
+++ b/common/src/iosMain/kotlin/com/darkrockstudios/apps/hammer/common/NapierProxy.kt
@@ -1,6 +1,5 @@
 package com.darkrockstudios.apps.hammer.common
 
-import com.darkrockstudios.apps.hammer.base.BuildMetadata
 import io.github.aakira.napier.Napier
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -44,7 +43,7 @@ private fun writeCrashDump(throwable: Throwable) {
 	fileSystem.createDirectories(dir)
 	val file = dir / "crash-${Clock.System.now().toEpochMilliseconds()}.txt"
 	fileSystem.write(file) {
-		writeUtf8("Hammer v${BuildMetadata.APP_VERSION} | ${platformStartupInfo()}\n")
+		writeUtf8(startupBanner() + "\n")
 		writeUtf8("Uncaught exception\n\n")
 		writeUtf8(throwable.stackTraceToString())
 	}

--- a/common/src/iosMain/kotlin/com/darkrockstudios/apps/hammer/common/server/IoFailure.ios.kt
+++ b/common/src/iosMain/kotlin/com/darkrockstudios/apps/hammer/common/server/IoFailure.ios.kt
@@ -1,0 +1,5 @@
+package com.darkrockstudios.apps.hammer.common.server
+
+import okio.IOException
+
+actual fun Throwable.asIoFailure(): IOException? = this as? IOException

--- a/common/src/jvmMain/kotlin/com/darkrockstudios/apps/hammer/common/server/IoFailure.jvm.kt
+++ b/common/src/jvmMain/kotlin/com/darkrockstudios/apps/hammer/common/server/IoFailure.jvm.kt
@@ -1,0 +1,15 @@
+package com.darkrockstudios.apps.hammer.common.server
+
+import java.io.IOException
+import java.io.UncheckedIOException
+
+/**
+ * `java.net.http.HttpClient`'s constructor wraps a failed `Selector.open()` in an
+ * [UncheckedIOException], so a machine that cannot open the JDK's internal loopback socket pair
+ * fails with an unchecked exception before a request is ever sent.
+ */
+actual fun Throwable.asIoFailure(): IOException? = when (this) {
+	is IOException -> this
+	is UncheckedIOException -> cause as? IOException
+	else -> null
+}

--- a/composeUi/src/desktopMain/kotlin/com/darkrockstudios/apps/hammer/common/projectselection/about/PlatformAboutSection.desktop.kt
+++ b/composeUi/src/desktopMain/kotlin/com/darkrockstudios/apps/hammer/common/projectselection/about/PlatformAboutSection.desktop.kt
@@ -2,25 +2,57 @@ package com.darkrockstudios.apps.hammer.common.projectselection.about
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.unit.dp
+import com.arkivanov.decompose.extensions.compose.subscribeAsState
 import com.darkrockstudios.apps.hammer.Res
 import com.darkrockstudios.apps.hammer.about_logs_directory_label
+import com.darkrockstudios.apps.hammer.about_logs_export_button
+import com.darkrockstudios.apps.hammer.about_logs_export_failed
+import com.darkrockstudios.apps.hammer.about_logs_export_success
 import com.darkrockstudios.apps.hammer.about_logs_header
+import com.darkrockstudios.apps.hammer.about_logs_no_logs
 import com.darkrockstudios.apps.hammer.about_logs_open_tooltip
 import com.darkrockstudios.apps.hammer.common.components.projectselection.aboutapp.AboutApp
 import com.darkrockstudios.apps.hammer.common.compose.designsystem.HdHairlineButton
 import com.darkrockstudios.apps.hammer.common.compose.designsystem.HdHairlineSection
 import com.darkrockstudios.apps.hammer.common.compose.designsystem.HdMetadataItem
 import com.darkrockstudios.apps.hammer.common.compose.resources.get
-import com.darkrockstudios.apps.hammer.common.getLogDirectory
+import com.darkrockstudios.apps.hammer.common.getPlatformFilesystem
+import com.darkrockstudios.apps.hammer.common.platformIoDispatcher
+import com.darkrockstudios.apps.hammer.common.util.zip.zipDirectory
 import io.github.aakira.napier.Napier
+import io.github.vinceglb.filekit.FileKit
+import io.github.vinceglb.filekit.absolutePath
+import io.github.vinceglb.filekit.dialogs.openFileSaver
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import okio.Path.Companion.toPath
 import java.awt.Desktop
 import java.io.File
 
+private const val LOGS_ZIP_BASE_NAME = "hammer-logs"
+
 @Composable
 actual fun PlatformAboutSection(component: AboutApp, section: Int) {
-	val logDir = getLogDirectory() ?: return
+	val scope = rememberCoroutineScope()
+	val state by component.state.subscribeAsState()
+	val logDir = state.logDirectoryPath
+	var exporting by remember { mutableStateOf(false) }
+	var status by remember { mutableStateOf<String?>(null) }
+
+	val noLogsMessage = Res.string.about_logs_no_logs.get()
+	val failedMessage = Res.string.about_logs_export_failed.get()
+	val successMessage = Res.string.about_logs_export_success.get()
 
 	HdHairlineSection(
 		section = section,
@@ -32,22 +64,85 @@ actual fun PlatformAboutSection(component: AboutApp, section: Int) {
 				value = logDir,
 				selectable = true,
 			)
-			HdHairlineButton(
-				label = Res.string.about_logs_open_tooltip.get(),
-				onClick = { openLogDirectory(logDir) },
-			)
+			Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
+				HdHairlineButton(
+					label = Res.string.about_logs_open_tooltip.get(),
+					onClick = { openLogDirectory(logDir) },
+				)
+				HdHairlineButton(
+					label = Res.string.about_logs_export_button.get(),
+					enabled = !exporting,
+					onClick = {
+						exporting = true
+						status = null
+						scope.launch {
+							status = when (exportLogs(logDir)) {
+								ExportResult.EXPORTED -> successMessage
+								ExportResult.NO_LOGS -> noLogsMessage
+								ExportResult.FAILED -> failedMessage
+								ExportResult.CANCELLED -> null
+							}
+							exporting = false
+						}
+					},
+				)
+			}
+			status?.let {
+				Text(text = it, style = MaterialTheme.typography.bodySmall)
+			}
 		}
 	}
 }
 
 actual val platformAboutSectionCount: Int = 1
 
+private enum class ExportResult { EXPORTED, NO_LOGS, FAILED, CANCELLED }
+
+private suspend fun exportLogs(logDirPath: String): ExportResult {
+	val fileSystem = getPlatformFilesystem()
+	val logsDir = logDirPath.toPath()
+
+	val hasLogs = withContext(platformIoDispatcher) {
+		try {
+			fileSystem.exists(logsDir) && fileSystem.list(logsDir).any { it.name.endsWith(".txt") }
+		} catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
+			Napier.e("Failed to list log files", e)
+			false
+		}
+	}
+	if (!hasLogs) return ExportResult.NO_LOGS
+
+	val destination = FileKit.openFileSaver(
+		suggestedName = LOGS_ZIP_BASE_NAME,
+		defaultExtension = "zip",
+	) ?: return ExportResult.CANCELLED
+
+	return withContext(platformIoDispatcher) {
+		val zipPath = destination.absolutePath().toPath()
+		try {
+			if (fileSystem.exists(zipPath)) fileSystem.delete(zipPath)
+			zipDirectory(fileSystem, logsDir, zipPath)
+			ExportResult.EXPORTED
+		} catch (e: CancellationException) {
+			throw e
+		} catch (@Suppress("TooGenericExceptionCaught") e: Throwable) {
+			Napier.e("Failed to export logs", e)
+			ExportResult.FAILED
+		}
+	}
+}
+
+/**
+ * Hands the shell the nearest existing ancestor rather than a dead path: under an MSIX or Snap
+ * container the app's own writes are redirected, so a path that resolves from inside the container
+ * can still be missing from the shell's point of view.
+ */
 private fun openLogDirectory(logDir: String) {
 	try {
-		val dir = File(logDir)
-		if (dir.exists() && Desktop.isDesktopSupported()) {
-			Desktop.getDesktop().open(dir)
-		}
+		if (!Desktop.isDesktopSupported()) return
+		val target = generateSequence(File(logDir)) { it.parentFile }
+			.firstOrNull { it.isDirectory } ?: return
+		Desktop.getDesktop().open(target)
 	} catch (@Suppress("TooGenericExceptionCaught") e: Exception) { // Desktop.open can throw varied IO/security errors
 		Napier.e("Failed to open log directory", e)
 	}

--- a/composeUi/src/desktopMain/kotlin/com/darkrockstudios/apps/hammer/common/projectselection/about/PlatformAboutSection.desktop.kt
+++ b/composeUi/src/desktopMain/kotlin/com/darkrockstudios/apps/hammer/common/projectselection/about/PlatformAboutSection.desktop.kt
@@ -28,6 +28,7 @@ import com.darkrockstudios.apps.hammer.common.compose.designsystem.HdMetadataIte
 import com.darkrockstudios.apps.hammer.common.compose.resources.get
 import com.darkrockstudios.apps.hammer.common.getPlatformFilesystem
 import com.darkrockstudios.apps.hammer.common.platformIoDispatcher
+import com.darkrockstudios.apps.hammer.common.shellPath
 import com.darkrockstudios.apps.hammer.common.util.zip.zipDirectory
 import io.github.aakira.napier.Napier
 import io.github.vinceglb.filekit.FileKit
@@ -47,6 +48,8 @@ actual fun PlatformAboutSection(component: AboutApp, section: Int) {
 	val scope = rememberCoroutineScope()
 	val state by component.state.subscribeAsState()
 	val logDir = state.logDirectoryPath
+	// What the user would paste into a file manager, which under a container is not what the app writes to.
+	val displayedLogDir = shellPath(logDir)
 	var exporting by remember { mutableStateOf(false) }
 	var status by remember { mutableStateOf<String?>(null) }
 
@@ -61,13 +64,13 @@ actual fun PlatformAboutSection(component: AboutApp, section: Int) {
 		Column(verticalArrangement = Arrangement.spacedBy(14.dp)) {
 			HdMetadataItem(
 				label = Res.string.about_logs_directory_label.get(),
-				value = logDir,
+				value = displayedLogDir,
 				selectable = true,
 			)
 			Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
 				HdHairlineButton(
 					label = Res.string.about_logs_open_tooltip.get(),
-					onClick = { openLogDirectory(logDir) },
+					onClick = { openLogDirectory(displayedLogDir) },
 				)
 				HdHairlineButton(
 					label = Res.string.about_logs_export_button.get(),
@@ -133,9 +136,9 @@ private suspend fun exportLogs(logDirPath: String): ExportResult {
 }
 
 /**
- * Hands the shell the nearest existing ancestor rather than a dead path: under an MSIX or Snap
- * container the app's own writes are redirected, so a path that resolves from inside the container
- * can still be missing from the shell's point of view.
+ * Hands the shell the nearest existing ancestor rather than a dead path. [shellPath] already
+ * un-redirects the known container layouts; this covers the rest, including a log directory that
+ * has not been written to yet.
  */
 private fun openLogDirectory(logDir: String) {
 	try {

--- a/composeUi/src/desktopTest/kotlin/PlatformAboutSectionTest.kt
+++ b/composeUi/src/desktopTest/kotlin/PlatformAboutSectionTest.kt
@@ -1,0 +1,46 @@
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import com.arkivanov.decompose.value.MutableValue
+import com.arkivanov.decompose.value.Value
+import com.darkrockstudios.apps.hammer.common.components.projectselection.aboutapp.AboutApp
+import com.darkrockstudios.apps.hammer.common.compose.theme.AppTheme
+import com.darkrockstudios.apps.hammer.common.preview.globalSettingsPreview
+import com.darkrockstudios.apps.hammer.common.projectselection.about.PlatformAboutSection
+import org.junit.Rule
+import org.junit.Test
+
+/**
+ * The support case behind the export button was a user who could not get at their logs, so both
+ * routes to them have to actually render.
+ */
+class PlatformAboutSectionTest {
+	@get:Rule
+	val compose = createComposeRule()
+
+	private class FakeAboutApp(logDirectoryPath: String) : AboutApp {
+		override val state: Value<AboutApp.State> =
+			MutableValue(AboutApp.State(logDirectoryPath = logDirectoryPath))
+
+		override fun openDiscord() = Unit
+		override fun openReddit() = Unit
+		override fun openGithub() = Unit
+		override fun viewChangelog() = Unit
+		override fun openLatestRelease() = Unit
+	}
+
+	@Test
+	fun `both log actions and the log directory are shown`() {
+		val logDir = "/home/someone/.config/DarkrockStudios/hammer/0/logs"
+		compose.setContent {
+			AppTheme(globalSettingsPreview) {
+				PlatformAboutSection(FakeAboutApp(logDir), section = 0)
+			}
+		}
+
+		compose.onNodeWithText("Application Logs").assertIsDisplayed()
+		compose.onNodeWithText(logDir).assertIsDisplayed()
+		compose.onNodeWithText("Open log directory").assertIsDisplayed()
+		compose.onNodeWithText("Export Logs").assertIsDisplayed()
+	}
+}

--- a/desktop/scripts/build-appstore.sh
+++ b/desktop/scripts/build-appstore.sh
@@ -62,7 +62,7 @@ fi
 echo "→ Building Hammer for the Mac App Store (build #$BUILD_NUMBER)"
 
 ./gradlew --stop
-./gradlew :desktop:packageReleasePkg \
+./gradlew :desktop:packageReleasePkg -Pchannel=mac-app-store \
 	-PmacOsAppStoreRelease=true \
 	-PbuildNumber="$BUILD_NUMBER" \
 	--no-daemon

--- a/desktop/src/jvmMain/kotlin/com/darkrockstudios/apps/hammer/desktop/Main.kt
+++ b/desktop/src/jvmMain/kotlin/com/darkrockstudios/apps/hammer/desktop/Main.kt
@@ -14,7 +14,6 @@ import com.arkivanov.decompose.ExperimentalDecomposeApi
 import com.arkivanov.decompose.extensions.compose.subscribeAsState
 import com.arkivanov.decompose.value.MutableValue
 import com.arkivanov.decompose.value.getAndUpdate
-import com.darkrockstudios.apps.hammer.base.BuildMetadata
 import com.darkrockstudios.apps.hammer.common.AppCloseManager
 import com.darkrockstudios.apps.hammer.common.compose.getDefaultDispatcher
 import com.darkrockstudios.apps.hammer.common.compose.getMainDispatcher
@@ -32,7 +31,7 @@ import com.darkrockstudios.apps.hammer.common.dependencyinjection.mainModule
 import com.darkrockstudios.apps.hammer.common.getInDevelopmentMode
 import com.darkrockstudios.apps.hammer.common.getLogDirectory
 import com.darkrockstudios.apps.hammer.common.logStartupBanner
-import com.darkrockstudios.apps.hammer.common.platformStartupInfo
+import com.darkrockstudios.apps.hammer.common.startupBanner
 import com.darkrockstudios.apps.hammer.common.setInDevelopmentMode
 import com.darkrockstudios.apps.hammer.desktop.aboutlibraries.aboutLibrariesModule
 import com.darkrockstudios.apps.hammer.desktop.sandbox.SandboxStartup
@@ -98,7 +97,7 @@ private fun writeCrashDump(thread: Thread, throwable: Throwable) {
 	File(dir).mkdirs()
 	File(dir, "crash-${System.currentTimeMillis()}.txt").writeText(
 		buildString {
-			append("Hammer v${BuildMetadata.APP_VERSION} | ${platformStartupInfo()}\n")
+			append(startupBanner() + "\n")
 			append("Uncaught exception on thread '${thread.name}'\n\n")
 			append(throwable.stackTraceToString())
 		}

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -306,7 +306,8 @@ platform :android do
   lane :internal do
     gradle(
       task: ":android:bundleRelease",
-      gradle_path: "./gradlew"
+      gradle_path: "./gradlew",
+      properties: { "channel" => "google-play" }
     )
     upload_to_play_store(track: 'internal')
   end
@@ -315,7 +316,8 @@ platform :android do
   lane :alpha do
     gradle(
       task: ":android:bundleRelease",
-      gradle_path: "./gradlew"
+      gradle_path: "./gradlew",
+      properties: { "channel" => "google-play" }
     )
     upload_to_play_store(track: 'alpha')
   end
@@ -324,7 +326,8 @@ platform :android do
   lane :beta do
     gradle(
       task: ":android:bundleRelease",
-      gradle_path: "./gradlew"
+      gradle_path: "./gradlew",
+      properties: { "channel" => "google-play" }
     )
     upload_to_play_store(track: 'beta')
   end
@@ -333,7 +336,8 @@ platform :android do
   lane :release do
     gradle(
       task: "clean bundleRelease",
-      gradle_path: "./gradlew"
+      gradle_path: "./gradlew",
+      properties: { "channel" => "google-play" }
     )
     upload_to_play_store(
       root_url: "https://androidpublisher.googleapis.com/",

--- a/flatpak/studio.darkrock.hammer.yaml
+++ b/flatpak/studio.darkrock.hammer.yaml
@@ -32,7 +32,7 @@ modules:
                 export PATH=$JAVA_HOME/bin:$PATH
                 java -version
                 chmod +x gradlew
-                ./gradlew :desktop:createDistributable -x test --no-daemon
+                ./gradlew :desktop:createDistributable -Pchannel=flathub -x test --no-daemon
             # Install the app (outputBaseDir is set to 'installers' in build.gradle.kts)
             - mkdir -p /app/lib/hammer
             - cp -r desktop/build/installers/main/app/hammer/* /app/lib/hammer/

--- a/ios/ios.xcodeproj/project.pbxproj
+++ b/ios/ios.xcodeproj/project.pbxproj
@@ -281,7 +281,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "cd \"$SRCROOT/..\"\n./gradlew :composeUi:embedAndSignAppleFrameworkForXcode\n";
+			shellScript = "cd \"$SRCROOT/..\"\n# Only a Release build is the one that reaches the App Store; a local Debug build stays 'dev'.\nif [ \"$CONFIGURATION\" = \"Release\" ]; then\n  CHANNEL_ARG=-Pchannel=ios-app-store\nelse\n  CHANNEL_ARG=\nfi\n./gradlew :composeUi:embedAndSignAppleFrameworkForXcode $CHANNEL_ARG\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -65,8 +65,8 @@ parts:
             java -version
 
             chmod +x ./gradlew
-            ./gradlew :desktop:jvmJar --no-daemon
-            ./gradlew :desktop:createDistributable -x desktopTest --no-daemon
+            ./gradlew :desktop:jvmJar -Pchannel=snap --no-daemon
+            ./gradlew :desktop:createDistributable -Pchannel=snap -x desktopTest --no-daemon
 
             # The installers/ path comes from outputBaseDir in
             # desktop/build.gradle.kts; the app tree carries its own JVM at


### PR DESCRIPTION
A Store user reported the open-logs button erroring. That turned out to sit on top of a second, worse bug: all networking crashes the app under MSIX. Both affect every Store user.

## Networking crashes under MSIX

`java.net.http.HttpClient`'s constructor opens an NIO `Selector`, whose Windows wakeup pipe is an AF_UNIX socket. The MSIX sandbox rejects the connect with `EINVAL`, so the app dies while *constructing* the client, before any request is sent. Any URL fails identically. Tracked upstream as JDK-8312215: open since Java 17, "Cause Known", no movement in three years, so a JDK bump will not fix it.

Switched the desktop Ktor engine to OkHttp, which uses blocking socket IO. Shipped unconditionally rather than gated on the channel: OkHttp works in both sandboxed and normal contexts, gating would leave Store users broken until the rest landed, and two engines is two code paths to test forever. Android already uses it.

CIO and Apache 5 are not alternatives; both are NIO-based and die at the same frame.

Also folds in the unchecked-IO mapping from `fix/unchecked-io-network-errors`: `UncheckedIOException` is a `RuntimeException`, so it slipped past every catch in `Api.makeRequest` and took the app down from a coroutine with no handler. It now surfaces as a network error.

## Open-logs button points at a path that does not exist

MSIX filesystem redirection is asymmetric. Writes under `%LOCALAPPDATA%` land in the package container, but reads fall through, so `File.exists()` is true from inside the container and the app is satisfied. Explorer runs outside it and correctly reports nothing there.

Two fixes, because each is useful without the other:

- Rewrite the path into the container for the Store channel, both where it is displayed and where it is handed to the shell. The package family name is hardcoded; Windows derives its hash suffix from the publisher ID, so it is not in `AppxManifest.xml` and cannot be computed from it.
- Add an **Export Logs** button that writes a zip wherever the user picks. This works identically on MSIX, MSI, Snap, Flatpak and portable, which makes it the one support instruction that never needs a per-channel caveat. Snap confinement will produce the same problem on Linux eventually.

The open handler also walks up to the nearest existing ancestor rather than handing the shell a dead path.

`Windows.Storage.ApplicationData.Current.LocalCacheFolder` is the native answer but means a WinRT dependency on a KMP desktop target for one path lookup. Worth revisiting only if more packaged-app APIs are needed.

## Distribution channel constant

Per-vehicle rules were tracked by hand: self-update (forbidden in MS Store and Play, expected for GitHub/AppImage), where "get the app" links point, external-payment policy, sandbox-aware paths. `-Pchannel=<token>` now resolves to a `DistributionChannel` constant, defaulting to `dev`. An unknown token **fails the build** rather than falling back, so a typo in a release workflow cannot ship a store binary as `dev`. Every release pipeline passes its own channel; the existing F-Droid flags map to `fdroid` without their call sites changing.

Flat enum rather than capability flags, so every channel-conditional branch is a greppable `when` on the type. Flags can emerge later from real duplication rather than a guess at the axes. Note that every branch compiles into every build, so a store-forbidden path is physically present in a store binary even when unreachable; if a store ever objects to presence rather than behaviour, that is the trigger to promote that one case to a source set.

The startup banner and all three crash dumps now carry the channel. That line pays for itself immediately: this investigation started from a crash log that did not say which build produced it.

## Testing

- `unredirectMsixPath` unit tests built from the real paths in the report.
- Build-side channel resolution tests, including that a typo fails and that the two enums stay in step.
- A render test for the About log section covering both buttons and the path display.
- Full desktop suites, plus Android and iOS compilation.

**Not verified: the MSIX build itself.** This bug is invisible outside the sandbox, so the engine swap needs a real Store install to confirm.

## Note for review

`msix/AppxManifest.xml` declares only `runFullTrust`, no `internetClient`. Full-trust apps generally do not need it and it does not match the AF_UNIX diagnosis, so I left the manifest alone rather than make a speculative change to something Store-submitted. Worth adding if networking still fails after the swap.