### PR TITLE
Fix Community Pagination Links

### DIFF
--- a/server/src/main/resources/templates/authors.mustache
+++ b/server/src/main/resources/templates/authors.mustache
@@ -52,7 +52,7 @@
 				{{#isPaged}}
 					<div class="pagination">
 						{{#hasPrevPage}}
-							<a href="/authors?page={{prevPage}}" class="pagination-button">
+							<a href="/community/authors?page={{prevPage}}" class="pagination-button">
 							<i class="fa-solid fa-chevron-left"></i>
 							{{msg.admin_pagination_prev}}
 							</a>
@@ -69,7 +69,7 @@
 				</span>
 
 						{{#hasNextPage}}
-							<a href="/authors?page={{nextPage}}" class="pagination-button">
+							<a href="/community/authors?page={{nextPage}}" class="pagination-button">
 							{{msg.admin_pagination_next}}
 							<i class="fa-solid fa-chevron-right"></i>
 							</a>

--- a/server/src/main/resources/templates/feed.mustache
+++ b/server/src/main/resources/templates/feed.mustache
@@ -64,7 +64,7 @@
 				{{#isPaged}}
 					<div class="pagination">
 						{{#hasPrevPage}}
-							<a href="/feed?page={{prevPage}}" class="pagination-button">
+							<a href="/community/feed?page={{prevPage}}" class="pagination-button">
 							<i class="fa-solid fa-chevron-left"></i>
 							{{msg.admin_pagination_prev}}
 							</a>
@@ -81,7 +81,7 @@
 				</span>
 
 						{{#hasNextPage}}
-							<a href="/feed?page={{nextPage}}" class="pagination-button">
+							<a href="/community/feed?page={{nextPage}}" class="pagination-button">
 							{{msg.admin_pagination_next}}
 							<i class="fa-solid fa-chevron-right"></i>
 							</a>


### PR DESCRIPTION
Currently on the [Community Authors page](https://hammer.ink/community/authors), the "Next" button links to https://hammer.ink/authors?page=1, which 404s because the authors page is actually under the `/community/` route. If you manually navigate to https://hammer.ink/community/authors?page=1, you get the second page of authors successfully.

This PR updates the links in authors.mustache to fix that, as well as in feed.mustache (it's not an issue on that page just yet, but it looks like the same issue).