### PR TITLE
Fail fast on App Store Connect validation errors

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -71,6 +71,29 @@ rescue => e
   false
 end
 
+# App Store Connect validation failures: the version's contents or state are
+# rejected outright, so the same call will fail identically forever. Retrying
+# these only buries the real cause — the first 3.9.7 iOS submit spent all six
+# attempts and five minutes restating "App screenshot missing". Matched on
+# message text rather than exception class because Spaceship raises
+# UnexpectedResponse for transient faults too, so the class cannot tell them
+# apart. Keep this list narrow: anything not matched here still gets retried,
+# which is the safe direction to be wrong in.
+PERMANENT_DELIVER_ERRORS = [
+  /is not in valid state/i,
+  /cannot be reviewed/i,
+  /screenshot missing/i,
+  /required but was not provided/i,
+].freeze
+
+# Matches against the whole message, not just the first line: App Store Connect
+# puts the summary on line 1 ("...is not in valid state") and the actual reasons
+# on the lines below it ("App screenshot missing (APP_IPHONE_65)").
+def permanent_deliver_error?(error)
+  message = error.message.to_s
+  PERMANENT_DELIVER_ERRORS.any? { |pattern| message.match?(pattern) }
+end
+
 # Run deliver with a bounded retry. Right after upload the build is processed in
 # TestFlight but can lag propagating to the App Store version API, so deliver
 # crashes with "Could not find build". That crash happens during build lookup —
@@ -90,6 +113,14 @@ def deliver_with_retry(params, attempts: 6, wait_seconds: 60)
       UI.success("App Store version #{params[:app_version]} is already submitted for review — deliver's error was a false negative.")
       return
     end
+    if permanent_deliver_error?(e)
+      # Print the whole message — the summary line names the version, but the
+      # lines under it are the ones that say what is actually wrong.
+      UI.error("App Store Connect rejected the submission. This will not clear on its own, so not retrying:")
+      UI.error(e.message.to_s)
+      raise
+    end
+
     raise if try >= attempts
     UI.important("deliver attempt #{try}/#{attempts} failed: #{e.message.to_s.lines.first&.strip}")
     UI.important("Build may still be propagating to App Store Connect; retrying in #{wait_seconds}s…")


### PR DESCRIPTION
`deliver_with_retry` treated every error as transient. It exists for App Store
Connect's eventual consistency around build lookup and attachment, but a
validation failure will fail identically forever.

Tonight's first `v3.9.7+ios-app-store` submit spent all six attempts and five
minutes restating the same complaint before surfacing it:

```
deliver attempt 1/6 failed: appStoreVersions with id '...' is not in valid state.
deliver attempt 2/6 failed: appStoreVersions with id '...' is not in valid state.
... (four more)
```

The actual cause — `App screenshot missing (APP_IPHONE_65)` — was on line 2 of
the message, and the retry logging only ever printed `.lines.first`.

## Changes

- `PERMANENT_DELIVER_ERRORS`: four patterns matching App Store Connect
  validation failures. Matched on message text rather than exception class,
  because Spaceship raises `UnexpectedResponse` for transient faults too, so
  the class cannot tell them apart.
- Matching runs against the whole message, not just the first line — ASC puts
  the summary on line 1 and the reasons underneath.
- Permanent errors print the full message before raising.
- `submission_landed?` still runs first, so the false-negative case (deliver
  raising after the submission already landed) is unchanged.

The list is deliberately narrow — anything unmatched still retries. A new
permanent error costs a few wasted attempts; a misclassified transient one
costs a failed release.

## Verification

Tested against the classifier extracted from the Fastfile itself, using the
verbatim error text from the failed run:

```
ok   real 3.9.7 screenshot failure       permanent=true
ok   screenshot line alone (not line 1)  permanent=true
ok   invalid state alone                 permanent=true
ok   build still propagating             permanent=false
ok   build relationship unmodifiable     permanent=false
ok   ASC 500                             permanent=false
ok   network timeout                     permanent=false
ok   generic spaceship hiccup            permanent=false
```

The three transient cases that must keep retrying are exactly the ones the
wrapper was built for.

Also applies to `desktop_submit`, which shares the wrapper with `attempts: 30`
— a validation error there would previously have retried for half an hour.
