### PR TITLE
Add a project-scoped user spelling dictionary

### DIFF
--- a/base/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/base/http/projectdata/ProjectData.kt
+++ b/base/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/base/http/projectdata/ProjectData.kt
@@ -13,6 +13,8 @@ data class ProjectData(
 	val language: String? = null,
 	/** Whether Encyclopedia entry names feed the spell-check session dictionary for this project. */
 	val encyclopediaDictionary: Boolean = true,
+	/** User-added spell-check words. Unlike [tags], a conflict merges both sides by union. */
+	val dictionaryWords: Set<String> = emptySet(),
 )
 
 /** Picked as a unit during conflict resolution — one device's primary paired with another's secondary is undesigned. */

--- a/base/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/base/http/synchronizer/ProjectDataHasher.kt
+++ b/base/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/base/http/synchronizer/ProjectDataHasher.kt
@@ -62,6 +62,13 @@ object ProjectDataHasher {
 			d.update(-2, buf)
 		}
 
+		// Zero bytes when empty, same rule as tags. -3 marker: -1 and -2 are taken.
+		if (data.dictionaryWords.isNotEmpty()) {
+			d.update(-3, buf)
+			d.update(data.dictionaryWords.size, buf)
+			data.dictionaryWords.sorted().forEach { word -> d.update(word, buf) }
+		}
+
 		return d.digest().base64Url
 	}
 }

--- a/base/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/base/http/synchronizer/ProjectDataHasher.kt
+++ b/base/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/base/http/synchronizer/ProjectDataHasher.kt
@@ -62,11 +62,16 @@ object ProjectDataHasher {
 			d.update(-2, buf)
 		}
 
-		// Zero bytes when empty, same rule as tags. -3 marker: -1 and -2 are taken.
+		// Zero bytes when empty, same rule as tags. -3 marker: -1 and -2 are taken. Each word
+		// carries its length: update(String) writes bare char codes, so without it
+		// {"a","bc"} and {"ab","c"} would collide.
 		if (data.dictionaryWords.isNotEmpty()) {
 			d.update(-3, buf)
 			d.update(data.dictionaryWords.size, buf)
-			data.dictionaryWords.sorted().forEach { word -> d.update(word, buf) }
+			data.dictionaryWords.sorted().forEach { word ->
+				d.update(word.length, buf)
+				d.update(word, buf)
+			}
 		}
 
 		return d.digest().base64Url

--- a/base/src/commonTest/kotlin/com/darkrockstudios/apps/hammer/base/http/synchronizer/ProjectDataHasherTest.kt
+++ b/base/src/commonTest/kotlin/com/darkrockstudios/apps/hammer/base/http/synchronizer/ProjectDataHasherTest.kt
@@ -107,6 +107,11 @@ class ProjectDataHasherTest {
 		val joined = ProjectData(dictionaryWords = setOf("ab"))
 		val split = ProjectData(dictionaryWords = setOf("a", "b"))
 		assertNotEquals(ProjectDataHasher.hash(joined), ProjectDataHasher.hash(split))
+
+		// Same size and same concatenation: only a per-word length keeps these apart.
+		val left = ProjectData(dictionaryWords = setOf("a", "bc"))
+		val right = ProjectData(dictionaryWords = setOf("ab", "c"))
+		assertNotEquals(ProjectDataHasher.hash(left), ProjectDataHasher.hash(right))
 	}
 
 	@Test

--- a/base/src/commonTest/kotlin/com/darkrockstudios/apps/hammer/base/http/synchronizer/ProjectDataHasherTest.kt
+++ b/base/src/commonTest/kotlin/com/darkrockstudios/apps/hammer/base/http/synchronizer/ProjectDataHasherTest.kt
@@ -89,6 +89,34 @@ class ProjectDataHasherTest {
 	}
 
 	@Test
+	fun `dictionary words affect hash`() {
+		val without = ProjectData(authorName = "Pat")
+		val with = without.copy(dictionaryWords = setOf("kvothe"))
+		assertNotEquals(ProjectDataHasher.hash(without), ProjectDataHasher.hash(with))
+	}
+
+	@Test
+	fun `dictionary word insertion order does not affect hash`() {
+		val ab = ProjectData(dictionaryWords = setOf("alpha", "beta"))
+		val ba = ProjectData(dictionaryWords = setOf("beta", "alpha"))
+		assertEquals(ProjectDataHasher.hash(ab), ProjectDataHasher.hash(ba))
+	}
+
+	@Test
+	fun `dictionary word boundaries affect hash`() {
+		val joined = ProjectData(dictionaryWords = setOf("ab"))
+		val split = ProjectData(dictionaryWords = setOf("a", "b"))
+		assertNotEquals(ProjectDataHasher.hash(joined), ProjectDataHasher.hash(split))
+	}
+
+	@Test
+	fun `dictionary block does not collide with tags or language`() {
+		val words = ProjectData(dictionaryWords = setOf("en"))
+		assertNotEquals(ProjectDataHasher.hash(ProjectData(tags = setOf("en"))), ProjectDataHasher.hash(words))
+		assertNotEquals(ProjectDataHasher.hash(ProjectData(language = "en")), ProjectDataHasher.hash(words))
+	}
+
+	@Test
 	fun `null vs empty language distinguishable`() {
 		val nullLanguage = ProjectData(language = null)
 		val emptyLanguage = ProjectData(language = "")

--- a/common/src/commonMain/composeResources/values/strings_scene_editor.xml
+++ b/common/src/commonMain/composeResources/values/strings_scene_editor.xml
@@ -24,6 +24,7 @@
 	<string name="scene_editor_menu_item_archive">Archive</string>
 	<string name="scene_editor_menu_item_save">Save</string>
 	<string name="scene_editor_menu_item_close">Close</string>
+	<string name="scene_editor_add_to_dictionary">Add to dictionary</string>
 
 	<string name="archive_scene_dialog_title">Archive Scene</string>
 	<string name="archive_scene_dialog_message">Are you sure you want to archive '%1$s'? The scene will be hidden from the scene list but can be restored later.</string>

--- a/common/src/commonMain/composeResources/values/strings_sync.xml
+++ b/common/src/commonMain/composeResources/values/strings_sync.xml
@@ -65,6 +65,9 @@
 	<string name="project_settings_spellcheck_mismatch_caption">Spell check is off: the project language (%1$s) doesn’t match your dictionary (%2$s). Change either to re-enable it.</string>
 	<string name="project_settings_spellcheck_encyclopedia_enable">Learn encyclopedia names in this project</string>
 	<string name="project_settings_spellcheck_encyclopedia_enable_hint">Turn off to keep this project&#8217;s entry names out of the spell check dictionary</string>
+	<string name="project_settings_dictionary_label">Project dictionary</string>
+	<string name="project_settings_dictionary_hint">↵ to add</string>
+	<string name="project_settings_dictionary_placeholder">Words the spell checker should accept in this project</string>
 	<string name="project_settings_folio_caption">Project Settings · %1$s</string>
 	<string name="project_settings_folio_section_count">§§ %1$d</string>
 
@@ -81,6 +84,7 @@
 	<string name="sync_conflict_project_data_value_off">Off</string>
 	<string name="sync_conflict_project_data_cadence_day">day</string>
 	<string name="sync_conflict_project_data_cadence_week">week</string>
+	<string name="sync_conflict_project_data_dictionary_merged">Project dictionary words from both sides are kept.</string>
 	<string name="sync_conflict_project_data_resolve_button">Resolve</string>
 
 

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/projecthome/ProjectSettings.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/projecthome/ProjectSettings.kt
@@ -26,6 +26,10 @@ interface ProjectSettings : HammerComponent {
 
 	fun setEncyclopediaDictionaryEnabled(enabled: Boolean)
 
+	/** Input that normalizes to nothing storable is ignored. */
+	fun addDictionaryWord(word: String)
+	fun removeDictionaryWord(word: String)
+
 	data class LanguageOption(
 		val tag: String,
 		val displayName: String,

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/projecthome/ProjectSettingsComponent.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/projecthome/ProjectSettingsComponent.kt
@@ -14,6 +14,7 @@ import com.darkrockstudios.apps.hammer.common.data.projectInject
 import com.darkrockstudios.apps.hammer.common.data.projectdata.ProjectDataRepository
 import com.darkrockstudios.apps.hammer.common.data.tagindex.AccountTagService
 import com.darkrockstudios.apps.hammer.common.dependencyinjection.injectMainDispatcher
+import com.darkrockstudios.apps.hammer.common.spellcheck.ProjectDictionaryUseCase
 import com.darkrockstudios.apps.hammer.common.spellcheck.displayName
 import com.darkrockstudios.apps.hammer.common.util.AvailableLocalesProvider
 import com.darkrockstudios.apps.hammer.common.util.Locale
@@ -28,6 +29,7 @@ class ProjectSettingsComponent(
 
 	private val mainDispatcher by injectMainDispatcher()
 	private val projectDataRepository: ProjectDataRepository by projectInject()
+	private val projectDictionary: ProjectDictionaryUseCase by projectInject()
 	private val accountTagService: AccountTagService by inject()
 	private val availableLocalesProvider: AvailableLocalesProvider by inject()
 
@@ -99,6 +101,14 @@ class ProjectSettingsComponent(
 		scope.launch {
 			projectDataRepository.updateData { it.copy(encyclopediaDictionary = enabled) }
 		}
+	}
+
+	override fun addDictionaryWord(word: String) {
+		scope.launch { projectDictionary.addWord(word) }
+	}
+
+	override fun removeDictionaryWord(word: String) {
+		scope.launch { projectDictionary.removeWord(word) }
 	}
 
 	override fun suggestProjectTags(prefix: String): List<String> {

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/storyeditor/focusmode/FocusMode.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/storyeditor/focusmode/FocusMode.kt
@@ -23,6 +23,9 @@ interface FocusMode {
 	fun setEditorMaxWidth(width: Float)
 	fun resetEditorMaxWidth()
 
+	/** Adds a flagged word to the project's spell-check dictionary. */
+	fun addWordToDictionary(word: String)
+
 	data class State(
 		val projectDef: ProjectDef,
 		val sceneItem: SceneItem,

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/storyeditor/focusmode/FocusModeComponent.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/storyeditor/focusmode/FocusModeComponent.kt
@@ -12,6 +12,7 @@ import com.darkrockstudios.apps.hammer.common.data.*
 import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettings
 import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettingsStore
 import com.darkrockstudios.apps.hammer.common.data.sceneeditorrepository.SceneEditorService
+import com.darkrockstudios.apps.hammer.common.spellcheck.ProjectDictionaryUseCase
 import com.darkrockstudios.apps.hammer.common.spellcheck.ProjectSpellCheckRepository
 import io.github.aakira.napier.Napier
 import kotlinx.coroutines.Job
@@ -29,6 +30,7 @@ class FocusModeComponent(
 
 	private val settingsRepository: GlobalSettingsStore by inject()
 	private val spellCheckRepository: ProjectSpellCheckRepository by projectInject()
+	private val projectDictionary: ProjectDictionaryUseCase by projectInject()
 	private val focusModeService: FocusModeService by inject()
 	private val sceneEditor: SceneEditorService by projectInject()
 
@@ -134,6 +136,10 @@ class FocusModeComponent(
 				)
 			}
 		}
+	}
+
+	override fun addWordToDictionary(word: String) {
+		scope.launch { projectDictionary.addWord(word) }
 	}
 
 	private fun subscribeToBufferUpdates() {

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/storyeditor/sceneeditor/SceneEditor.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/storyeditor/sceneeditor/SceneEditor.kt
@@ -57,6 +57,9 @@ interface SceneEditor : HammerComponent, ComponentToaster {
 	fun resetEditorMaxWidth()
 	fun enterFocusMode()
 
+	/** Adds a flagged word to the project's spell-check dictionary. */
+	fun addWordToDictionary(word: String)
+
 	data class State(
 		val sceneItem: SceneItem,
 		val sceneBuffer: SceneBuffer? = null,

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/storyeditor/sceneeditor/SceneEditorComponent.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/components/storyeditor/sceneeditor/SceneEditorComponent.kt
@@ -22,6 +22,7 @@ import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettings
 import com.darkrockstudios.apps.hammer.common.data.projectsrepository.ProjectsRepository
 import com.darkrockstudios.apps.hammer.common.data.references.AutoConfirmReferencesUseCase
 import com.darkrockstudios.apps.hammer.common.data.sceneeditorrepository.SceneEditorService
+import com.darkrockstudios.apps.hammer.common.spellcheck.ProjectDictionaryUseCase
 import com.darkrockstudios.apps.hammer.common.spellcheck.ProjectSpellCheckRepository
 import io.github.aakira.napier.Napier
 import kotlinx.coroutines.Job
@@ -50,6 +51,7 @@ class SceneEditorComponent(
 	private val autoConfirmReferences: AutoConfirmReferencesUseCase by projectInject()
 
 	private val spellCheckRepository: ProjectSpellCheckRepository by projectInject()
+	private val projectDictionary: ProjectDictionaryUseCase by projectInject()
 
 	private val _state = MutableValue(
 		SceneEditor.State(
@@ -488,6 +490,10 @@ class SceneEditorComponent(
 
 	override fun enterFocusMode() {
 		showFocusMode(sceneDef)
+	}
+
+	override fun addWordToDictionary(word: String) {
+		scope.launch { projectDictionary.addWord(word) }
 	}
 
 	override fun decreaseTextSize() {

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/ProjectEditorScopeUtils.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/ProjectEditorScopeUtils.kt
@@ -5,6 +5,9 @@ import com.darkrockstudios.apps.hammer.common.data.timelinerepository.TimeLineRe
 import com.darkrockstudios.apps.hammer.common.dependencyinjection.ProjectDefScope
 import com.darkrockstudios.apps.hammer.common.spellcheck.ProjectDictionaryService
 import io.github.aakira.napier.Napier
+import kotlinx.atomicfu.atomic
+import kotlinx.atomicfu.getAndUpdate
+import kotlinx.atomicfu.update
 import org.koin.core.Koin
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.getScopeId
@@ -14,13 +17,19 @@ import org.koin.core.scope.Scope
 import org.koin.core.scope.ScopeID
 import org.koin.mp.KoinPlatform.getKoin
 
+// Scopes an editor has opened. A temporary task that created the scope must not close it
+// once an editor owns it, and an editor opening an existing temporary scope must still
+// start the editor-only services.
+private val editorScopes = atomic(emptySet<ScopeID>())
+
 suspend fun KoinComponent.temporaryProjectTask(projectDef: ProjectDef, block: suspend (projectScope: Scope) -> Unit) {
-	val hadToCreate = getKoin().getScopeOrNull(ProjectDefScope(projectDef).getScopeId()) == null
+	val scopeId = ProjectDefScope(projectDef).getScopeId()
+	val hadToCreate = getKoin().getScopeOrNull(scopeId) == null
 	val projScope = openProjectScope(projectDef, temporary = true)
 
 	block(projScope)
 
-	if (hadToCreate) {
+	if (hadToCreate && scopeId !in editorScopes.value) {
 		closeProjectScope(projScope, projectDef)
 	}
 }
@@ -37,12 +46,15 @@ fun createProjectScope(projectDef: ProjectDef): Scope {
 
 suspend fun openProjectScope(projectDef: ProjectDef, temporary: Boolean = false): Scope {
 	val defScope = ProjectDefScope(projectDef)
+	val scopeId = defScope.getScopeId()
 
-	val needsInit = getKoin().getScopeOrNull(ProjectDefScope(projectDef).getScopeId()) == null
-	val projScope = getKoin().getOrCreateScope<ProjectDefScope>(defScope.getScopeId(), source = defScope)
+	val needsInit = getKoin().getScopeOrNull(scopeId) == null
+	val projScope = getKoin().getOrCreateScope<ProjectDefScope>(scopeId, source = defScope)
 
 	if (needsInit) {
 		initializeProjectScope(projectDef, temporary)
+	} else if (!temporary && markOpenedForEditing(scopeId)) {
+		initializeEditorServices(projScope)
 	}
 
 	return projScope
@@ -61,14 +73,25 @@ suspend fun initializeProjectScope(projectDef: ProjectDef, temporary: Boolean = 
 
 		// Skipped for temporary scopes (background sync, import): loading session words
 		// there only churns the shared checker while the sync rewrites entries.
-		if (!temporary) {
-			projScope.get<ProjectDictionaryService>().initialize()
+		if (!temporary && markOpenedForEditing(defScope.getScopeId())) {
+			initializeEditorServices(projScope)
 		}
 	} ?: throw IllegalStateException("No scope found for $projectDef")
 }
 
+private fun initializeEditorServices(projScope: Scope) {
+	projScope.get<ProjectDictionaryService>().initialize()
+}
+
+/** Returns true the first time [scopeId] is marked. */
+private fun markOpenedForEditing(scopeId: ScopeID): Boolean {
+	val before = editorScopes.getAndUpdate { it + scopeId }
+	return scopeId !in before
+}
+
 fun closeProjectScope(projectScope: Scope, projectDef: ProjectDef) {
 	Napier.d { "closeProjectScope: ${projectDef.name}" }
+	editorScopes.update { it - ProjectDefScope(projectDef).getScopeId() }
 	projectScope.close()
 }
 

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/projectdata/ProjectDataMerge.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/projectdata/ProjectDataMerge.kt
@@ -1,0 +1,11 @@
+package com.darkrockstudios.apps.hammer.common.data.projectdata
+
+import com.darkrockstudios.apps.hammer.base.http.projectdata.ProjectData
+
+/** Dictionary words never need a decision: a conflict keeps both sides. */
+fun mergeDictionaryWords(local: ProjectData, server: ProjectData): Set<String> =
+	local.dictionaryWords + server.dictionaryWords
+
+/** True when something other than the auto-merged dictionary differs. */
+fun ProjectData.differsOutsideDictionary(other: ProjectData): Boolean =
+	copy(dictionaryWords = emptySet()) != other.copy(dictionaryWords = emptySet())

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/projectdata/ProjectDataMerge.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/projectdata/ProjectDataMerge.kt
@@ -1,11 +1,34 @@
 package com.darkrockstudios.apps.hammer.common.data.projectdata
 
 import com.darkrockstudios.apps.hammer.base.http.projectdata.ProjectData
+import com.darkrockstudios.apps.hammer.common.spellcheck.cleanDictionaryWords
 
 /** Dictionary words never need a decision: a conflict keeps both sides. */
 fun mergeDictionaryWords(local: ProjectData, server: ProjectData): Set<String> =
-	local.dictionaryWords + server.dictionaryWords
+	cleanDictionaryWords(local.dictionaryWords + server.dictionaryWords)
 
 /** True when something other than the auto-merged dictionary differs. */
 fun ProjectData.differsOutsideDictionary(other: ProjectData): Boolean =
-	copy(dictionaryWords = emptySet()) != other.copy(dictionaryWords = emptySet())
+	copy(dictionaryWords = other.dictionaryWords) != other
+
+/**
+ * Re-applies the edits made between [base] and [local] on top of [incoming]: a field the user
+ * changed keeps its local value, the rest take the incoming value, and dictionary words carry
+ * the local additions and removals over as a delta.
+ */
+fun reapplyLocalEdits(base: ProjectData, local: ProjectData, incoming: ProjectData): ProjectData {
+	fun <T> pick(baseValue: T, localValue: T, incomingValue: T): T =
+		if (localValue != baseValue) localValue else incomingValue
+
+	return incoming.copy(
+		authorName = pick(base.authorName, local.authorName, incoming.authorName),
+		theme = pick(base.theme, local.theme, incoming.theme),
+		wordCountGoal = pick(base.wordCountGoal, local.wordCountGoal, incoming.wordCountGoal),
+		tags = pick(base.tags, local.tags, incoming.tags),
+		language = pick(base.language, local.language, incoming.language),
+		encyclopediaDictionary = pick(base.encyclopediaDictionary, local.encyclopediaDictionary, incoming.encyclopediaDictionary),
+		dictionaryWords = incoming.dictionaryWords +
+			(local.dictionaryWords - base.dictionaryWords) -
+			(base.dictionaryWords - local.dictionaryWords),
+	)
+}

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/projectdata/ProjectDataRepository.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/projectdata/ProjectDataRepository.kt
@@ -61,13 +61,18 @@ class ProjectDataRepository(
 	}
 
 	/**
-	 * Sync-only: replace both [ProjectData] and [StoredProjectData.lastSyncedHash]
-	 * atomically, e.g. after a successful upload or after fast-forwarding to
-	 * the server's state.
+	 * Sync-only: install [data] as the state agreed with the server under [lastSyncedHash], e.g.
+	 * after a successful upload or a fast-forward. Edits made since the sync read [snapshot]
+	 * are re-applied on top, so they stay pending for the next sync instead of being lost.
 	 */
-	suspend fun updateFromSync(data: ProjectData, lastSyncedHash: String) = mutex.withLock {
-		val current = _state.value
-		val next = StoredProjectData(data = data, lastSyncedHash = lastSyncedHash)
+	suspend fun updateFromSync(
+		data: ProjectData,
+		lastSyncedHash: String,
+		snapshot: ProjectData,
+	) = mutex.withLock {
+		val current = _state.value ?: datasource.load()
+		val merged = if (current.data == snapshot) data else reapplyLocalEdits(snapshot, current.data, data)
+		val next = StoredProjectData(data = merged, lastSyncedHash = lastSyncedHash)
 		if (current == next) return@withLock
 		datasource.save(next)
 		_state.value = next

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/sync/projectsync/operations/ProjectDataSyncOperation.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/sync/projectsync/operations/ProjectDataSyncOperation.kt
@@ -12,6 +12,8 @@ import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettings
 import com.darkrockstudios.apps.hammer.common.data.projectdata.ProjectDataConflict
 import com.darkrockstudios.apps.hammer.common.data.projectdata.ProjectDataConflictBroker
 import com.darkrockstudios.apps.hammer.common.data.projectdata.ProjectDataRepository
+import com.darkrockstudios.apps.hammer.common.data.projectdata.differsOutsideDictionary
+import com.darkrockstudios.apps.hammer.common.data.projectdata.mergeDictionaryWords
 import com.darkrockstudios.apps.hammer.common.data.sync.projectsync.EntityConflictHandler
 import com.darkrockstudios.apps.hammer.common.data.sync.projectsync.IdConflictResolutionState
 import com.darkrockstudios.apps.hammer.common.data.sync.projectsync.OnSyncLog
@@ -26,6 +28,9 @@ import io.github.aakira.napier.Napier
 /**
  * A non-conflict server error fails the whole sync — unlike writing-activity sync,
  * the data is user-authored and silent loss is unacceptable.
+ *
+ * A conflict confined to [ProjectData.dictionaryWords] is merged by union here and never
+ * reaches the resolver; any other conflicting field still goes through the broker.
  */
 class ProjectDataSyncOperation(
 	projectDef: ProjectDef,
@@ -116,15 +121,21 @@ class ProjectDataSyncOperation(
 			return null
 		}
 
-		onLog(syncLogW("Project data conflict detected", projectDef))
-		broker.reportConflict(
-			ProjectDataConflict(
-				local = data,
-				server = conflict.conflict.server,
-				serverHash = conflict.conflict.serverHash,
+		val server = conflict.conflict.server
+		val resolved = if (data.differsOutsideDictionary(server)) {
+			onLog(syncLogW("Project data conflict detected", projectDef))
+			broker.reportConflict(
+				ProjectDataConflict(
+					local = data,
+					server = server,
+					serverHash = conflict.conflict.serverHash,
+				)
 			)
-		)
-		val resolved = broker.awaitResolution()
+			broker.awaitResolution()
+		} else {
+			onLog(syncLogI("Project data conflict: dictionary words merged", projectDef))
+			data.copy(dictionaryWords = mergeDictionaryWords(data, server))
+		}
 
 		val resolveResult = api.uploadProjectData(
 			userId = userId,

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/sync/projectsync/operations/ProjectDataSyncOperation.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/data/sync/projectsync/operations/ProjectDataSyncOperation.kt
@@ -75,7 +75,7 @@ class ProjectDataSyncOperation(
 			}
 			serverDto.hash == localHash -> {
 				if (lastSyncedHash != serverDto.hash) {
-					repository.updateFromSync(serverDto.data, serverDto.hash)
+					repository.updateFromSync(serverDto.data, serverDto.hash, snapshot = stored.data)
 				}
 				onLog(syncLogI("Project data already in sync", projectDef))
 				return CResult.success(state)
@@ -86,7 +86,7 @@ class ProjectDataSyncOperation(
 				// recording the server hash would make the stored copy look locally edited, and the
 				// next sync would upload it — deleting the newer field server-side. With the stored
 				// hash, an out-of-date device just keeps fast-forwarding harmlessly.
-				repository.updateFromSync(serverDto.data, ProjectDataHasher.hash(serverDto.data))
+				repository.updateFromSync(serverDto.data, ProjectDataHasher.hash(serverDto.data), snapshot = stored.data)
 				onLog(syncLogI("Project data updated from server", projectDef))
 				return CResult.success(state)
 			}
@@ -108,7 +108,7 @@ class ProjectDataSyncOperation(
 		val result = api.uploadProjectData(userId, projectId, data, originalHash)
 		val success = result.getOrNull()
 		if (success != null) {
-			repository.updateFromSync(success.data, success.hash)
+			repository.updateFromSync(success.data, success.hash, snapshot = data)
 			onLog(syncLogI("Project data synced", projectDef))
 			return success
 		}
@@ -150,7 +150,7 @@ class ProjectDataSyncOperation(
 			onLog(syncLogE("Project data conflict resolution failed: ${resolveError?.message}", projectDef))
 			return null
 		}
-		repository.updateFromSync(resolvedDto.data, resolvedDto.hash)
+		repository.updateFromSync(resolvedDto.data, resolvedDto.hash, snapshot = data)
 		onLog(syncLogI("Project data synced", projectDef))
 		return resolvedDto
 	}

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/dependencyinjection/mainModule.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/dependencyinjection/mainModule.kt
@@ -118,6 +118,7 @@ import com.darkrockstudios.apps.hammer.common.server.ServerIdeasApi
 import com.darkrockstudios.apps.hammer.common.server.ServerProjectsApi
 import com.darkrockstudios.apps.hammer.common.server.WritingActivityApi
 import com.darkrockstudios.apps.hammer.common.spellcheck.ProjectDictionaryService
+import com.darkrockstudios.apps.hammer.common.spellcheck.ProjectDictionaryUseCase
 import com.darkrockstudios.apps.hammer.common.spellcheck.ProjectSpellCheckRepository
 import com.darkrockstudios.apps.hammer.common.spellcheck.SpellCheckRepository
 import com.russhwolf.settings.Settings
@@ -291,6 +292,7 @@ val mainModule = module {
 		scoped<ProjectDataConflictBroker>()
 		scoped<ProjectSpellCheckRepository>()
 		scoped<ProjectDictionaryService>()
+		factory<ProjectDictionaryUseCase>()
 
 		scoped<ReferenceIndexDatasource>()
 		scoped<ReferenceIndexRepository>()

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/spellcheck/ProjectDictionaryService.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/spellcheck/ProjectDictionaryService.kt
@@ -25,9 +25,10 @@ import org.koin.core.scope.ScopeCallback
 import kotlin.time.Duration.Companion.milliseconds
 
 /**
- * Feeds the project's Encyclopedia entry names and aliases to the spell checker as
- * session words for the lifetime of the project scope. Gated on spell check being
- * enabled, the global feature setting and the project's own toggle, all live-reactive.
+ * Feeds the project's user dictionary words, plus its Encyclopedia entry names and
+ * aliases, to the spell checker as session words for the lifetime of the project
+ * scope. Gated on spell check being enabled; the encyclopedia half is further gated
+ * on the global feature setting and the project's own toggle, all live-reactive.
  */
 @OptIn(FlowPreview::class)
 class ProjectDictionaryService(
@@ -52,12 +53,15 @@ class ProjectDictionaryService(
 			combine(
 				projectSpellCheckRepository.spellCheckEnabled,
 				projectSpellCheckRepository.encyclopediaDictionaryEnabled,
+				projectSpellCheckRepository.userDictionaryWords,
 				encyclopediaRepository.entryContentChangedFlow.onStart { emit(Unit) },
-			) { spellCheckOn, featureOn, _ -> spellCheckOn && featureOn }
+			) { spellCheckOn, encyclopediaOn, userWords, _ ->
+				if (spellCheckOn) Sources(encyclopediaOn, userWords) else null
+			}
 				.debounce(REBUILD_DEBOUNCE)
-				.collect { enabled ->
-					if (enabled) {
-						rebuild()
+				.collect { sources ->
+					if (sources != null) {
+						rebuild(sources)
 					} else {
 						spellCheckRepository.clearSessionWords(projectDef)
 					}
@@ -65,21 +69,16 @@ class ProjectDictionaryService(
 		}
 	}
 
+	private data class Sources(val encyclopediaOn: Boolean, val userWords: Set<String>)
+
 	@Suppress("TooGenericExceptionCaught") // Background rebuild must not crash on any failure
-	private suspend fun rebuild() {
+	private suspend fun rebuild(sources: Sources) {
 		try {
-			// entryListFlow's replay cache is not refreshed by entry writes, so force a
-			// reload before reading defs - renames change EntryDef.name.
-			val defs = encyclopediaRepository.loadEntriesImperative()
-			val words = coroutineScope {
-				defs.map { def ->
-					async {
-						val entry = encyclopediaRepository.loadEntry(def).entry
-						if (entry.excludeFromDictionary) emptySet()
-						else tokenizeDictionaryWords(listOf(entry.name) + entry.aliases)
-					}
-				}.awaitAll()
-			}.flatten().toSet()
+			val encyclopediaWords = if (sources.encyclopediaOn) loadEncyclopediaWords() else emptySet()
+			// Both the exact spelling and the tokenized form go in: the tokenizer lowercases,
+			// which is what the encyclopedia path relies on, but a mixed-case word like
+			// "McKinley" must also be accepted as typed.
+			val words = encyclopediaWords + sources.userWords + tokenizeDictionaryWords(sources.userWords)
 			// Never push words after onScopeClose has cleared them: close cancels this
 			// scope first, so a rebuild that raced past its last suspension bails here.
 			if (!currentCoroutineContext().isActive) return
@@ -89,6 +88,21 @@ class ProjectDictionaryService(
 		} catch (t: Throwable) {
 			Napier.e("ProjectDictionaryService rebuild failed", t)
 		}
+	}
+
+	private suspend fun loadEncyclopediaWords(): Set<String> {
+		// entryListFlow's replay cache is not refreshed by entry writes, so force a
+		// reload before reading defs - renames change EntryDef.name.
+		val defs = encyclopediaRepository.loadEntriesImperative()
+		return coroutineScope {
+			defs.map { def ->
+				async {
+					val entry = encyclopediaRepository.loadEntry(def).entry
+					if (entry.excludeFromDictionary) emptySet()
+					else tokenizeDictionaryWords(listOf(entry.name) + entry.aliases)
+				}
+			}.awaitAll()
+		}.flatten().toSet()
 	}
 
 	override fun onScopeClose(scope: Scope) {

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/spellcheck/ProjectDictionaryService.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/spellcheck/ProjectDictionaryService.kt
@@ -8,6 +8,7 @@ import com.darkrockstudios.apps.hammer.common.dependencyinjection.injectDefaultD
 import io.github.aakira.napier.Napier
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
@@ -16,6 +17,7 @@ import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.debounce
+import kotlinx.coroutines.flow.mapLatest
 import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
@@ -30,7 +32,7 @@ import kotlin.time.Duration.Companion.milliseconds
  * scope. Gated on spell check being enabled; the encyclopedia half is further gated
  * on the global feature setting and the project's own toggle, all live-reactive.
  */
-@OptIn(FlowPreview::class)
+@OptIn(FlowPreview::class, ExperimentalCoroutinesApi::class)
 class ProjectDictionaryService(
 	private val projectDef: ProjectDef,
 	private val encyclopediaRepository: EncyclopediaRepository,
@@ -50,18 +52,32 @@ class ProjectDictionaryService(
 	/** Starts watching for words to load; called from initializeProjectScope on project open. */
 	fun initialize() {
 		serviceScope.launch {
+			// Entries are only re-read when one changes or the feature toggles; a user word
+			// edit unions into the cached set without touching the encyclopedia on disk.
+			val encyclopediaWords = combine(
+				projectSpellCheckRepository.encyclopediaDictionaryEnabled,
+				encyclopediaRepository.entryContentChangedFlow.onStart { emit(Unit) },
+			) { enabled, _ -> enabled }
+				.debounce(REBUILD_DEBOUNCE)
+				.mapLatest { enabled -> if (enabled) loadEncyclopediaWords() else emptySet() }
+
 			combine(
 				projectSpellCheckRepository.spellCheckEnabled,
-				projectSpellCheckRepository.encyclopediaDictionaryEnabled,
+				encyclopediaWords,
 				projectSpellCheckRepository.userDictionaryWords,
-				encyclopediaRepository.entryContentChangedFlow.onStart { emit(Unit) },
-			) { spellCheckOn, encyclopediaOn, userWords, _ ->
-				if (spellCheckOn) Sources(encyclopediaOn, userWords) else null
+			) { spellCheckOn, encyclopedia, userWords ->
+				// Both the exact spelling and the tokenized form go in: the tokenizer lowercases,
+				// which is what the encyclopedia path relies on, but a mixed-case word like
+				// "McKinley" must also be accepted as typed.
+				if (spellCheckOn) encyclopedia + userWords + tokenizeDictionaryWords(userWords) else null
 			}
 				.debounce(REBUILD_DEBOUNCE)
-				.collect { sources ->
-					if (sources != null) {
-						rebuild(sources)
+				.collect { words ->
+					// Never push words after onScopeClose has cleared them: close cancels this
+					// scope first, so a collect that raced past its last suspension bails here.
+					if (!currentCoroutineContext().isActive) return@collect
+					if (words != null) {
+						spellCheckRepository.setSessionWords(projectDef, words)
 					} else {
 						spellCheckRepository.clearSessionWords(projectDef)
 					}
@@ -69,40 +85,27 @@ class ProjectDictionaryService(
 		}
 	}
 
-	private data class Sources(val encyclopediaOn: Boolean, val userWords: Set<String>)
-
-	@Suppress("TooGenericExceptionCaught") // Background rebuild must not crash on any failure
-	private suspend fun rebuild(sources: Sources) {
+	@Suppress("TooGenericExceptionCaught") // A failed reload must not kill the collector
+	private suspend fun loadEncyclopediaWords(): Set<String> {
 		try {
-			val encyclopediaWords = if (sources.encyclopediaOn) loadEncyclopediaWords() else emptySet()
-			// Both the exact spelling and the tokenized form go in: the tokenizer lowercases,
-			// which is what the encyclopedia path relies on, but a mixed-case word like
-			// "McKinley" must also be accepted as typed.
-			val words = encyclopediaWords + sources.userWords + tokenizeDictionaryWords(sources.userWords)
-			// Never push words after onScopeClose has cleared them: close cancels this
-			// scope first, so a rebuild that raced past its last suspension bails here.
-			if (!currentCoroutineContext().isActive) return
-			spellCheckRepository.setSessionWords(projectDef, words)
+			// entryListFlow's replay cache is not refreshed by entry writes, so force a
+			// reload before reading defs - renames change EntryDef.name.
+			val defs = encyclopediaRepository.loadEntriesImperative()
+			return coroutineScope {
+				defs.map { def ->
+					async {
+						val entry = encyclopediaRepository.loadEntry(def).entry
+						if (entry.excludeFromDictionary) emptySet()
+						else tokenizeDictionaryWords(listOf(entry.name) + entry.aliases)
+					}
+				}.awaitAll()
+			}.flatMapTo(mutableSetOf()) { it }
 		} catch (e: CancellationException) {
 			throw e
 		} catch (t: Throwable) {
-			Napier.e("ProjectDictionaryService rebuild failed", t)
+			Napier.e("ProjectDictionaryService encyclopedia reload failed", t)
+			return emptySet()
 		}
-	}
-
-	private suspend fun loadEncyclopediaWords(): Set<String> {
-		// entryListFlow's replay cache is not refreshed by entry writes, so force a
-		// reload before reading defs - renames change EntryDef.name.
-		val defs = encyclopediaRepository.loadEntriesImperative()
-		return coroutineScope {
-			defs.map { def ->
-				async {
-					val entry = encyclopediaRepository.loadEntry(def).entry
-					if (entry.excludeFromDictionary) emptySet()
-					else tokenizeDictionaryWords(listOf(entry.name) + entry.aliases)
-				}
-			}.awaitAll()
-		}.flatten().toSet()
 	}
 
 	override fun onScopeClose(scope: Scope) {

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/spellcheck/ProjectDictionaryUseCase.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/spellcheck/ProjectDictionaryUseCase.kt
@@ -1,0 +1,19 @@
+package com.darkrockstudios.apps.hammer.common.spellcheck
+
+import com.darkrockstudios.apps.hammer.common.data.projectdata.ProjectDataRepository
+
+/** Edits the project's user dictionary words; every writer goes through [normalizeDictionaryWord]. */
+class ProjectDictionaryUseCase(
+	private val projectDataRepository: ProjectDataRepository,
+) {
+	/** Returns false when [raw] normalizes to nothing storable. */
+	suspend fun addWord(raw: String): Boolean {
+		val word = normalizeDictionaryWord(raw) ?: return false
+		projectDataRepository.updateData { it.copy(dictionaryWords = it.dictionaryWords + word) }
+		return true
+	}
+
+	suspend fun removeWord(word: String) {
+		projectDataRepository.updateData { it.copy(dictionaryWords = it.dictionaryWords - word) }
+	}
+}

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/spellcheck/ProjectDictionaryUseCase.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/spellcheck/ProjectDictionaryUseCase.kt
@@ -6,11 +6,13 @@ import com.darkrockstudios.apps.hammer.common.data.projectdata.ProjectDataReposi
 class ProjectDictionaryUseCase(
 	private val projectDataRepository: ProjectDataRepository,
 ) {
-	/** Returns false when [raw] normalizes to nothing storable. */
-	suspend fun addWord(raw: String): Boolean {
-		val word = normalizeDictionaryWord(raw) ?: return false
-		projectDataRepository.updateData { it.copy(dictionaryWords = it.dictionaryWords + word) }
-		return true
+	/** Input that normalizes to nothing storable, or a word already present in any case, is ignored. */
+	suspend fun addWord(raw: String) {
+		val word = normalizeDictionaryWord(raw) ?: return
+		projectDataRepository.updateData { data ->
+			if (data.dictionaryWords.any { it.equals(word, ignoreCase = true) }) data
+			else data.copy(dictionaryWords = data.dictionaryWords + word)
+		}
 	}
 
 	suspend fun removeWord(word: String) {

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/spellcheck/ProjectSpellCheckRepository.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/spellcheck/ProjectSpellCheckRepository.kt
@@ -64,9 +64,9 @@ class ProjectSpellCheckRepository(
 		.onStart { projectDataRepository.load() }
 		.distinctUntilChanged()
 
-	/** The project's user-added dictionary words, as stored. */
+	/** The project's user-added dictionary words. Cleaned on read: the stored set may come from sync. */
 	val userDictionaryWords: Flow<Set<String>> = projectDataRepository.state
-		.map { stored -> stored?.data?.dictionaryWords ?: emptySet() }
+		.map { stored -> cleanDictionaryWords(stored?.data?.dictionaryWords ?: emptySet()) }
 		.onStart { projectDataRepository.load() }
 		.distinctUntilChanged()
 }

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/spellcheck/ProjectSpellCheckRepository.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/spellcheck/ProjectSpellCheckRepository.kt
@@ -63,4 +63,10 @@ class ProjectSpellCheckRepository(
 	}
 		.onStart { projectDataRepository.load() }
 		.distinctUntilChanged()
+
+	/** The project's user-added dictionary words, as stored. */
+	val userDictionaryWords: Flow<Set<String>> = projectDataRepository.state
+		.map { stored -> stored?.data?.dictionaryWords ?: emptySet() }
+		.onStart { projectDataRepository.load() }
+		.distinctUntilChanged()
 }

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/spellcheck/UserDictionaryWords.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/spellcheck/UserDictionaryWords.kt
@@ -1,18 +1,21 @@
 package com.darkrockstudios.apps.hammer.common.spellcheck
 
+import com.darkrockstudios.apps.hammer.common.data.tagindex.normalizeTagForm
+
 const val MAX_DICTIONARY_WORD_LENGTH = 64
 
 /**
- * The single normalization rule for user dictionary words: trimmed, one token, bounded length.
- * Case is kept as typed. Returns null for input that must not be stored.
+ * The single normalization rule for user dictionary words: NFC form, trimmed, one token,
+ * bounded length. Case is kept as typed. Returns null for input that must not be stored.
  */
 fun normalizeDictionaryWord(raw: String): String? {
-	val word = raw.trim()
+	val word = normalizeTagForm(raw.trim())
 	if (word.isEmpty()) return null
 	if (word.any { it.isWhitespace() }) return null
 	if (word.length > MAX_DICTIONARY_WORD_LENGTH) return null
 	return word
 }
 
+/** Applied wherever words enter from outside the local add path (sync, disk). */
 fun cleanDictionaryWords(words: Iterable<String>): Set<String> =
 	words.mapNotNullTo(mutableSetOf(), ::normalizeDictionaryWord)

--- a/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/spellcheck/UserDictionaryWords.kt
+++ b/common/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/spellcheck/UserDictionaryWords.kt
@@ -1,0 +1,18 @@
+package com.darkrockstudios.apps.hammer.common.spellcheck
+
+const val MAX_DICTIONARY_WORD_LENGTH = 64
+
+/**
+ * The single normalization rule for user dictionary words: trimmed, one token, bounded length.
+ * Case is kept as typed. Returns null for input that must not be stored.
+ */
+fun normalizeDictionaryWord(raw: String): String? {
+	val word = raw.trim()
+	if (word.isEmpty()) return null
+	if (word.any { it.isWhitespace() }) return null
+	if (word.length > MAX_DICTIONARY_WORD_LENGTH) return null
+	return word
+}
+
+fun cleanDictionaryWords(words: Iterable<String>): Set<String> =
+	words.mapNotNullTo(mutableSetOf(), ::normalizeDictionaryWord)

--- a/common/src/commonTest/kotlin/com/darkrockstudios/apps/hammer/common/data/projectdata/ProjectDataMergeTest.kt
+++ b/common/src/commonTest/kotlin/com/darkrockstudios/apps/hammer/common/data/projectdata/ProjectDataMergeTest.kt
@@ -1,0 +1,50 @@
+package com.darkrockstudios.apps.hammer.common.data.projectdata
+
+import com.darkrockstudios.apps.hammer.base.http.projectdata.ProjectData
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class ProjectDataMergeTest {
+
+	@Test
+	fun `merged dictionary words are the cleaned union`() {
+		val local = ProjectData(dictionaryWords = setOf("Kvothe", "two words"))
+		val server = ProjectData(dictionaryWords = setOf("Denna", " Imre "))
+
+		assertEquals(setOf("Kvothe", "Denna", "Imre"), mergeDictionaryWords(local, server))
+	}
+
+	@Test
+	fun `differsOutsideDictionary ignores the dictionary and nothing else`() {
+		val base = ProjectData(authorName = "Pat", dictionaryWords = setOf("a"))
+
+		assertFalse(base.differsOutsideDictionary(base.copy(dictionaryWords = setOf("b"))))
+		assertTrue(base.differsOutsideDictionary(base.copy(authorName = "Sam")))
+	}
+
+	@Test
+	fun `reapplyLocalEdits keeps changed fields and takes the rest from incoming`() {
+		val base = ProjectData(authorName = "Pat", language = "en")
+		val local = base.copy(authorName = "Edited")
+		val incoming = ProjectData(authorName = "Server", language = "fr")
+
+		assertEquals(
+			ProjectData(authorName = "Edited", language = "fr"),
+			reapplyLocalEdits(base, local, incoming),
+		)
+	}
+
+	@Test
+	fun `reapplyLocalEdits carries dictionary additions and removals as a delta`() {
+		val base = ProjectData(dictionaryWords = setOf("keep", "drop"))
+		val local = base.copy(dictionaryWords = setOf("keep", "added"))
+		val incoming = ProjectData(dictionaryWords = setOf("keep", "drop", "server"))
+
+		assertEquals(
+			setOf("keep", "server", "added"),
+			reapplyLocalEdits(base, local, incoming).dictionaryWords,
+		)
+	}
+}

--- a/common/src/commonTest/kotlin/com/darkrockstudios/apps/hammer/common/spellcheck/UserDictionaryWordsTest.kt
+++ b/common/src/commonTest/kotlin/com/darkrockstudios/apps/hammer/common/spellcheck/UserDictionaryWordsTest.kt
@@ -1,0 +1,42 @@
+package com.darkrockstudios.apps.hammer.common.spellcheck
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class UserDictionaryWordsTest {
+
+	@Test
+	fun `surrounding whitespace is trimmed`() {
+		assertEquals("Kvothe", normalizeDictionaryWord("  Kvothe\t"))
+	}
+
+	@Test
+	fun `case is preserved`() {
+		assertEquals("McKinley", normalizeDictionaryWord("McKinley"))
+	}
+
+	@Test
+	fun `blank input is rejected`() {
+		assertNull(normalizeDictionaryWord("   "))
+	}
+
+	@Test
+	fun `multi-word input is rejected`() {
+		assertNull(normalizeDictionaryWord("two words"))
+	}
+
+	@Test
+	fun `overlong input is rejected`() {
+		assertNull(normalizeDictionaryWord("a".repeat(MAX_DICTIONARY_WORD_LENGTH + 1)))
+		assertEquals("a".repeat(MAX_DICTIONARY_WORD_LENGTH), normalizeDictionaryWord("a".repeat(MAX_DICTIONARY_WORD_LENGTH)))
+	}
+
+	@Test
+	fun `cleaning drops invalid entries and dedupes`() {
+		assertEquals(
+			setOf("alpha", "beta"),
+			cleanDictionaryWords(listOf(" alpha ", "", "two words", "beta", "alpha")),
+		)
+	}
+}

--- a/common/src/commonTest/kotlin/com/darkrockstudios/apps/hammer/common/spellcheck/UserDictionaryWordsTest.kt
+++ b/common/src/commonTest/kotlin/com/darkrockstudios/apps/hammer/common/spellcheck/UserDictionaryWordsTest.kt
@@ -17,6 +17,11 @@ class UserDictionaryWordsTest {
 	}
 
 	@Test
+	fun `decomposed characters are composed`() {
+		assertEquals("\u00e8", normalizeDictionaryWord("e\u0300"))
+	}
+
+	@Test
 	fun `blank input is rejected`() {
 		assertNull(normalizeDictionaryWord("   "))
 	}

--- a/common/src/desktopTest/kotlin/components/projecthome/ProjectSettingsComponentTest.kt
+++ b/common/src/desktopTest/kotlin/components/projecthome/ProjectSettingsComponentTest.kt
@@ -18,6 +18,7 @@ import com.darkrockstudios.apps.hammer.common.data.tagindex.AccountTagService
 import com.darkrockstudios.apps.hammer.common.dependencyinjection.ProjectDefScope
 import com.darkrockstudios.apps.hammer.common.dependencyinjection.createTomlSerializer
 import com.darkrockstudios.apps.hammer.common.fileio.okio.toOkioPath
+import com.darkrockstudios.apps.hammer.common.spellcheck.ProjectDictionaryUseCase
 import com.darkrockstudios.apps.hammer.common.util.AvailableLocalesProvider
 import com.darkrockstudios.apps.hammer.common.util.Locale
 import com.darkrockstudios.libs.platformspellchecker.PlatformSpellCheckerFactory
@@ -82,6 +83,7 @@ class ProjectSettingsComponentTest : ComponentTest() {
 			}
 			scope<ProjectDefScope> {
 				scoped { ProjectDataRepository(datasource, projectDef) }
+				scoped { ProjectDictionaryUseCase(get()) }
 				scoped<SyncDataDatasource> { mockk(relaxed = true) }
 			}
 		})
@@ -183,6 +185,46 @@ class ProjectSettingsComponentTest : ComponentTest() {
 
 		assertEquals(goal, comp.projectInfoState.value.data.wordCountGoal)
 		assertEquals(goal, datasource.load().data.wordCountGoal)
+	}
+
+	@Test
+	fun `addDictionaryWord normalizes and persists`() = runTest(mainTestDispatcher) {
+		val comp = newComponent()
+		context.resume()
+		advanceUntilIdle()
+
+		comp.addDictionaryWord("  Kvothe ")
+		advanceUntilIdle()
+
+		assertEquals(setOf("Kvothe"), comp.projectInfoState.value.data.dictionaryWords)
+		assertEquals(setOf("Kvothe"), datasource.load().data.dictionaryWords)
+	}
+
+	@Test
+	fun `addDictionaryWord ignores input that is not a single word`() = runTest(mainTestDispatcher) {
+		val comp = newComponent()
+		context.resume()
+		advanceUntilIdle()
+
+		comp.addDictionaryWord("two words")
+		comp.addDictionaryWord("   ")
+		advanceUntilIdle()
+
+		assertEquals(emptySet(), comp.projectInfoState.value.data.dictionaryWords)
+	}
+
+	@Test
+	fun `removeDictionaryWord persists the removal`() = runTest(mainTestDispatcher) {
+		datasource.save(StoredProjectData(data = ProjectData(dictionaryWords = setOf("Kvothe", "Denna"))))
+		val comp = newComponent()
+		context.resume()
+		advanceUntilIdle()
+
+		comp.removeDictionaryWord("Kvothe")
+		advanceUntilIdle()
+
+		assertEquals(setOf("Denna"), comp.projectInfoState.value.data.dictionaryWords)
+		assertEquals(setOf("Denna"), datasource.load().data.dictionaryWords)
 	}
 
 	@Test

--- a/common/src/desktopTest/kotlin/components/projecthome/ProjectSettingsComponentTest.kt
+++ b/common/src/desktopTest/kotlin/components/projecthome/ProjectSettingsComponentTest.kt
@@ -214,6 +214,19 @@ class ProjectSettingsComponentTest : ComponentTest() {
 	}
 
 	@Test
+	fun `addDictionaryWord ignores a word already present in another case`() = runTest(mainTestDispatcher) {
+		datasource.save(StoredProjectData(data = ProjectData(dictionaryWords = setOf("Kvothe"))))
+		val comp = newComponent()
+		context.resume()
+		advanceUntilIdle()
+
+		comp.addDictionaryWord("kvothe")
+		advanceUntilIdle()
+
+		assertEquals(setOf("Kvothe"), datasource.load().data.dictionaryWords)
+	}
+
+	@Test
 	fun `removeDictionaryWord persists the removal`() = runTest(mainTestDispatcher) {
 		datasource.save(StoredProjectData(data = ProjectData(dictionaryWords = setOf("Kvothe", "Denna"))))
 		val comp = newComponent()

--- a/common/src/desktopTest/kotlin/components/storyeditor/focusmode/FocusModeComponentTest.kt
+++ b/common/src/desktopTest/kotlin/components/storyeditor/focusmode/FocusModeComponentTest.kt
@@ -10,8 +10,10 @@ import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettings
 import com.darkrockstudios.apps.hammer.common.data.globalsettings.GlobalSettingsStore
 import com.darkrockstudios.apps.hammer.common.data.sceneeditorrepository.SceneEditorService
 import com.darkrockstudios.apps.hammer.common.dependencyinjection.ProjectDefScope
+import com.darkrockstudios.apps.hammer.common.spellcheck.ProjectDictionaryUseCase
 import com.darkrockstudios.apps.hammer.common.spellcheck.ProjectSpellCheckRepository
 import io.mockk.coEvery
+import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.slot
@@ -34,6 +36,7 @@ class FocusModeComponentTest : ComponentTest() {
 	private lateinit var settingsStore: GlobalSettingsStore
 	private lateinit var focusModeService: FocusModeService
 	private lateinit var sceneEditor: SceneEditorService
+	private lateinit var projectDictionary: ProjectDictionaryUseCase
 	private lateinit var settingsUpdates: MutableSharedFlow<GlobalSettings>
 
 	private val bufferCallback = slot<suspend (SceneBuffer) -> Unit>()
@@ -72,10 +75,12 @@ class FocusModeComponentTest : ComponentTest() {
 
 		val spellCheckRepository = mockk<ProjectSpellCheckRepository>(relaxed = true)
 		every { spellCheckRepository.dictionaryFlow } returns MutableSharedFlow()
+		projectDictionary = mockk(relaxed = true)
 
 		setupComponentKoin(module {
 			single { settingsStore }
 			single { spellCheckRepository }
+			single { projectDictionary }
 			single { focusModeService }
 			scope<ProjectDefScope> {
 				scoped { sceneEditor }
@@ -111,6 +116,18 @@ class FocusModeComponentTest : ComponentTest() {
 		context.stop()
 		advanceUntilIdle()
 		verify(exactly = 1) { focusModeService.exitFocusMode() }
+	}
+
+	@Test
+	fun `addWordToDictionary delegates to the project dictionary`() = runTest(mainTestDispatcher) {
+		val comp = newComponent()
+		context.resume()
+		advanceUntilIdle()
+
+		comp.addWordToDictionary("Kvothe")
+		advanceUntilIdle()
+
+		coVerify(exactly = 1) { projectDictionary.addWord("Kvothe") }
 	}
 
 	@Test

--- a/common/src/desktopTest/kotlin/components/storyeditor/sceneeditor/SceneEditorComponentTest.kt
+++ b/common/src/desktopTest/kotlin/components/storyeditor/sceneeditor/SceneEditorComponentTest.kt
@@ -13,6 +13,7 @@ import com.darkrockstudios.apps.hammer.common.data.references.ScrubInvalidRefere
 import com.darkrockstudios.apps.hammer.common.data.sceneeditorrepository.SceneEditorService
 import com.darkrockstudios.apps.hammer.common.data.tree.ImmutableTree
 import com.darkrockstudios.apps.hammer.common.data.tree.TreeValue
+import com.darkrockstudios.apps.hammer.common.spellcheck.ProjectDictionaryUseCase
 import com.darkrockstudios.apps.hammer.common.spellcheck.ProjectSpellCheckRepository
 import com.darkrockstudios.libs.platformspellchecker.PlatformSpellChecker
 import io.mockk.*
@@ -46,6 +47,7 @@ class SceneEditorComponentTest : ComponentTest() {
 	private lateinit var draftsRepository: SceneDraftRepository
 	private lateinit var autoConfirm: AutoConfirmReferencesUseCase
 	private lateinit var spellCheck: ProjectSpellCheckRepository
+	private lateinit var projectDictionary: ProjectDictionaryUseCase
 
 	private lateinit var settingsUpdates: MutableSharedFlow<GlobalSettings>
 	private lateinit var dictionaryFlow: MutableSharedFlow<PlatformSpellChecker?>
@@ -98,9 +100,12 @@ class SceneEditorComponentTest : ComponentTest() {
 		} returns mockk(relaxed = true)
 		every { sceneEditor.subscribeToSceneUpdates(any(), capture(sceneTreeCallback)) } returns mockk(relaxed = true)
 
+		projectDictionary = mockk(relaxed = true)
+
 		setupComponentKoin(module {
 			single<GlobalSettingsStore> { settingsStore }
 			single<ProjectSpellCheckRepository> { spellCheck }
+			single { projectDictionary }
 			single { sceneEditor } bind SceneEditorService::class
 			single { draftsRepository } bind SceneDraftRepository::class
 			single { autoConfirm } bind AutoConfirmReferencesUseCase::class
@@ -148,6 +153,17 @@ class SceneEditorComponentTest : ComponentTest() {
 
 		assertFalse(comp.state.value.spellCheckingEnabled)
 		assertFalse(comp.state.value.metadataPanelVisible)
+	}
+
+	@Test
+	fun `addWordToDictionary delegates to the project dictionary`() = runTest(mainTestDispatcher) {
+		val comp = newComponent()
+		comp.onCreate()
+
+		comp.addWordToDictionary("Kvothe")
+		advanceUntilIdle()
+
+		coVerify(exactly = 1) { projectDictionary.addWord("Kvothe") }
 	}
 
 	// --- scene name ----------------------------------------------------------

--- a/common/src/desktopTest/kotlin/data/ProjectEditorScopeUtilsTest.kt
+++ b/common/src/desktopTest/kotlin/data/ProjectEditorScopeUtilsTest.kt
@@ -1,0 +1,73 @@
+package data
+
+import PROJECT_EMPTY_NAME
+import com.darkrockstudios.apps.hammer.common.data.closeProjectScope
+import com.darkrockstudios.apps.hammer.common.data.openProjectScope
+import com.darkrockstudios.apps.hammer.common.data.sceneeditorrepository.SceneEditorService
+import com.darkrockstudios.apps.hammer.common.data.temporaryProjectTask
+import com.darkrockstudios.apps.hammer.common.data.timelinerepository.TimeLineRepository
+import com.darkrockstudios.apps.hammer.common.dependencyinjection.ProjectDefScope
+import com.darkrockstudios.apps.hammer.common.spellcheck.ProjectDictionaryService
+import getProjectDef
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.koin.core.component.getScopeId
+import org.koin.dsl.module
+import utils.BaseTest
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+
+class ProjectEditorScopeUtilsTest : BaseTest() {
+
+	private val projectDef = getProjectDef(PROJECT_EMPTY_NAME)
+	private lateinit var dictionaryService: ProjectDictionaryService
+
+	@BeforeEach
+	override fun setup() {
+		super.setup()
+		dictionaryService = mockk(relaxed = true)
+		setupKoin(module {
+			scope<ProjectDefScope> {
+				scoped { projectDef }
+				scoped<SceneEditorService> { mockk(relaxed = true) }
+				scoped<TimeLineRepository> { mockk(relaxed = true) }
+				scoped { dictionaryService }
+			}
+		})
+	}
+
+	private fun scopeOrNull() = getKoin().getScopeOrNull(ProjectDefScope(projectDef).getScopeId())
+
+	@Test
+	fun `a temporary task alone never starts the editor services and closes its scope`() = runTest {
+		temporaryProjectTask(projectDef) {}
+
+		verify(exactly = 0) { dictionaryService.initialize() }
+		assertNull(scopeOrNull())
+	}
+
+	@Test
+	fun `opening for editing while a temporary task holds the scope starts the editor services and keeps the scope`() =
+		runTest {
+			temporaryProjectTask(projectDef) {
+				verify(exactly = 0) { dictionaryService.initialize() }
+				openProjectScope(projectDef)
+				verify(exactly = 1) { dictionaryService.initialize() }
+			}
+
+			val scope = assertNotNull(scopeOrNull())
+			closeProjectScope(scope, projectDef)
+		}
+
+	@Test
+	fun `reopening for editing does not start the editor services twice`() = runTest {
+		openProjectScope(projectDef)
+		openProjectScope(projectDef)
+
+		verify(exactly = 1) { dictionaryService.initialize() }
+		closeProjectScope(assertNotNull(scopeOrNull()), projectDef)
+	}
+}

--- a/common/src/desktopTest/kotlin/repositories/projectdata/ProjectDataRepositoryTest.kt
+++ b/common/src/desktopTest/kotlin/repositories/projectdata/ProjectDataRepositoryTest.kt
@@ -169,9 +169,9 @@ class ProjectDataRepositoryTest : BaseTest() {
 
 	@Test
 	fun `updateFromSync replaces both data and the synced hash`() = runTest {
-		repository.load()
+		val snapshot = repository.load().data
 
-		repository.updateFromSync(ProjectData(authorName = "Server"), "server-hash")
+		repository.updateFromSync(ProjectData(authorName = "Server"), "server-hash", snapshot)
 
 		assertEquals(
 			StoredProjectData(ProjectData(authorName = "Server"), "server-hash"),
@@ -187,11 +187,34 @@ class ProjectDataRepositoryTest : BaseTest() {
 
 	@Test
 	fun `updateFromSync is idempotent`() = runTest {
-		repository.updateFromSync(ProjectData(authorName = "Server"), "server-hash")
-		repository.updateFromSync(ProjectData(authorName = "Server"), "server-hash")
+		val snapshot = repository.load().data
+		repository.updateFromSync(ProjectData(authorName = "Server"), "server-hash", snapshot)
+		repository.updateFromSync(ProjectData(authorName = "Server"), "server-hash", snapshot)
 
 		assertEquals(
 			StoredProjectData(ProjectData(authorName = "Server"), "server-hash"),
+			repository.state.value,
+		)
+	}
+
+	@Test
+	fun `updateFromSync keeps edits made after the snapshot`() = runTest {
+		val snapshot = repository.load().data
+
+		// Lands while the sync's network round-trip is in flight.
+		repository.updateData { it.copy(dictionaryWords = setOf("local"), authorName = "Edited") }
+
+		repository.updateFromSync(
+			ProjectData(authorName = "Server", language = "en", dictionaryWords = setOf("server")),
+			"server-hash",
+			snapshot,
+		)
+
+		assertEquals(
+			StoredProjectData(
+				ProjectData(authorName = "Edited", language = "en", dictionaryWords = setOf("server", "local")),
+				"server-hash",
+			),
 			repository.state.value,
 		)
 	}

--- a/common/src/desktopTest/kotlin/repositories/spellcheck/ProjectDictionaryServiceTest.kt
+++ b/common/src/desktopTest/kotlin/repositories/spellcheck/ProjectDictionaryServiceTest.kt
@@ -280,6 +280,44 @@ class ProjectDictionaryServiceTest : BaseTest() {
 	}
 
 	@Test
+	fun `user dictionary words are pushed exactly and lowercased`() = scope.runTest {
+		projectDataRepository.updateData { it.copy(dictionaryWords = setOf("McKinley")) }
+
+		createService()
+		advanceUntilIdle()
+
+		assertEquals(setOf("McKinley", "mckinley"), appliedPerChecker.last())
+	}
+
+	@Test
+	fun `user dictionary words do not depend on the encyclopedia feature`() = scope.runTest {
+		createEntry("Zaltharion")
+		projectDataRepository.updateData {
+			it.copy(dictionaryWords = setOf("kvothe"), encyclopediaDictionary = false)
+		}
+
+		createService()
+		advanceUntilIdle()
+
+		assertEquals(setOf("kvothe"), appliedPerChecker.last())
+	}
+
+	@Test
+	fun `adding and removing a user word after start updates the checker`() = scope.runTest {
+		createEntry("Zaltharion")
+		createService()
+		advanceUntilIdle()
+
+		projectDataRepository.updateData { it.copy(dictionaryWords = setOf("kvothe")) }
+		advanceUntilIdle()
+		assertEquals(setOf("zaltharion", "kvothe"), appliedPerChecker.last())
+
+		projectDataRepository.updateData { it.copy(dictionaryWords = emptySet()) }
+		advanceUntilIdle()
+		assertEquals(setOf("zaltharion"), appliedPerChecker.last())
+	}
+
+	@Test
 	fun `closing the project scope clears the words`() = scope.runTest {
 		createEntry("Zaltharion")
 		val service = createService()

--- a/common/src/desktopTest/kotlin/repositories/spellcheck/ProjectDictionaryServiceTest.kt
+++ b/common/src/desktopTest/kotlin/repositories/spellcheck/ProjectDictionaryServiceTest.kt
@@ -28,7 +28,10 @@ import getProjectDef
 import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.just
+import io.mockk.clearMocks
+import io.mockk.coVerify
 import io.mockk.mockk
+import io.mockk.spyk
 import io.mockk.Runs
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.advanceUntilIdle
@@ -113,16 +116,18 @@ class ProjectDictionaryServiceTest : BaseTest() {
 		createProject(fileSystem, PROJECT_EMPTY_NAME)
 
 		val toml = createTomlSerializer()
-		encyclopediaRepository = EncyclopediaRepository(
-			projectDef = projectDef,
-			idAllocator = idAllocator,
-			datasource = EncyclopediaDatasource(
+		encyclopediaRepository = spyk(
+			EncyclopediaRepository(
 				projectDef = projectDef,
-				toml = toml,
-				fileSystem = fileSystem,
-				externalFileIo = mockk<ExternalFileIo>(),
-			),
-			syncJournal = syncJournal,
+				idAllocator = idAllocator,
+				datasource = EncyclopediaDatasource(
+					projectDef = projectDef,
+					toml = toml,
+					fileSystem = fileSystem,
+					externalFileIo = mockk<ExternalFileIo>(),
+				),
+				syncJournal = syncJournal,
+			)
 		)
 		projectDataRepository = ProjectDataRepository(
 			ProjectDataDatasource(fileSystem, toml, projectDef),
@@ -315,6 +320,20 @@ class ProjectDictionaryServiceTest : BaseTest() {
 		projectDataRepository.updateData { it.copy(dictionaryWords = emptySet()) }
 		advanceUntilIdle()
 		assertEquals(setOf("zaltharion"), appliedPerChecker.last())
+	}
+
+	@Test
+	fun `a user word edit does not reload the encyclopedia`() = scope.runTest {
+		createEntry("Zaltharion")
+		createService()
+		advanceUntilIdle()
+		clearMocks(encyclopediaRepository, answers = false, recordedCalls = true, childMocks = false)
+
+		projectDataRepository.updateData { it.copy(dictionaryWords = setOf("kvothe")) }
+		advanceUntilIdle()
+
+		assertEquals(setOf("zaltharion", "kvothe"), appliedPerChecker.last())
+		coVerify(exactly = 0) { encyclopediaRepository.loadEntriesImperative() }
 	}
 
 	@Test

--- a/common/src/desktopTest/kotlin/repositories/spellcheck/ProjectSpellCheckRepositoryTest.kt
+++ b/common/src/desktopTest/kotlin/repositories/spellcheck/ProjectSpellCheckRepositoryTest.kt
@@ -167,6 +167,21 @@ class ProjectSpellCheckRepositoryTest : BaseTest() {
 	}
 
 	@Test
+	fun `userDictionaryWords follows the stored project data`() = scope.runTest {
+		projectDataDatasource.save(StoredProjectData(ProjectData(dictionaryWords = setOf("Kvothe")), null))
+		val repo = repository(settingsStore(Locale.forLanguageTag("en-US")))
+
+		repo.userDictionaryWords.test {
+			assertEquals(setOf("Kvothe"), awaitItem())
+
+			projectDataRepository.updateData { it.copy(dictionaryWords = it.dictionaryWords + "Denna") }
+
+			assertEquals(setOf("Kvothe", "Denna"), awaitItem())
+			cancelAndConsumeRemainingEvents()
+		}
+	}
+
+	@Test
 	fun `spellCheckAllowed reflects the language gate`() = scope.runTest {
 		projectDataDatasource.save(StoredProjectData(ProjectData(language = "fr"), null))
 		val repo = repository(settingsStore(Locale.forLanguageTag("en-US")))

--- a/common/src/desktopTest/kotlin/synchronizer/operations/ProjectDataSyncOperationTest.kt
+++ b/common/src/desktopTest/kotlin/synchronizer/operations/ProjectDataSyncOperationTest.kt
@@ -257,6 +257,28 @@ class ProjectDataSyncOperationTest : BaseTest() {
 	}
 
 	@Test
+	fun `a word added while the upload is in flight is kept and left pending`() = runTest {
+		val local = ProjectData(authorName = "Local Edit")
+		datasource.save(StoredProjectData(local, lastSyncedHash = "stale-hash"))
+		coEvery { api.getProjectData(any(), any()) } returns
+			Result.success(ProjectDataDto(ProjectData(authorName = "Server"), "server-hash"))
+		coEvery {
+			api.uploadProjectData(any(), any(), local, "stale-hash")
+		} coAnswers {
+			repository.updateData { it.copy(dictionaryWords = it.dictionaryWords + "kvothe") }
+			Result.success(ProjectDataDto(local, "new-hash"))
+		}
+
+		val result = createOperation().run()
+
+		assertTrue(isSuccess(result))
+		val stored = repository.state.value
+		assertEquals(local.copy(dictionaryWords = setOf("kvothe")), stored?.data)
+		// The baseline is what the server holds, so the concurrent add uploads next time.
+		assertEquals("new-hash", stored?.lastSyncedHash)
+	}
+
+	@Test
 	fun `a non-conflict upload failure fails the sync`() = runTest {
 		val local = ProjectData(authorName = "Local Edit")
 		datasource.save(StoredProjectData(local, lastSyncedHash = "stale-hash"))

--- a/common/src/desktopTest/kotlin/synchronizer/operations/ProjectDataSyncOperationTest.kt
+++ b/common/src/desktopTest/kotlin/synchronizer/operations/ProjectDataSyncOperationTest.kt
@@ -312,6 +312,61 @@ class ProjectDataSyncOperationTest : BaseTest() {
 	}
 
 	@Test
+	fun `a dictionary-only conflict merges both sides without a resolver`() = runTest {
+		val local = ProjectData(authorName = "Author", dictionaryWords = setOf("local"))
+		datasource.save(StoredProjectData(local, lastSyncedHash = "stale-hash"))
+		val server = ProjectData(authorName = "Author", dictionaryWords = setOf("server"))
+		coEvery { api.getProjectData(any(), any()) } returns
+			Result.success(ProjectDataDto(server, "server-hash"))
+		coEvery {
+			api.uploadProjectData(any(), any(), local, "stale-hash")
+		} returns Result.failure(
+			ProjectDataConflictException(ProjectDataConflictDto(server, "server-hash"))
+		)
+		val merged = local.copy(dictionaryWords = setOf("local", "server"))
+		coEvery {
+			api.uploadProjectData(any(), any(), merged, "server-hash")
+		} returns Result.success(ProjectDataDto(merged, "merged-hash"))
+
+		val result = createOperation().run()
+
+		assertTrue(isSuccess(result))
+		assertEquals(StoredProjectData(merged, "merged-hash"), repository.state.value)
+		assertTrue(broker.conflicts.tryReceive().isFailure, "no conflict should reach the resolver")
+	}
+
+	@Test
+	fun `a conflict on another field still reaches the resolver`() = runTest {
+		val local = ProjectData(authorName = "Local Edit", dictionaryWords = setOf("local"))
+		datasource.save(StoredProjectData(local, lastSyncedHash = "stale-hash"))
+		val server = ProjectData(authorName = "Server", dictionaryWords = setOf("server"))
+		coEvery { api.getProjectData(any(), any()) } returns
+			Result.success(ProjectDataDto(server, "server-hash"))
+		coEvery {
+			api.uploadProjectData(any(), any(), local, "stale-hash")
+		} returns Result.failure(
+			ProjectDataConflictException(ProjectDataConflictDto(server, "server-hash"))
+		)
+		val resolved = ProjectData(authorName = "Merged", dictionaryWords = setOf("local", "server"))
+		coEvery {
+			api.uploadProjectData(any(), any(), resolved, "server-hash")
+		} returns Result.success(ProjectDataDto(resolved, "resolved-hash"))
+
+		var reported: ProjectData? = null
+		val watcher = launch {
+			reported = broker.conflicts.receive().local
+			broker.resolve(resolved)
+		}
+
+		val result = createOperation().run()
+
+		assertTrue(isSuccess(result))
+		assertEquals(local, reported)
+		assertEquals(StoredProjectData(resolved, "resolved-hash"), repository.state.value)
+		watcher.cancel()
+	}
+
+	@Test
 	fun `a failed conflict-resolution upload fails the sync`() = runTest {
 		val local = ProjectData(authorName = "Local Edit")
 		datasource.save(StoredProjectData(local, lastSyncedHash = "stale-hash"))

--- a/common/src/desktopTest/kotlin/utils/ComponentTest.kt
+++ b/common/src/desktopTest/kotlin/utils/ComponentTest.kt
@@ -109,6 +109,7 @@ open class ComponentTest : BaseTest() {
 						every { spellCheckAllowed } returns emptyFlow()
 						every { dictionaryFlow } returns emptyFlow()
 						every { encyclopediaDictionaryEnabled } returns emptyFlow()
+						every { userDictionaryWords } returns emptyFlow()
 					}
 				}
 			},

--- a/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/compose/designsystem/DESIGN_README.md
+++ b/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/compose/designsystem/DESIGN_README.md
@@ -291,6 +291,10 @@ The handwriting of the system. Reach for these instead of styling
 - **[`HdHairlineTagField`](HdHairlineTagField.kt)** — same vocabulary
   but the value is a `List<String>` of `HdTagChip`s; Enter / comma
   adds a tag, Backspace on empty removes the last.
+- **[`HdHairlineWordListField`](HdHairlineWordListField.kt)** — the
+  tag field's shape for a plain word list (the project dictionary):
+  neutral `#` chips that wrap instead of scrolling, Enter / comma /
+  space commits, and the caller's `parseInput` decides what a word is.
 - **[`HdHairlineTypePicker`](HdHairlineTypePicker.kt)** — segmented
   picker for `EntryType`. Glyph square + mono label per cell, 2dp
   top stripe in the type's color when active.

--- a/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/compose/designsystem/DESIGN_README.md
+++ b/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/compose/designsystem/DESIGN_README.md
@@ -291,10 +291,13 @@ The handwriting of the system. Reach for these instead of styling
 - **[`HdHairlineTagField`](HdHairlineTagField.kt)** — same vocabulary
   but the value is a `List<String>` of `HdTagChip`s; Enter / comma
   adds a tag, Backspace on empty removes the last.
-- **[`HdHairlineWordListField`](HdHairlineWordListField.kt)** — the
+- **[`HdHairlineWordListField`](HdHairlineWordListField.kt)**: the
   tag field's shape for a plain word list (the project dictionary):
   neutral `#` chips that wrap instead of scrolling, Enter / comma /
   space commits, and the caller's `parseInput` decides what a word is.
+  Both fields are thin wrappers over the internal
+  [`HdHairlineChipInput`](HdHairlineChipInput.kt), which owns the chip
+  run, the draft input, and its key and focus handling.
 - **[`HdHairlineTypePicker`](HdHairlineTypePicker.kt)** — segmented
   picker for `EntryType`. Glyph square + mono label per cell, 2dp
   top stripe in the type's color when active.

--- a/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/compose/designsystem/HdHairlineChipInput.kt
+++ b/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/compose/designsystem/HdHairlineChipInput.kt
@@ -1,0 +1,170 @@
+package com.darkrockstudios.apps.hammer.common.compose.designsystem
+
+import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.onFocusChanged
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.input.key.KeyEventType
+import androidx.compose.ui.input.key.key
+import androidx.compose.ui.input.key.onPreviewKeyEvent
+import androidx.compose.ui.input.key.type
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+
+/**
+ * The body shared by [HdHairlineTagField] and [HdHairlineWordListField]: mono label and
+ * hint, a run of removable [HdTagChip]s, a trailing draft input that commits on Enter or
+ * focus loss and removes the last chip on Backspace when empty, and the hairline rule.
+ * Parsing and persistence stay with the caller, which also decides what typed text does
+ * through [onInput].
+ *
+ * @param onInput Receives every value change of the draft input.
+ * @param onCommitDraft Commits the draft; returns whether the key event was consumed.
+ * @param onRemoveLast Removes the last chip; returns whether the key event was consumed.
+ * @param wrapChips Wrap chips onto further rows instead of scrolling one row sideways.
+ * @param accentChips Give each chip its per-label color swatch instead of a neutral `#`.
+ * @param footer Drawn under the rule, e.g. a suggestion strip.
+ */
+@OptIn(ExperimentalLayoutApi::class)
+@Composable
+internal fun HdHairlineChipInput(
+	label: String,
+	chips: List<String>,
+	draft: String,
+	onInput: (String) -> Unit,
+	onCommitDraft: () -> Boolean,
+	onRemoveLast: () -> Boolean,
+	onRemoveChip: (String) -> Unit,
+	modifier: Modifier = Modifier,
+	hint: String? = null,
+	placeholder: String? = null,
+	wrapChips: Boolean = false,
+	accentChips: Boolean = true,
+	testTag: String? = null,
+	onFocusChanged: (Boolean) -> Unit = {},
+	footer: @Composable () -> Unit = {},
+) {
+	val onSurface = MaterialTheme.colorScheme.onSurface
+	val muted = MaterialTheme.colorScheme.onSurfaceVariant
+	val textStyle = MaterialTheme.typography.bodyMedium.copy(color = onSurface)
+
+	Column(modifier = modifier.fillMaxWidth()) {
+		Row(
+			modifier = Modifier.fillMaxWidth(),
+			verticalAlignment = Alignment.Bottom,
+			horizontalArrangement = Arrangement.spacedBy(10.dp),
+		) {
+			HdMonoLabel(text = label)
+			if (hint != null) {
+				HdMonoLabel(text = hint, color = muted)
+			}
+		}
+
+		val content: @Composable () -> Unit = {
+			chips.forEach { chip ->
+				if (accentChips) {
+					HdTagChip(label = chip, active = true, onRemove = { onRemoveChip(chip) })
+				} else {
+					HdTagChip(label = chip, active = true, accent = null, onRemove = { onRemoveChip(chip) })
+				}
+			}
+			Box(
+				modifier = Modifier
+					.width(200.dp)
+					.heightIn(min = 24.dp)
+					.padding(vertical = 2.dp),
+				contentAlignment = Alignment.CenterStart,
+			) {
+				BasicTextField(
+					value = draft,
+					onValueChange = onInput,
+					singleLine = true,
+					textStyle = textStyle,
+					cursorBrush = SolidColor(onSurface),
+					keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
+					modifier = Modifier
+						.fillMaxWidth()
+						.heightIn(min = 24.dp)
+						.onFocusChanged { focusState ->
+							onFocusChanged(focusState.isFocused)
+							// A typed-but-uncommitted value would otherwise be silently
+							// dropped when focus moves on; commit it instead.
+							if (!focusState.isFocused && draft.isNotBlank()) {
+								onCommitDraft()
+							}
+						}
+						.then(if (testTag != null) Modifier.testTag(testTag) else Modifier)
+						.onPreviewKeyEvent { event ->
+							if (event.type != KeyEventType.KeyDown) return@onPreviewKeyEvent false
+							when (event.key) {
+								Key.Enter, Key.NumPadEnter -> onCommitDraft()
+								Key.Backspace -> onRemoveLast()
+								else -> false
+							}
+						},
+				)
+				if (draft.isEmpty() && chips.isEmpty() && placeholder != null) {
+					Text(
+						text = placeholder,
+						style = textStyle.copy(color = muted),
+					)
+				}
+			}
+		}
+
+		if (wrapChips) {
+			FlowRow(
+				modifier = Modifier
+					.fillMaxWidth()
+					.heightIn(min = 38.dp)
+					.padding(top = 6.dp, bottom = 6.dp),
+				horizontalArrangement = Arrangement.spacedBy(6.dp),
+				verticalArrangement = Arrangement.spacedBy(6.dp),
+			) {
+				content()
+			}
+		} else {
+			// One scrollable line: chips and input share a fixed container so focus survives
+			// the keyboard opening, and chips never wrap to extra rows that eat editor space.
+			Row(
+				modifier = Modifier
+					.fillMaxWidth()
+					.heightIn(min = 38.dp)
+					.horizontalScroll(rememberScrollState())
+					.padding(top = 6.dp, bottom = 6.dp),
+				horizontalArrangement = Arrangement.spacedBy(6.dp),
+				verticalAlignment = Alignment.CenterVertically,
+			) {
+				content()
+			}
+		}
+
+		HorizontalDivider(
+			thickness = Dp.Hairline,
+			color = MaterialTheme.colorScheme.outlineVariant,
+		)
+
+		footer()
+	}
+}

--- a/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/compose/designsystem/HdHairlineTagField.kt
+++ b/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/compose/designsystem/HdHairlineTagField.kt
@@ -1,24 +1,18 @@
 package com.darkrockstudios.apps.hammer.common.compose.designsystem
 
-import androidx.compose.foundation.horizontalScroll
-import androidx.compose.foundation.layout.*
-import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.text.BasicTextField
-import androidx.compose.foundation.text.KeyboardOptions
-import androidx.compose.material3.HorizontalDivider
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Text
-import androidx.compose.runtime.*
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
-import androidx.compose.ui.Alignment
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.focusProperties
-import androidx.compose.ui.focus.onFocusChanged
-import androidx.compose.ui.graphics.SolidColor
-import androidx.compose.ui.platform.testTag
-import androidx.compose.ui.input.key.*
-import androidx.compose.ui.text.input.ImeAction
-import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.darkrockstudios.apps.hammer.common.compose.CollapseWhileTyping
 import com.darkrockstudios.apps.hammer.common.data.tagindex.isTagSeparator
@@ -27,17 +21,15 @@ import com.darkrockstudios.apps.hammer.common.data.tagindex.replaceTagPrefix
 import com.darkrockstudios.apps.hammer.common.data.tagindex.tagPrefixOf
 
 /**
- * Tag chip field — labeled hairline-underline input that keeps its
- * value as a list of tags rather than a free-form string. Each tag
- * renders as an [HdTagChip] with a `×` remove affordance; the trailing
- * input adds a tag on Enter or comma and removes the last tag on
- * Backspace when empty.
+ * Tag chip field: labeled hairline-underline input that keeps its value as a list of
+ * tags rather than a free-form string. Each tag renders as an [HdTagChip] with a `×`
+ * remove affordance; the trailing input adds a tag on Enter or comma and removes the
+ * last tag on Backspace when empty. Built on [HdHairlineChipInput].
  *
  *     TAGS                              ↵ to add
  *     [# animal ×] [# guide ×]  ritual,…
  *     ────────────────────────────────────────────
  */
-@OptIn(ExperimentalLayoutApi::class)
 @Composable
 fun HdHairlineTagField(
 	label: String,
@@ -79,110 +71,38 @@ fun HdHairlineTagField(
 
 	val suggestions = rememberTagSuggestions(draft, tags, suggestTags)
 
-	val onSurface = MaterialTheme.colorScheme.onSurface
-	val muted = MaterialTheme.colorScheme.onSurfaceVariant
-	val textStyle = MaterialTheme.typography.bodyMedium.copy(color = onSurface)
-
 	// Collapse the whole field while the body editor is being typed into; keep it visible while it
 	// holds focus itself so tapping it (which raises the keyboard) doesn't make it vanish.
 	var tagsFocused by remember { mutableStateOf(false) }
 	CollapseWhileTyping(modifier = modifier, keepVisible = tagsFocused) {
-		Column(modifier = Modifier.fillMaxWidth()) {
-			Row(
-				modifier = Modifier.fillMaxWidth(),
-				verticalAlignment = Alignment.Bottom,
-				horizontalArrangement = Arrangement.spacedBy(10.dp),
-			) {
-				HdMonoLabel(text = label)
-				if (hint != null) {
-					HdMonoLabel(
-						text = hint,
-						color = MaterialTheme.colorScheme.onSurfaceVariant,
-					)
+		HdHairlineChipInput(
+			label = label,
+			chips = tags,
+			draft = draft,
+			onInput = { next ->
+				val last = next.lastOrNull()
+				if (last != null && last.isTagSeparator()) {
+					updateDraft(next.dropLast(1))
+					addCurrent()
+				} else {
+					updateDraft(next)
 				}
-			}
-
-			// One scrollable line — chips + input share a fixed container so focus survives
-			// the keyboard opening, and tags never wrap to extra rows that eat editor space.
-			Row(
-				modifier = Modifier
-					.fillMaxWidth()
-					.heightIn(min = 38.dp)
-					.horizontalScroll(rememberScrollState())
-					.padding(top = 6.dp, bottom = 6.dp),
-				horizontalArrangement = Arrangement.spacedBy(6.dp),
-				verticalAlignment = Alignment.CenterVertically,
-			) {
-				tags.forEach { tag ->
-					HdTagChip(
-						label = tag,
-						active = true,
-						onRemove = { onTagsChange(tags - tag) },
-					)
-				}
-				Box(
-					modifier = Modifier
-						.width(200.dp)
-						.heightIn(min = 24.dp)
-						.padding(vertical = 2.dp),
-					contentAlignment = Alignment.CenterStart,
-				) {
-					BasicTextField(
-						value = draft,
-						onValueChange = { next ->
-							val last = next.lastOrNull()
-							if (last != null && last.isTagSeparator()) {
-								updateDraft(next.dropLast(1))
-								addCurrent()
-							} else {
-								updateDraft(next)
-							}
-						},
-						singleLine = true,
-						textStyle = textStyle,
-						cursorBrush = SolidColor(onSurface),
-						keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
-						modifier = Modifier
-							.fillMaxWidth()
-							.heightIn(min = 24.dp)
-							.onFocusChanged { focusState ->
-								tagsFocused = focusState.isFocused
-								// A typed-but-uncommitted tag would otherwise be silently
-								// dropped when focus moves on — commit it instead.
-								if (!focusState.isFocused && draft.isNotBlank()) {
-									addCurrent()
-								}
-							}
-							.then(if (testTag != null) Modifier.testTag(testTag) else Modifier)
-							.onPreviewKeyEvent { event ->
-								if (event.type != KeyEventType.KeyDown) return@onPreviewKeyEvent false
-								when (event.key) {
-									Key.Enter, Key.NumPadEnter -> addCurrent()
-									Key.Backspace -> removeLast()
-									else -> false
-								}
-							},
-					)
-					if (draft.isEmpty() && tags.isEmpty() && placeholder != null) {
-						Text(
-							text = placeholder,
-							style = textStyle.copy(color = muted),
-						)
-					}
-				}
-			}
-
-			HorizontalDivider(
-				thickness = Dp.Hairline,
-				color = MaterialTheme.colorScheme.outlineVariant,
-			)
-
-			HdTagSuggestionStrip(
-				suggestions = suggestions,
-				onSelect = { addTag(replaceTagPrefix(draft, it)) },
-				modifier = Modifier.padding(top = 6.dp),
-			)
-		}
+			},
+			onCommitDraft = addCurrent,
+			onRemoveLast = removeLast,
+			onRemoveChip = { onTagsChange(tags - it) },
+			hint = hint,
+			placeholder = placeholder,
+			testTag = testTag,
+			onFocusChanged = { tagsFocused = it },
+			footer = {
+				HdTagSuggestionStrip(
+					suggestions = suggestions,
+					onSelect = { addTag(replaceTagPrefix(draft, it)) },
+					modifier = Modifier.padding(top = 6.dp),
+				)
+			},
+		)
 	}
 }
 

--- a/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/compose/designsystem/HdHairlineWordListField.kt
+++ b/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/compose/designsystem/HdHairlineWordListField.kt
@@ -1,54 +1,26 @@
 package com.darkrockstudios.apps.hammer.common.compose.designsystem
 
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.ExperimentalLayoutApi
-import androidx.compose.foundation.layout.FlowRow
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.heightIn
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.text.BasicTextField
-import androidx.compose.foundation.text.KeyboardOptions
-import androidx.compose.material3.HorizontalDivider
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.focus.onFocusChanged
-import androidx.compose.ui.graphics.SolidColor
-import androidx.compose.ui.input.key.Key
-import androidx.compose.ui.input.key.KeyEventType
-import androidx.compose.ui.input.key.key
-import androidx.compose.ui.input.key.onPreviewKeyEvent
-import androidx.compose.ui.input.key.type
-import androidx.compose.ui.platform.testTag
-import androidx.compose.ui.text.input.ImeAction
-import androidx.compose.ui.unit.Dp
-import androidx.compose.ui.unit.dp
+import com.darkrockstudios.apps.hammer.common.data.tagindex.isTagSeparator
 
 /**
- * Word list field — labeled hairline-underline input whose value is a
- * list of single words, each rendered as a neutral [HdTagChip] with a
- * `×` remove affordance. Chips wrap, so a long list grows downward
- * rather than scrolling sideways. The trailing input commits on Enter,
- * comma, or space, and removes the last word on Backspace when empty.
- * [parseInput] is the same rule persistence applies, so a chip is never
- * shown for input that would be dropped on save.
+ * Word list field: the tag field's shape for a plain list of single words, such as the
+ * project dictionary. Neutral chips wrap onto further rows; a separator (space, comma, or
+ * their fullwidth forms), Enter, or focus loss commits the draft, and Backspace on an empty
+ * draft removes the last chip. [parseInput] is the same rule persistence applies, so a chip
+ * is never shown for input that would be dropped on save; input it rejects stays in the
+ * draft where the user can see it. Duplicates are matched ignoring case.
  *
- *     PROJECT DICTIONARY                      ↵ to add
- *     [# Kvothe ×] [# Denna ×] [# Tarbean ×]
- *     [# Imre ×]  Ademre…
- *     ────────────────────────────────────────────
+ *     PROJECT DICTIONARY                      to add
+ *     [# Kvothe x] [# Denna x] [# Tarbean x]
+ *     [# Imre x]  Ademre
+ *     ----------------------------------------------
  */
-@OptIn(ExperimentalLayoutApi::class)
 @Composable
 fun HdHairlineWordListField(
 	label: String,
@@ -64,11 +36,31 @@ fun HdHairlineWordListField(
 	// Saveable so a configuration change can't drop a word that was typed but not yet committed.
 	var draft by rememberSaveable { mutableStateOf("") }
 
-	val commitDraft: () -> Boolean = commit@{
-		val word = parseInput(draft) ?: return@commit false
-		if (word !in words) onAdd(word)
-		draft = ""
+	/** Commits what the parser accepts and returns the tokens it rejected. */
+	fun commitAll(tokens: List<String>): List<String> = tokens.filterNot { token ->
+		val word = parseInput(token) ?: return@filterNot false
+		if (words.none { it.equals(word, ignoreCase = true) }) onAdd(word)
 		true
+	}
+
+	val onInput: (String) -> Unit = { next ->
+		if (next.any { it.isTagSeparator() }) {
+			// A separator anywhere commits the complete words before it, so a pasted
+			// list is not stranded as one draft the parser rejects.
+			val tokens = splitOnSeparators(next)
+			val endsWithSeparator = next.last().isTagSeparator()
+			val complete = if (endsWithSeparator) tokens else tokens.dropLast(1)
+			val partial = if (endsWithSeparator) emptyList() else tokens.takeLast(1)
+			draft = (commitAll(complete) + partial).joinToString(" ")
+		} else {
+			draft = next
+		}
+	}
+	val commitDraft: () -> Boolean = commit@{
+		val tokens = splitOnSeparators(draft)
+		val rejected = commitAll(tokens)
+		draft = rejected.joinToString(" ")
+		rejected.size < tokens.size
 	}
 	val removeLast: () -> Boolean = remove@{
 		if (draft.isNotEmpty() || words.isEmpty()) return@remove false
@@ -76,92 +68,34 @@ fun HdHairlineWordListField(
 		true
 	}
 
-	val onSurface = MaterialTheme.colorScheme.onSurface
-	val muted = MaterialTheme.colorScheme.onSurfaceVariant
-	val textStyle = MaterialTheme.typography.bodyMedium.copy(color = onSurface)
+	HdHairlineChipInput(
+		label = label,
+		chips = words,
+		draft = draft,
+		onInput = onInput,
+		onCommitDraft = commitDraft,
+		onRemoveLast = removeLast,
+		onRemoveChip = onRemove,
+		modifier = modifier,
+		hint = hint,
+		placeholder = placeholder,
+		wrapChips = true,
+		accentChips = false,
+		testTag = testTag,
+	)
+}
 
-	Column(modifier = modifier.fillMaxWidth()) {
-		Row(
-			modifier = Modifier.fillMaxWidth(),
-			verticalAlignment = Alignment.Bottom,
-			horizontalArrangement = Arrangement.spacedBy(10.dp),
-		) {
-			HdMonoLabel(text = label)
-			if (hint != null) {
-				HdMonoLabel(text = hint, color = muted)
-			}
+private fun splitOnSeparators(text: String): List<String> {
+	val tokens = mutableListOf<String>()
+	val current = StringBuilder()
+	for (c in text) {
+		if (c.isTagSeparator()) {
+			if (current.isNotEmpty()) tokens += current.toString()
+			current.clear()
+		} else {
+			current.append(c)
 		}
-
-		FlowRow(
-			modifier = Modifier
-				.fillMaxWidth()
-				.heightIn(min = 38.dp)
-				.padding(top = 6.dp, bottom = 6.dp),
-			horizontalArrangement = Arrangement.spacedBy(6.dp),
-			verticalArrangement = Arrangement.spacedBy(6.dp),
-		) {
-			words.forEach { word ->
-				HdTagChip(
-					label = word,
-					active = true,
-					accent = null,
-					onRemove = { onRemove(word) },
-				)
-			}
-			Box(
-				modifier = Modifier
-					.width(200.dp)
-					.heightIn(min = 24.dp)
-					.padding(vertical = 2.dp),
-				contentAlignment = Alignment.CenterStart,
-			) {
-				BasicTextField(
-					value = draft,
-					onValueChange = { next ->
-						val last = next.lastOrNull()
-						if (last != null && (last == ',' || last.isWhitespace())) {
-							draft = next.dropLast(1)
-							commitDraft()
-						} else {
-							draft = next
-						}
-					},
-					singleLine = true,
-					textStyle = textStyle,
-					cursorBrush = SolidColor(onSurface),
-					keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
-					modifier = Modifier
-						.fillMaxWidth()
-						.heightIn(min = 24.dp)
-						.onFocusChanged { focusState ->
-							// A typed-but-uncommitted word would otherwise be silently
-							// dropped when focus moves on — commit it instead.
-							if (!focusState.isFocused && draft.isNotBlank()) {
-								commitDraft()
-							}
-						}
-						.then(if (testTag != null) Modifier.testTag(testTag) else Modifier)
-						.onPreviewKeyEvent { event ->
-							if (event.type != KeyEventType.KeyDown) return@onPreviewKeyEvent false
-							when (event.key) {
-								Key.Enter, Key.NumPadEnter -> commitDraft()
-								Key.Backspace -> removeLast()
-								else -> false
-							}
-						},
-				)
-				if (draft.isEmpty() && words.isEmpty() && placeholder != null) {
-					Text(
-						text = placeholder,
-						style = textStyle.copy(color = muted),
-					)
-				}
-			}
-		}
-
-		HorizontalDivider(
-			thickness = Dp.Hairline,
-			color = MaterialTheme.colorScheme.outlineVariant,
-		)
 	}
+	if (current.isNotEmpty()) tokens += current.toString()
+	return tokens
 }

--- a/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/compose/designsystem/HdHairlineWordListField.kt
+++ b/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/compose/designsystem/HdHairlineWordListField.kt
@@ -1,0 +1,167 @@
+package com.darkrockstudios.apps.hammer.common.compose.designsystem
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.onFocusChanged
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.input.key.KeyEventType
+import androidx.compose.ui.input.key.key
+import androidx.compose.ui.input.key.onPreviewKeyEvent
+import androidx.compose.ui.input.key.type
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+
+/**
+ * Word list field — labeled hairline-underline input whose value is a
+ * list of single words, each rendered as a neutral [HdTagChip] with a
+ * `×` remove affordance. Chips wrap, so a long list grows downward
+ * rather than scrolling sideways. The trailing input commits on Enter,
+ * comma, or space, and removes the last word on Backspace when empty.
+ * [parseInput] is the same rule persistence applies, so a chip is never
+ * shown for input that would be dropped on save.
+ *
+ *     PROJECT DICTIONARY                      ↵ to add
+ *     [# Kvothe ×] [# Denna ×] [# Tarbean ×]
+ *     [# Imre ×]  Ademre…
+ *     ────────────────────────────────────────────
+ */
+@OptIn(ExperimentalLayoutApi::class)
+@Composable
+fun HdHairlineWordListField(
+	label: String,
+	words: List<String>,
+	onAdd: (String) -> Unit,
+	onRemove: (String) -> Unit,
+	parseInput: (String) -> String?,
+	modifier: Modifier = Modifier,
+	hint: String? = null,
+	placeholder: String? = null,
+	testTag: String? = null,
+) {
+	// Saveable so a configuration change can't drop a word that was typed but not yet committed.
+	var draft by rememberSaveable { mutableStateOf("") }
+
+	val commitDraft: () -> Boolean = commit@{
+		val word = parseInput(draft) ?: return@commit false
+		if (word !in words) onAdd(word)
+		draft = ""
+		true
+	}
+	val removeLast: () -> Boolean = remove@{
+		if (draft.isNotEmpty() || words.isEmpty()) return@remove false
+		onRemove(words.last())
+		true
+	}
+
+	val onSurface = MaterialTheme.colorScheme.onSurface
+	val muted = MaterialTheme.colorScheme.onSurfaceVariant
+	val textStyle = MaterialTheme.typography.bodyMedium.copy(color = onSurface)
+
+	Column(modifier = modifier.fillMaxWidth()) {
+		Row(
+			modifier = Modifier.fillMaxWidth(),
+			verticalAlignment = Alignment.Bottom,
+			horizontalArrangement = Arrangement.spacedBy(10.dp),
+		) {
+			HdMonoLabel(text = label)
+			if (hint != null) {
+				HdMonoLabel(text = hint, color = muted)
+			}
+		}
+
+		FlowRow(
+			modifier = Modifier
+				.fillMaxWidth()
+				.heightIn(min = 38.dp)
+				.padding(top = 6.dp, bottom = 6.dp),
+			horizontalArrangement = Arrangement.spacedBy(6.dp),
+			verticalArrangement = Arrangement.spacedBy(6.dp),
+		) {
+			words.forEach { word ->
+				HdTagChip(
+					label = word,
+					active = true,
+					accent = null,
+					onRemove = { onRemove(word) },
+				)
+			}
+			Box(
+				modifier = Modifier
+					.width(200.dp)
+					.heightIn(min = 24.dp)
+					.padding(vertical = 2.dp),
+				contentAlignment = Alignment.CenterStart,
+			) {
+				BasicTextField(
+					value = draft,
+					onValueChange = { next ->
+						val last = next.lastOrNull()
+						if (last != null && (last == ',' || last.isWhitespace())) {
+							draft = next.dropLast(1)
+							commitDraft()
+						} else {
+							draft = next
+						}
+					},
+					singleLine = true,
+					textStyle = textStyle,
+					cursorBrush = SolidColor(onSurface),
+					keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
+					modifier = Modifier
+						.fillMaxWidth()
+						.heightIn(min = 24.dp)
+						.onFocusChanged { focusState ->
+							// A typed-but-uncommitted word would otherwise be silently
+							// dropped when focus moves on — commit it instead.
+							if (!focusState.isFocused && draft.isNotBlank()) {
+								commitDraft()
+							}
+						}
+						.then(if (testTag != null) Modifier.testTag(testTag) else Modifier)
+						.onPreviewKeyEvent { event ->
+							if (event.type != KeyEventType.KeyDown) return@onPreviewKeyEvent false
+							when (event.key) {
+								Key.Enter, Key.NumPadEnter -> commitDraft()
+								Key.Backspace -> removeLast()
+								else -> false
+							}
+						},
+				)
+				if (draft.isEmpty() && words.isEmpty() && placeholder != null) {
+					Text(
+						text = placeholder,
+						style = textStyle.copy(color = muted),
+					)
+				}
+			}
+		}
+
+		HorizontalDivider(
+			thickness = Dp.Hairline,
+			color = MaterialTheme.colorScheme.outlineVariant,
+		)
+	}
+}

--- a/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/projecthome/ProjectSettingsUi.kt
+++ b/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/projecthome/ProjectSettingsUi.kt
@@ -37,6 +37,7 @@ import com.darkrockstudios.apps.hammer.common.compose.designsystem.HdCrumbBackLi
 import com.darkrockstudios.apps.hammer.common.compose.designsystem.HdFolioDivider
 import com.darkrockstudios.apps.hammer.common.compose.designsystem.HdHairlineSection
 import com.darkrockstudios.apps.hammer.common.compose.designsystem.HdHairlineToggleRow
+import com.darkrockstudios.apps.hammer.common.compose.designsystem.HdHairlineWordListField
 import com.darkrockstudios.apps.hammer.common.compose.designsystem.HdMonoLabel
 import com.darkrockstudios.apps.hammer.common.compose.resources.get
 import com.darkrockstudios.apps.hammer.common.compose.scrollBarOverlay
@@ -44,10 +45,14 @@ import com.darkrockstudios.apps.hammer.common.compose.theme.LocalHammerColors
 import com.darkrockstudios.apps.hammer.common.projectselection.settings.SpellCheckSettingsContent
 import com.darkrockstudios.apps.hammer.common.spellcheck.displayName
 import com.darkrockstudios.apps.hammer.common.spellcheck.isSpellCheckAllowedForProject
+import com.darkrockstudios.apps.hammer.common.spellcheck.normalizeDictionaryWord
 import com.darkrockstudios.apps.hammer.common.util.Locale
 import com.darkrockstudios.apps.hammer.project_settings_autosaved
 import com.darkrockstudios.apps.hammer.project_settings_breadcrumb_home
 import com.darkrockstudios.apps.hammer.project_settings_breadcrumb_root
+import com.darkrockstudios.apps.hammer.project_settings_dictionary_hint
+import com.darkrockstudios.apps.hammer.project_settings_dictionary_label
+import com.darkrockstudios.apps.hammer.project_settings_dictionary_placeholder
 import com.darkrockstudios.apps.hammer.project_settings_folio_caption
 import com.darkrockstudios.apps.hammer.project_settings_folio_section_count
 import com.darkrockstudios.apps.hammer.project_settings_hero_by
@@ -126,6 +131,10 @@ fun ProjectSettingsUi(
 									enabled = state.data.encyclopediaDictionary,
 									component = component,
 								)
+								ProjectDictionaryWords(
+									words = state.data.dictionaryWords,
+									component = component,
+								)
 								SpellCheckMismatchCaption(
 									projectLanguageTag = state.data.language,
 									spellCheckSettings = component.spellCheckSettings,
@@ -167,6 +176,24 @@ private fun ProjectDictionaryToggle(
 		hint = Res.string.project_settings_spellcheck_encyclopedia_enable_hint.get(),
 		enabled = spellCheckState.spellCheckingEnabled,
 		onCheckedChange = { component.setEncyclopediaDictionaryEnabled(it) },
+	)
+}
+
+/** The user-added words this project's spell checker accepts, synced with the project. */
+@Composable
+private fun ProjectDictionaryWords(
+	words: Set<String>,
+	component: ProjectSettings,
+) {
+	HdHairlineWordListField(
+		label = Res.string.project_settings_dictionary_label.get(),
+		words = words.sortedBy { it.lowercase() },
+		onAdd = component::addDictionaryWord,
+		onRemove = component::removeDictionaryWord,
+		parseInput = ::normalizeDictionaryWord,
+		hint = Res.string.project_settings_dictionary_hint.get(),
+		placeholder = Res.string.project_settings_dictionary_placeholder.get(),
+		testTag = "project-settings-dictionary",
 	)
 }
 

--- a/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/projecthome/ProjectSettingsUi.kt
+++ b/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/projecthome/ProjectSettingsUi.kt
@@ -20,6 +20,7 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.windowsizeclass.WindowWidthSizeClass
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.RectangleShape
@@ -185,9 +186,10 @@ private fun ProjectDictionaryWords(
 	words: Set<String>,
 	component: ProjectSettings,
 ) {
+	val sorted = remember(words) { words.sortedBy { it.lowercase() } }
 	HdHairlineWordListField(
 		label = Res.string.project_settings_dictionary_label.get(),
-		words = words.sortedBy { it.lowercase() },
+		words = sorted,
 		onAdd = component::addDictionaryWord,
 		onRemove = component::removeDictionaryWord,
 		parseInput = ::normalizeDictionaryWord,

--- a/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/projectsync/ProjectDataConflict.kt
+++ b/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/projectsync/ProjectDataConflict.kt
@@ -36,8 +36,10 @@ import com.darkrockstudios.apps.hammer.common.compose.designsystem.HdConflictFie
 import com.darkrockstudios.apps.hammer.common.compose.designsystem.HdHairlineButton
 import com.darkrockstudios.apps.hammer.common.compose.designsystem.HdMonoLabel
 import com.darkrockstudios.apps.hammer.common.compose.resources.get
+import com.darkrockstudios.apps.hammer.common.data.projectdata.mergeDictionaryWords
 import com.darkrockstudios.apps.hammer.sync_conflict_project_data_cadence_day
 import com.darkrockstudios.apps.hammer.sync_conflict_project_data_cadence_week
+import com.darkrockstudios.apps.hammer.sync_conflict_project_data_dictionary_merged
 import com.darkrockstudios.apps.hammer.sync_conflict_project_data_explanation
 import com.darkrockstudios.apps.hammer.common.spellcheck.displayName
 import com.darkrockstudios.apps.hammer.common.util.Locale
@@ -171,6 +173,14 @@ internal fun ProjectDataConflict(
 			stackVertical = stackVertical,
 		)
 
+		if (conflictState.local.dictionaryWords != conflictState.server.dictionaryWords) {
+			Text(
+				text = Res.string.sync_conflict_project_data_dictionary_merged.get(),
+				style = MaterialTheme.typography.bodySmall,
+				color = MaterialTheme.colorScheme.onSurfaceVariant,
+			)
+		}
+
 		Row(
 			modifier = Modifier.fillMaxWidth(),
 			horizontalArrangement = Arrangement.End,
@@ -299,6 +309,7 @@ private fun buildResolved(
 	tags = if (tagsChoice == DataChoice.LOCAL) local.tags else server.tags,
 	language = if (languageChoice == DataChoice.LOCAL) local.language else server.language,
 	encyclopediaDictionary = if (dictionaryChoice == DataChoice.LOCAL) local.encyclopediaDictionary else server.encyclopediaDictionary,
+	dictionaryWords = mergeDictionaryWords(local, server),
 )
 
 private fun displayString(value: String?, unsetLabel: String): String =

--- a/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/storyeditor/focusmode/FocusModeUi.kt
+++ b/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/storyeditor/focusmode/FocusModeUi.kt
@@ -52,7 +52,9 @@ import com.darkrockstudios.apps.hammer.common.compose.resources.get
 import com.darkrockstudios.apps.hammer.common.data.UpdateSource
 import com.darkrockstudios.apps.hammer.common.storyeditor.sceneeditor.loadSceneContent
 import com.darkrockstudios.apps.hammer.common.storyeditor.sceneeditor.sceneContentMarkdown
+import com.darkrockstudios.apps.hammer.common.utils.addToDictionaryMenuItems
 import com.darkrockstudios.apps.hammer.common.utils.toEditorSpellChecker
+import com.darkrockstudios.apps.hammer.scene_editor_add_to_dictionary
 import com.darkrockstudios.apps.hammer.scene_editor_menu_item_close
 import com.darkrockstudios.texteditor.find.FindBar
 import com.darkrockstudios.texteditor.find.rememberFindState
@@ -69,6 +71,10 @@ fun FocusModeUi(component: FocusMode) {
 	val markdownConfig = LocalMarkdownConfig.current
 	val defaultDispatcher = rememberDefaultDispatcher()
 
+	val addToDictionaryLabel = Res.string.scene_editor_add_to_dictionary.get()
+	val spellCheckMenuItems = remember(addToDictionaryLabel, component) {
+		addToDictionaryMenuItems(addToDictionaryLabel, component::addWordToDictionary)
+	}
 	val editorSpellChecker = remember(state.spellChecker) {
 		state.spellChecker.toEditorSpellChecker()
 	}
@@ -193,6 +199,7 @@ fun FocusModeUi(component: FocusMode) {
 						state = textEditorState,
 						contentPadding = PaddingValues(Ui.Padding.XL),
 						enabled = hasReceivedInitialBuffer,
+						spellCheckMenuItems = spellCheckMenuItems,
 						style = rememberTextEditorStyle(
 							textStyle = TextStyle.Default.copy(
 								textIndent = TextIndent(firstLine = 24.sp)

--- a/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/storyeditor/sceneeditor/SceneEditorUi.kt
+++ b/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/storyeditor/sceneeditor/SceneEditorUi.kt
@@ -46,6 +46,7 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.arkivanov.decompose.extensions.compose.subscribeAsState
+import com.darkrockstudios.apps.hammer.Res
 import com.darkrockstudios.apps.hammer.common.TextEditorDefaults
 import com.darkrockstudios.apps.hammer.common.components.storyeditor.sceneeditor.SceneEditor
 import com.darkrockstudios.apps.hammer.common.components.storyeditor.sceneeditor.clampEditorWidth
@@ -62,10 +63,13 @@ import com.darkrockstudios.apps.hammer.common.compose.designsystem.HdResizeHandl
 import com.darkrockstudios.apps.hammer.common.compose.designsystem.rememberHdResizeHandleState
 import com.darkrockstudios.apps.hammer.common.compose.markdowneditor.MarkdownFormatBar
 import com.darkrockstudios.apps.hammer.common.compose.markdowneditor.markdownFormatShortcuts
+import com.darkrockstudios.apps.hammer.common.compose.resources.get
 import com.darkrockstudios.apps.hammer.common.compose.saveShortcutModifier
 import com.darkrockstudios.apps.hammer.common.data.UpdateSource
 import com.darkrockstudios.apps.hammer.common.storyeditor.scenelist.SceneDeleteDialog
+import com.darkrockstudios.apps.hammer.common.utils.addToDictionaryMenuItems
 import com.darkrockstudios.apps.hammer.common.utils.toEditorSpellChecker
+import com.darkrockstudios.apps.hammer.scene_editor_add_to_dictionary
 import com.darkrockstudios.texteditor.find.FindBar
 import com.darkrockstudios.texteditor.find.rememberFindState
 import com.darkrockstudios.texteditor.rememberTextEditorStyle
@@ -93,6 +97,10 @@ fun SceneEditorUi(
 	val scope = rememberCoroutineScope()
 	val defaultDispatcher = rememberDefaultDispatcher()
 
+	val addToDictionaryLabel = Res.string.scene_editor_add_to_dictionary.get()
+	val spellCheckMenuItems = remember(addToDictionaryLabel, component) {
+		addToDictionaryMenuItems(addToDictionaryLabel, component::addWordToDictionary)
+	}
 	val editorSpellChecker = remember(state.spellChecker) {
 		state.spellChecker.toEditorSpellChecker()
 	}
@@ -227,6 +235,7 @@ fun SceneEditorUi(
 						state = textEditorState,
 						contentPadding = PaddingValues(Ui.Padding.XL),
 						enabled = hasReceivedInitialBuffer,
+						spellCheckMenuItems = spellCheckMenuItems,
 						style = rememberTextEditorStyle(
 							textStyle = TextStyle.Default.copy(
 								textIndent = TextIndent(firstLine = 24.sp)

--- a/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/utils/AddToDictionaryMenu.kt
+++ b/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/utils/AddToDictionaryMenu.kt
@@ -1,16 +1,18 @@
 package com.darkrockstudios.apps.hammer.common.utils
 
+import com.darkrockstudios.apps.hammer.common.spellcheck.normalizeDictionaryWord
 import com.darkrockstudios.texteditor.contextmenu.ContextMenuItem
 import com.darkrockstudios.texteditor.spellcheck.SpellCheckItem
 
-/** Context-menu items for a flagged span: "Add to dictionary" on a misspelled word, nothing on sentence issues. */
+/**
+ * Context-menu items for a flagged span: "Add to dictionary" on a misspelled word the
+ * dictionary can store, nothing on sentence issues or unstorable tokens.
+ */
 fun addToDictionaryMenuItems(
 	label: String,
 	addWord: (String) -> Unit,
 ): (SpellCheckItem) -> List<ContextMenuItem> = { item ->
-	if (item is SpellCheckItem.MisspelledWord) {
-		listOf(ContextMenuItem(label = label) { addWord(item.segment.text) })
-	} else {
-		emptyList()
-	}
+	val word = (item as? SpellCheckItem.MisspelledWord)
+		?.let { normalizeDictionaryWord(it.segment.text) }
+	if (word != null) listOf(ContextMenuItem(label = label) { addWord(word) }) else emptyList()
 }

--- a/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/utils/AddToDictionaryMenu.kt
+++ b/composeUi/src/commonMain/kotlin/com/darkrockstudios/apps/hammer/common/utils/AddToDictionaryMenu.kt
@@ -1,0 +1,16 @@
+package com.darkrockstudios.apps.hammer.common.utils
+
+import com.darkrockstudios.texteditor.contextmenu.ContextMenuItem
+import com.darkrockstudios.texteditor.spellcheck.SpellCheckItem
+
+/** Context-menu items for a flagged span: "Add to dictionary" on a misspelled word, nothing on sentence issues. */
+fun addToDictionaryMenuItems(
+	label: String,
+	addWord: (String) -> Unit,
+): (SpellCheckItem) -> List<ContextMenuItem> = { item ->
+	if (item is SpellCheckItem.MisspelledWord) {
+		listOf(ContextMenuItem(label = label) { addWord(item.segment.text) })
+	} else {
+		emptyList()
+	}
+}

--- a/composeUi/src/desktopMain/kotlin/com/darkrockstudios/apps/hammer/common/preview/projecthome/ProjectSettingsUi.Preview.kt
+++ b/composeUi/src/desktopMain/kotlin/com/darkrockstudios/apps/hammer/common/preview/projecthome/ProjectSettingsUi.Preview.kt
@@ -98,6 +98,8 @@ private fun fakeComponent(language: String?) = object : ProjectSettings {
 	override fun setTags(tags: Set<String>) {}
 	override fun setProjectLanguage(tag: String?) {}
 	override fun setEncyclopediaDictionaryEnabled(enabled: Boolean) {}
+	override fun addDictionaryWord(word: String) {}
+	override fun removeDictionaryWord(word: String) {}
 	override fun suggestProjectTags(prefix: String): List<String> =
 		listOf("fantasy", "sci-fi", "nanowrimo").filter { it.startsWith(prefix, ignoreCase = true) }
 }

--- a/composeUi/src/desktopMain/kotlin/com/darkrockstudios/apps/hammer/common/preview/sceneeditor/FocusModeUi.Preview.kt
+++ b/composeUi/src/desktopMain/kotlin/com/darkrockstudios/apps/hammer/common/preview/sceneeditor/FocusModeUi.Preview.kt
@@ -55,6 +55,7 @@ private val focusMode = object : FocusMode {
 	override var lastForceUpdate = MutableValue(1L)
 
 	override fun dismiss() {}
+	override fun addWordToDictionary(word: String) {}
 	override fun onContentChanged(content: PlatformRichText) {}
 	override fun decreaseTextSize() {}
 	override fun increaseTextSize() {}

--- a/composeUi/src/desktopMain/kotlin/com/darkrockstudios/apps/hammer/common/preview/sceneeditor/SceneEditorUi.Preview.kt
+++ b/composeUi/src/desktopMain/kotlin/com/darkrockstudios/apps/hammer/common/preview/sceneeditor/SceneEditorUi.Preview.kt
@@ -97,6 +97,7 @@ private fun fakeComponent() = object : SceneEditor {
 	override fun addEditorMenu() {}
 	override fun removeEditorMenu() {}
 	override fun loadSceneContent() {}
+	override fun addWordToDictionary(word: String) {}
 	override suspend fun storeSceneContent() = true
 	override fun onContentChanged(content: PlatformRichText) {}
 	override fun beginSceneNameEdit() {}

--- a/composeUi/src/desktopTest/kotlin/AddToDictionaryMenuTest.kt
+++ b/composeUi/src/desktopTest/kotlin/AddToDictionaryMenuTest.kt
@@ -1,0 +1,39 @@
+import com.darkrockstudios.apps.hammer.common.utils.addToDictionaryMenuItems
+import com.darkrockstudios.texteditor.CharLineOffset
+import com.darkrockstudios.texteditor.TextEditorRange
+import com.darkrockstudios.texteditor.spellcheck.SpellCheckItem
+import com.darkrockstudios.texteditor.spellcheck.api.Correction
+import com.darkrockstudios.texteditor.state.WordSegment
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class AddToDictionaryMenuTest {
+
+	private val range = TextEditorRange(CharLineOffset(0, 0), CharLineOffset(0, 5))
+	private fun word(text: String) = SpellCheckItem.MisspelledWord(WordSegment(text, range))
+
+	@Test
+	fun `a misspelled word gets one item that adds the normalized word`() {
+		var added: String? = null
+		val items = addToDictionaryMenuItems("Add") { added = it }(word(" Kvothe "))
+
+		assertEquals(listOf("Add"), items.map { it.label })
+		items.single().onClick()
+		assertEquals("Kvothe", added)
+	}
+
+	@Test
+	fun `a word the dictionary cannot store gets no item`() {
+		val items = addToDictionaryMenuItems("Add") {}(word("a".repeat(65)))
+
+		assertEquals(emptyList<String>(), items.map { it.label })
+	}
+
+	@Test
+	fun `a sentence issue gets no item`() {
+		val issue = SpellCheckItem.SentenceIssue(Correction(range, "in the", emptyList()))
+		val items = addToDictionaryMenuItems("Add") {}(issue)
+
+		assertEquals(emptyList<String>(), items.map { it.label })
+	}
+}

--- a/composeUi/src/desktopTest/kotlin/HdHairlineWordListFieldTest.kt
+++ b/composeUi/src/desktopTest/kotlin/HdHairlineWordListFieldTest.kt
@@ -7,6 +7,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.key.Key
 import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.assertTextEquals
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
@@ -86,6 +87,41 @@ class HdHairlineWordListFieldTest {
 		compose.waitForIdle()
 
 		assertEquals(emptyList<String>(), words)
+	}
+
+	@Test
+	fun `a pasted list commits the complete words and keeps the partial one as draft`() {
+		showField()
+
+		compose.onNodeWithTag(FIELD_TAG).performTextInput("Kvothe Denna")
+		compose.waitForIdle()
+		assertEquals(listOf("Kvothe"), words)
+
+		compose.onNodeWithTag(FIELD_TAG).performKeyInput { pressKey(Key.Enter) }
+		compose.waitForIdle()
+		assertEquals(listOf("Kvothe", "Denna"), words)
+	}
+
+	@Test
+	fun `a word already present in another case is not added`() {
+		showField(listOf("Kvothe"))
+
+		compose.onNodeWithTag(FIELD_TAG).performTextInput("kvothe ")
+		compose.waitForIdle()
+
+		assertEquals(listOf("Kvothe"), words)
+	}
+
+	@Test
+	fun `a rejected word stays in the draft after a separator`() {
+		showField()
+		val tooLong = "a".repeat(65)
+
+		compose.onNodeWithTag(FIELD_TAG).performTextInput("$tooLong ")
+		compose.waitForIdle()
+
+		assertEquals(emptyList<String>(), words)
+		compose.onNodeWithTag(FIELD_TAG).assertTextEquals(tooLong)
 	}
 
 	@Test

--- a/composeUi/src/desktopTest/kotlin/HdHairlineWordListFieldTest.kt
+++ b/composeUi/src/desktopTest/kotlin/HdHairlineWordListFieldTest.kt
@@ -1,0 +1,101 @@
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performKeyInput
+import androidx.compose.ui.test.performTextInput
+import androidx.compose.ui.test.pressKey
+import androidx.compose.ui.unit.dp
+import com.darkrockstudios.apps.hammer.common.compose.designsystem.HdHairlineWordListField
+import com.darkrockstudios.apps.hammer.common.spellcheck.normalizeDictionaryWord
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+
+private const val FIELD_TAG = "word-list-field"
+
+@OptIn(ExperimentalTestApi::class)
+class HdHairlineWordListFieldTest {
+
+	@get:Rule
+	val compose = createComposeRule()
+
+	private lateinit var words: List<String>
+
+	private fun showField(initial: List<String> = emptyList()) {
+		compose.setContent {
+			var current by remember { mutableStateOf(initial) }
+			words = current
+			Box(modifier = Modifier.size(600.dp, 300.dp)) {
+				HdHairlineWordListField(
+					label = "PROJECT DICTIONARY",
+					words = current,
+					onAdd = { current = current + it },
+					onRemove = { current = current - it },
+					parseInput = ::normalizeDictionaryWord,
+					testTag = FIELD_TAG,
+				)
+			}
+		}
+	}
+
+	@Test
+	fun `space commits the typed word`() {
+		showField()
+
+		compose.onNodeWithTag(FIELD_TAG).performTextInput("Kvothe ")
+		compose.waitForIdle()
+
+		assertEquals(listOf("Kvothe"), words)
+	}
+
+	@Test
+	fun `enter commits the typed word`() {
+		showField()
+
+		compose.onNodeWithTag(FIELD_TAG).performTextInput("Denna")
+		compose.onNodeWithTag(FIELD_TAG).performKeyInput { pressKey(Key.Enter) }
+		compose.waitForIdle()
+
+		assertEquals(listOf("Denna"), words)
+	}
+
+	@Test
+	fun `a word already in the list is not added twice`() {
+		showField(listOf("Kvothe"))
+
+		compose.onNodeWithTag(FIELD_TAG).performTextInput("Kvothe ")
+		compose.waitForIdle()
+
+		assertEquals(listOf("Kvothe"), words)
+	}
+
+	@Test
+	fun `input the parser rejects is not committed`() {
+		showField()
+
+		compose.onNodeWithTag(FIELD_TAG).performTextInput("a".repeat(65) + " ")
+		compose.waitForIdle()
+
+		assertEquals(emptyList<String>(), words)
+	}
+
+	@Test
+	fun `backspace on an empty draft removes the last word`() {
+		showField(listOf("Kvothe", "Denna"))
+
+		compose.onNodeWithTag(FIELD_TAG).performClick()
+		compose.onNodeWithTag(FIELD_TAG).performKeyInput { pressKey(Key.Backspace) }
+		compose.waitForIdle()
+
+		assertEquals(listOf("Kvothe"), words)
+	}
+}

--- a/docs/SYNCING-PROTOCOL.md
+++ b/docs/SYNCING-PROTOCOL.md
@@ -592,6 +592,12 @@ sequenceDiagram
 
 Two further branches aren't diagrammed: if the server has no blob yet (`204`) and the local data is non-default, the client uploads with a null `originalHash` (the server accepts a baseline-less upload unchecked); and if the hashes already match, the phase is a no-op (re-recording `lastSyncedHash` if it was stale).
 
+One field is exempt from the per-field resolver: `dictionaryWords` (the project's user spell-check
+dictionary) is merged by union on both paths. When a `409` differs from the local copy *only* in that
+field, the client merges and re-uploads without involving the user; when other fields also differ, the
+resolver appears for those and the dictionary is still unioned. A word deleted on one device is therefore
+resurrected if the other device conflicts before the deletion syncs; that is accepted for a word list.
+
 Unlike writing-activity sync (which swallows errors and continues), a non-conflict failure on the project-data phase fails the whole sync — the data is user-authored and silent loss is unacceptable.
 
 Note: unlike the entity endpoints, the `project_data` and `writing_activity` endpoints are not gated on a `syncID` — they simply run inside the sync session window.

--- a/docs/SYNCING-PROTOCOL.md
+++ b/docs/SYNCING-PROTOCOL.md
@@ -598,6 +598,11 @@ field, the client merges and re-uploads without involving the user; when other f
 resolver appears for those and the dictionary is still unioned. A word deleted on one device is therefore
 resurrected if the other device conflicts before the deletion syncs; that is accepted for a word list.
 
+Sync writes never clobber a concurrent local edit: the client snapshots the blob when the phase
+starts, and when it installs the server-agreed state it re-applies any field the user changed since
+that snapshot (dictionary words as an add/remove delta). Those edits then differ from the recorded
+`lastSyncedHash`, so the next sync uploads them.
+
 Unlike writing-activity sync (which swallows errors and continues), a non-conflict failure on the project-data phase fails the whole sync — the data is user-authored and silent loss is unacceptable.
 
 Note: unlike the entity endpoints, the `project_data` and `writing_activity` endpoints are not gated on a `syncID` — they simply run inside the sync session window.

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -99,7 +99,7 @@ korge-core = "6.0.0"
 bouncycastle = "1.85"
 kotlinx-io-okio = "0.9.1"
 
-compose-texteditor = "2.4.3"
+compose-texteditor = "2.4.4"
 kotlin-multiplatform-diff = "1.3.0"
 platform-spellcheckerkt = "1.3.2"
 nucleus = "2.4.4"

--- a/server/src/test/kotlin/com/darkrockstudios/apps/hammer/utilities/EntityHashSensitivityTest.kt
+++ b/server/src/test/kotlin/com/darkrockstudios/apps/hammer/utilities/EntityHashSensitivityTest.kt
@@ -275,6 +275,7 @@ class EntityHashSensitivityTest {
 			wordCountGoal = WordCountGoal(cadence = WordCountGoal.Cadence.DAY, count = 100),
 			tags = setOf("base-tag"),
 			language = "en-US",
+			dictionaryWords = setOf("base-word"),
 		)
 		Spec(
 			klass = ProjectData::class,
@@ -293,6 +294,7 @@ class EntityHashSensitivityTest {
 				"tags" to base.copy(tags = setOf("different")),
 				"language" to base.copy(language = "fr"),
 				"encyclopediaDictionary" to base.copy(encyclopediaDictionary = false),
+				"dictionaryWords" to base.copy(dictionaryWords = setOf("different")),
 			),
 		)
 	}


### PR DESCRIPTION
Lets writers whitelist words per project.

- **Add to dictionary** in the scene editor and focus mode context menu on a flagged word.
- A **Project dictionary** word list in Project Settings › Spell checking (add, remove).
- Words are stored in `ProjectData.dictionaryWords`, so they sync with the project. A conflict confined to the word list merges both sides by union with no resolver; other conflicting fields still go through the existing resolver with the dictionary unioned. Documented in `docs/SYNCING-PROTOCOL.md`.
- `ProjectDictionaryService` feeds user words to the checker alongside encyclopedia words (as typed plus lowercased), independent of the encyclopedia toggle.
- New `HdHairlineWordListField` design-system component.

Depends on compose-texteditor 2.4.4 (`spellCheckMenuItems` hook), now on Maven Central.

Tests: hasher and hash-sensitivity guard, sync auto-merge, dictionary service, use-case wiring in the three components, word-list field UI test.
